### PR TITLE
Repair interrupted deletion in the Cognee candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ The 0.11 baseline remains under review; this is not a release or a completed MVP
 
 - **Operators can evaluate a proposed Cognee replacement independently of the deployed image.** The
   separate 1.5.4 qualification uses fresh disposable storage and retains evidence for image identity,
-  isolation, recovery and deletion. Explicit candidate repairs preserve the official source hashes
+  isolation, recovery and deletion. Dataset checks retain the saved name, owner and identifier across
+  concurrent creation, a lost creation response and provider restart. Explicit candidate repairs preserve the official source hashes
   and separately verify their patch artifacts, base image and running source. It cannot publish a
   candidate or replace the existing production provider gate. The candidate and personal memory
   journeys remain under qualification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,10 @@ The 0.11 baseline remains under review; this is not a release or a completed MVP
 
 - **Operators can evaluate a proposed Cognee replacement independently of the deployed image.** The
   separate 1.5.4 qualification uses fresh disposable storage and retains evidence for image identity,
-  isolation, recovery and deletion. It cannot publish a candidate or replace the existing production
-  provider gate. The candidate and personal memory journeys remain under qualification.
+  isolation, recovery and deletion. Explicit candidate repairs preserve the official source hashes
+  and separately verify their patch artifacts, base image and running source. It cannot publish a
+  candidate or replace the existing production provider gate. The candidate and personal memory
+  journeys remain under qualification.
 
 - **People can stop their own current personal-assistant turn from the conversation.** Stop checks
   current access, saves the selected turn and prevents further model or tool work. Pending approvals

--- a/apps/_infra/cognee/README.md
+++ b/apps/_infra/cognee/README.md
@@ -155,6 +155,12 @@ storage or independent stores sharing files. The build and runtime evidence reta
 hashes and separately verify each patch, its base image and its resulting source. Interrupted cleanup, restart and concurrent
 add/delete checks must pass before this candidate can replace the production image.
 
+The authenticated candidate also checks dataset creation with a saved opaque name: repeated and
+concurrent requests must return the same dataset and owner, and a lost response must be recoverable
+by listing that name without sending another create. The existing provider restart then checks all
+saved coordinates again. This does not prove recovery after partial access grants; that separate
+provider defect must be repaired before personal dataset provisioning can be activated.
+
 ## See also
 
 - Parent index: [_infra](../README.md)

--- a/apps/_infra/cognee/README.md
+++ b/apps/_infra/cognee/README.md
@@ -44,8 +44,9 @@ There is no importable application code.
 
 ## Boundary
 
-OpenCrane owns how Cognee is built, deployed, reached, and isolated. The vendor owns Cognee's
-behaviour and data model. Only the release-local memory gateway may connect to the Cognee Service.
+OpenCrane owns how Cognee is built, deployed, reached, and isolated. Cognee owns memory storage and
+its data model; candidate-only source repairs remain inside that provider. Only the release-local
+memory gateway may connect to the Cognee Service.
 Cognee may reach release-local LiteLLM, cluster DNS, and optional local telemetry, but not
 `extension.ladybugdb.com` at runtime.
 
@@ -144,6 +145,15 @@ The candidate changes dataset and native-database behavior, so its qualification
 full provider journey and deletion recovery. A successful ordinary delete alone does not establish
 safe local file ownership or recovery after an interrupted cleanup. Selecting a production image,
 changing chart defaults and enabling personal memory are later reviewed changes.
+
+The 1.5.4 candidate includes an explicit deletion repair under `tests/candidates/1.5.4/patches/`.
+It retains the document record until unreferenced local files have been removed, so a failed cleanup
+can resume through the same public document coordinate. Ingestion and deletion share a provider-owned
+file lock to protect shared references. Qualification covers fresh installations on Linux with local
+file storage, the default SQLite store and one shared local volume; it makes no claim for remote
+storage or independent stores sharing files. The build and runtime evidence retain the official source
+hashes and separately verify each patch, its base image and its resulting source. Interrupted cleanup, restart and concurrent
+add/delete checks must pass before this candidate can replace the production image.
 
 ## See also
 

--- a/apps/_infra/cognee/tests/candidates/1.5.4/Dockerfile
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/Dockerfile
@@ -11,6 +11,9 @@ LABEL org.opencontainers.image.source="https://github.com/topoteretes/cognee" \
   ai.opencrane.cognee.repair-postimage-sha256="3d7f8fdc029226ba33919838a522b0325e616d3c3c7820fde828f90c68c8daaf" \
   ai.opencrane.ladybug-json.sha256="39c51fa9b1915590a500eef732c76913aeb10cd942e46e1c259497e609b97426"
 
+# Installing the source repair and its evidence needs build-time write access to the image.
+USER root
+
 RUN mkdir -p /opt/opencrane/cognee-repair
 
 COPY --chmod=0644 apps/_infra/cognee/tests/candidates/1.5.4/patches/*.patch \
@@ -58,11 +61,11 @@ RUN package_root="$(python -c 'import cognee, pathlib; print(pathlib.Path(cognee
     --postimage-sha256 df8872f1f864b50640f7a083e62c33d29a1c704a8f9df9918702d0b712dedc7b && \
   rm /tmp/apply-cognee-source-patch.py
 
+USER cognee
+
 RUN mkdir -p /app/.lbdb/extension/0.19.0/linux_amd64/json
 
 ADD --chown=1000:1000 --chmod=0644 \
   --checksum=sha256:39c51fa9b1915590a500eef732c76913aeb10cd942e46e1c259497e609b97426 \
   https://extension.ladybugdb.com/v0.19.0/linux_amd64/json/libjson.lbug_extension \
   /app/.lbdb/extension/0.19.0/linux_amd64/json/libjson.lbug_extension
-
-USER cognee

--- a/apps/_infra/cognee/tests/candidates/1.5.4/Dockerfile
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/Dockerfile
@@ -7,7 +7,56 @@ LABEL org.opencontainers.image.source="https://github.com/topoteretes/cognee" \
   ai.opencrane.cognee.source-commit="20e0bd88746de2d96e99b4b122361dfc3dad21bc" \
   ai.opencrane.cognee.base-index-digest="sha256:68b755bebae2a19f482069b5efcbe8e4bdf717a68f6afb6fef80c3c352c37015" \
   ai.opencrane.cognee.base-linux-amd64-digest="sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10" \
+  ai.opencrane.cognee.repair-patch-sha256="08d46750e34abdc9a0cd76d37318fa886b027ef50bb792b0f25f27f526574b50" \
+  ai.opencrane.cognee.repair-postimage-sha256="3d7f8fdc029226ba33919838a522b0325e616d3c3c7820fde828f90c68c8daaf" \
   ai.opencrane.ladybug-json.sha256="39c51fa9b1915590a500eef732c76913aeb10cd942e46e1c259497e609b97426"
+
+RUN mkdir -p /opt/opencrane/cognee-repair
+
+COPY --chmod=0644 apps/_infra/cognee/tests/candidates/1.5.4/patches/*.patch \
+  /opt/opencrane/cognee-repair/
+COPY --chmod=0755 \
+  apps/_infra/cognee/tests/candidates/1.5.4/patches/apply-source-patch.py \
+  /tmp/apply-cognee-source-patch.py
+
+RUN package_root="$(python -c 'import cognee, pathlib; print(pathlib.Path(cognee.__file__).resolve().parent)')" && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py" \
+    --patch /opt/opencrane/cognee-repair/sqlalchemy-delete-recovery.patch \
+    --receipt /opt/opencrane/cognee-repair/sqlalchemy-delete-recovery.json \
+    --module cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 d64bd2d7214a0c69c8aa40268a0c2536d46cc54bade51b643341f82cb2f078e9 \
+    --patch-sha256 08d46750e34abdc9a0cd76d37318fa886b027ef50bb792b0f25f27f526574b50 \
+    --postimage-sha256 3d7f8fdc029226ba33919838a522b0325e616d3c3c7820fde828f90c68c8daaf && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/infrastructure/locks/__init__.py" \
+    --patch /opt/opencrane/cognee-repair/locks-export.patch \
+    --receipt /opt/opencrane/cognee-repair/locks-export.json \
+    --module cognee.infrastructure.locks \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 d8bc16e31af2aa5ea8c55e688216b2fa11aa8e36270977c9c4e4821b7ebbde1d \
+    --patch-sha256 0f3ecd0c126b4061bdf5efcc95b54e8ca90f6d0a887d817aa597ea77df0d9b88 \
+    --postimage-sha256 5df9e8d38636ae9f0e35978b6327ce1a530d0b949f484b4c1e8dee84fbe61abc && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/infrastructure/locks/managed_data_file_lock.py" \
+    --patch /opt/opencrane/cognee-repair/managed-data-file-lock.patch \
+    --receipt /opt/opencrane/cognee-repair/managed-data-file-lock.json \
+    --module cognee.infrastructure.locks.managed_data_file_lock \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-absent \
+    --patch-sha256 91c4006d8f69584b809eb1d3351363e8634d7f5068e4dcbcdcb550916e6fc938 \
+    --postimage-sha256 c3fbada36b40460f67832da43bf04b9d7e7ce2f56ed81aa01a0fc2b831fd51e7 && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/modules/pipelines/operations/run_tasks_data_item.py" \
+    --patch /opt/opencrane/cognee-repair/run-tasks-data-item.patch \
+    --receipt /opt/opencrane/cognee-repair/run-tasks-data-item.json \
+    --module cognee.modules.pipelines.operations.run_tasks_data_item \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 bf994bdf10d4d132ea75db57bd64ea64ced0615cf0177f1e5562f5d71b199ae7 \
+    --patch-sha256 7eb15e93fa0986d225ce0a3c89001f1c1b671db72c4254a690141edd4c4be312 \
+    --postimage-sha256 df8872f1f864b50640f7a083e62c33d29a1c704a8f9df9918702d0b712dedc7b && \
+  rm /tmp/apply-cognee-source-patch.py
 
 RUN mkdir -p /app/.lbdb/extension/0.19.0/linux_amd64/json
 

--- a/apps/_infra/cognee/tests/candidates/1.5.4/expected-source-hashes.json
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/expected-source-hashes.json
@@ -5,7 +5,7 @@
     "declaredVersion": "1.5.4",
     "isOciAttestation": false,
     "repository": "topoteretes/cognee",
-    "scope": "official-tag-source-expectations",
+    "scope": "official-tag-source-with-explicit-candidate-repair",
     "tag": "v1.5.4"
   },
   "modules": {
@@ -29,6 +29,7 @@
     "cognee.infrastructure.files.storage.LocalFileStorage": "5e0a9d26c3634b274436db0b9d950bf2d867d9faeb6bf254ecce0a457d218068",
     "cognee.infrastructure.files.storage.get_file_storage": "c9ff7589606d586025850d538d1d30aecee776ecad6fe6cb26e14be20bfbb953",
     "cognee.infrastructure.files.utils.local_path_safety": "40c7438ca9fbb61496aa5c2efb4e19579dc980f5c7e0828619f413b1c67fbb61",
+    "cognee.infrastructure.locks": "d8bc16e31af2aa5ea8c55e688216b2fa11aa8e36270977c9c4e4821b7ebbde1d",
     "cognee.infrastructure.loaders.core.text_loader": "9dbbe87e463bd735e59a808a825a724db090f2c82d15c1c64fc943bb7025f9e4",
     "cognee.modules.chunking.TextChunker": "4130617364aeff346703d5cf32708a766c27deabf80532409a262bfab8d19f59",
     "cognee.modules.data.methods.delete_data": "52d5e0a7021bc7b108a6ea919cdc32e11d371b37e9b3df68a695eda94ae11f71",
@@ -47,6 +48,7 @@
     "cognee.modules.migrations.versions.adapter_storage_migration": "4b2de3906d42d1d3ccd50780e85f7cc1549b3d48e55644143f8c4c10f844f453",
     "cognee.modules.migrations.versions.ladybug_graph_provenance_columns": "646587511d0ff7637eea711d655a9475c927909d8361c8abeab8c0b644c47c0c",
     "cognee.modules.migrations.versions.rekey_fork_document_ids": "5965b0d8594b2812c99d26e375151e9fcef8270d87010a2f302d2f729df5c6dc",
+    "cognee.modules.pipelines.operations.run_tasks_data_item": "bf994bdf10d4d132ea75db57bd64ea64ced0615cf0177f1e5562f5d71b199ae7",
     "cognee.modules.retrieval.chunks_retriever": "7cb62960a65e39915a21a2b1a72e6dff89fa1dd4be65c18a9cd252bb2d328525",
     "cognee.modules.search.methods.get_search_type_retriever_instance": "f557b9aec1a1156e23828a43b44662c5bd581c0efeff735e85b387a68e4294eb",
     "cognee.modules.search.methods.search": "687c15fc330bde5f262ad8f19d9e979e47bd4abaf24dea066a465243dfabfa58",
@@ -56,5 +58,39 @@
     "cognee.tasks.ingestion.ingest_data": "6493bd63bb7f860684695458c3755c3531a9722612da41a2deb5f5307b52d674",
     "cognee.tasks.ingestion.save_data_item_to_storage": "3979e866334ff639648441adf4afea4e3cbda7a323ce4c792f2f1208558ba6c5",
     "cognee.version": "8ac37d817a40c24611f36726871fb66a78bc2b2968b81caa33a8942ebf391f29"
+  },
+  "repairs": {
+    "cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "d64bd2d7214a0c69c8aa40268a0c2536d46cc54bade51b643341f82cb2f078e9",
+      "patchSha256": "08d46750e34abdc9a0cd76d37318fa886b027ef50bb792b0f25f27f526574b50",
+      "postimageSha256": "3d7f8fdc029226ba33919838a522b0325e616d3c3c7820fde828f90c68c8daaf",
+      "patchPath": "/opt/opencrane/cognee-repair/sqlalchemy-delete-recovery.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/sqlalchemy-delete-recovery.json"
+    },
+    "cognee.infrastructure.locks": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "d8bc16e31af2aa5ea8c55e688216b2fa11aa8e36270977c9c4e4821b7ebbde1d",
+      "patchSha256": "0f3ecd0c126b4061bdf5efcc95b54e8ca90f6d0a887d817aa597ea77df0d9b88",
+      "postimageSha256": "5df9e8d38636ae9f0e35978b6327ce1a530d0b949f484b4c1e8dee84fbe61abc",
+      "patchPath": "/opt/opencrane/cognee-repair/locks-export.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/locks-export.json"
+    },
+    "cognee.infrastructure.locks.managed_data_file_lock": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": null,
+      "patchSha256": "91c4006d8f69584b809eb1d3351363e8634d7f5068e4dcbcdcb550916e6fc938",
+      "postimageSha256": "c3fbada36b40460f67832da43bf04b9d7e7ce2f56ed81aa01a0fc2b831fd51e7",
+      "patchPath": "/opt/opencrane/cognee-repair/managed-data-file-lock.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/managed-data-file-lock.json"
+    },
+    "cognee.modules.pipelines.operations.run_tasks_data_item": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "bf994bdf10d4d132ea75db57bd64ea64ced0615cf0177f1e5562f5d71b199ae7",
+      "patchSha256": "7eb15e93fa0986d225ce0a3c89001f1c1b671db72c4254a690141edd4c4be312",
+      "postimageSha256": "df8872f1f864b50640f7a083e62c33d29a1c704a8f9df9918702d0b712dedc7b",
+      "patchPath": "/opt/opencrane/cognee-repair/run-tasks-data-item.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/run-tasks-data-item.json"
+    }
   }
 }

--- a/apps/_infra/cognee/tests/candidates/1.5.4/image-smoke.sh
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/image-smoke.sh
@@ -72,6 +72,12 @@ expected_labels = {
     "ai.opencrane.cognee.source-commit": profile["source"]["commit"],
     "ai.opencrane.cognee.base-index-digest": image["indexDigest"],
     "ai.opencrane.cognee.base-linux-amd64-digest": image["linuxAmd64Digest"],
+    "ai.opencrane.cognee.repair-patch-sha256": profile["source"]["repairs"][
+        "cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter"
+    ]["patchSha256"],
+    "ai.opencrane.cognee.repair-postimage-sha256": profile["source"]["repairs"][
+        "cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter"
+    ]["postimageSha256"],
     "ai.opencrane.ladybug-json.sha256": ladybug["extensionSha256"],
 }
 actual_labels = config.get("Labels") or {}
@@ -137,6 +143,7 @@ profile = json.loads(
 )
 image = profile["image"]
 ladybug_profile = profile["ladybug"]
+repair_profiles = profile["source"]["repairs"]
 
 require(
     cognee.__version__ == profile["source"]["runtimeVersion"],
@@ -176,6 +183,28 @@ require(
     extension.stat().st_size == ladybug_profile["extensionSizeBytes"],
     "Ladybug JSON extension size does not match the profile",
 )
+
+for repair_module, repair_profile in repair_profiles.items():
+    repair_patch = pathlib.Path(repair_profile["patchPath"])
+    repair_receipt = pathlib.Path(repair_profile["receiptPath"])
+    for repair_artifact in (repair_patch, repair_receipt):
+        require(repair_artifact.is_file(), "Cognee repair artifact is missing")
+        require(not repair_artifact.is_symlink(), "Cognee repair artifact must not be a symlink")
+    require(
+        hashlib.sha256(repair_patch.read_bytes()).hexdigest()
+        == repair_profile["patchSha256"],
+        "Cognee repair patch digest does not match the profile",
+    )
+    receipt = json.loads(repair_receipt.read_text(encoding="utf-8"))
+    require(receipt["module"] == repair_module, "Cognee repair module differs")
+    require(
+        receipt["patchSha256"] == repair_profile["patchSha256"],
+        "Cognee repair receipt patch digest differs",
+    )
+    require(
+        receipt["postimageSha256"] == repair_profile["postimageSha256"],
+        "Cognee repair receipt postimage digest differs",
+    )
 require(
     hashlib.sha256(extension.read_bytes()).hexdigest()
     == ladybug_profile["extensionSha256"],

--- a/apps/_infra/cognee/tests/candidates/1.5.4/image-smoke.test.sh
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/image-smoke.test.sh
@@ -32,6 +32,8 @@ if [[ "${1:-}" == "image" && "${2:-}" == "inspect" ]]; then
         "ai.opencrane.cognee.source-commit": "20e0bd88746de2d96e99b4b122361dfc3dad21bc",
         "ai.opencrane.cognee.base-index-digest": "sha256:68b755bebae2a19f482069b5efcbe8e4bdf717a68f6afb6fef80c3c352c37015",
         "ai.opencrane.cognee.base-linux-amd64-digest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+        "ai.opencrane.cognee.repair-patch-sha256": "08d46750e34abdc9a0cd76d37318fa886b027ef50bb792b0f25f27f526574b50",
+        "ai.opencrane.cognee.repair-postimage-sha256": "3d7f8fdc029226ba33919838a522b0325e616d3c3c7820fde828f90c68c8daaf",
         "ai.opencrane.ladybug-json.sha256": "39c51fa9b1915590a500eef732c76913aeb10cd942e46e1c259497e609b97426"
       }
     }

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/apply-source-patch.py
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/apply-source-patch.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Apply one preimage-bound unified source patch without external build tools."""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+
+
+_HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _apply_unified_patch(source: str, patch: str) -> str:
+    source_lines = source.splitlines(keepends=True)
+    patch_lines = patch.splitlines(keepends=True)
+    output: list[str] = []
+    source_index = 0
+    patch_index = 0
+    while patch_index < len(patch_lines) and not patch_lines[patch_index].startswith("@@ "):
+        patch_index += 1
+
+    while patch_index < len(patch_lines):
+        match = _HUNK.match(patch_lines[patch_index])
+        if match is None:
+            raise ValueError("Patch contains an invalid hunk header")
+        target_index = max(int(match.group(1)) - 1, 0)
+        if target_index < source_index:
+            raise ValueError("Patch hunks overlap or are out of order")
+        output.extend(source_lines[source_index:target_index])
+        source_index = target_index
+        patch_index += 1
+
+        while patch_index < len(patch_lines) and not patch_lines[patch_index].startswith("@@ "):
+            line = patch_lines[patch_index]
+            if line.startswith("\\ No newline at end of file"):
+                patch_index += 1
+                continue
+            if not line or line[0] not in " +-":
+                raise ValueError("Patch contains an unsupported line")
+            content = line[1:]
+            if line[0] in " -":
+                if source_index >= len(source_lines) or source_lines[source_index] != content:
+                    raise ValueError("Patch context does not match the source")
+                source_index += 1
+            if line[0] in " +":
+                output.append(content)
+            patch_index += 1
+
+    output.extend(source_lines[source_index:])
+    return "".join(output)
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--patch", required=True)
+    parser.add_argument("--receipt", required=True)
+    parser.add_argument("--module", required=True)
+    parser.add_argument("--base-image-digest", required=True)
+    preimage = parser.add_mutually_exclusive_group(required=True)
+    preimage.add_argument("--preimage-sha256")
+    preimage.add_argument("--preimage-absent", action="store_true")
+    parser.add_argument("--patch-sha256", required=True)
+    parser.add_argument("--postimage-sha256", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _arguments()
+    source_path = Path(args.source)
+    patch_path = Path(args.patch)
+    receipt_path = Path(args.receipt)
+    if patch_path.is_symlink() or not patch_path.is_file():
+        raise AssertionError("Repair patch must be a regular non-symlink file")
+
+    source_stat = None
+    if args.preimage_absent:
+        if source_path.exists() or source_path.is_symlink():
+            raise AssertionError("Cognee repair source addition already exists")
+        source_bytes = b""
+    else:
+        if source_path.is_symlink() or not source_path.is_file():
+            raise AssertionError("Repair source must be a regular non-symlink file")
+        source_bytes = source_path.read_bytes()
+        source_stat = source_path.stat()
+    patch_bytes = patch_path.read_bytes()
+    if not args.preimage_absent and _sha256(source_bytes) != args.preimage_sha256:
+        raise AssertionError("Cognee repair source preimage differs")
+    if _sha256(patch_bytes) != args.patch_sha256:
+        raise AssertionError("Cognee repair patch differs")
+
+    patched = _apply_unified_patch(
+        source_bytes.decode("utf-8"), patch_bytes.decode("utf-8")
+    ).encode("utf-8")
+    if _sha256(patched) != args.postimage_sha256:
+        raise AssertionError("Cognee repair source postimage differs")
+
+    temporary_path = source_path.with_suffix(source_path.suffix + ".opencrane-repair")
+    temporary_path.write_bytes(patched)
+    if source_stat is None:
+        os.chmod(temporary_path, 0o644)
+    else:
+        os.chmod(temporary_path, source_stat.st_mode)
+        os.chown(temporary_path, source_stat.st_uid, source_stat.st_gid)
+    temporary_path.replace(source_path)
+    receipt = {
+        "module": args.module,
+        "baseImageDigest": args.base_image_digest,
+        "preimageSha256": None if args.preimage_absent else args.preimage_sha256,
+        "patchSha256": args.patch_sha256,
+        "postimageSha256": args.postimage_sha256,
+        "patchPath": str(patch_path),
+        "receiptPath": str(receipt_path),
+    }
+    receipt_path.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/locks-export.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/locks-export.patch
@@ -1,0 +1,16 @@
+--- /private/tmp/cognee-patch-a/cognee/infrastructure/locks/__init__.py	2026-09-12 18:05:01
++++ /private/tmp/cognee-patch-b/cognee/infrastructure/locks/__init__.py	2026-09-12 18:05:59
+@@ -1,4 +1,5 @@
+ from .dataset_lock import dataset_lock, get_dataset_lock, held_datasets
++from .managed_data_file_lock import managed_data_file_lock
+ from .session_lock import (
+     release_improve_lock,
+     session_lock,
+@@ -10,6 +11,7 @@
+     "dataset_lock",
+     "get_dataset_lock",
+     "held_datasets",
++    "managed_data_file_lock",
+     "release_improve_lock",
+     "session_lock",
+     "session_turn_lock",

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/managed-data-file-lock.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/managed-data-file-lock.patch
@@ -1,0 +1,94 @@
+--- /dev/null	2026-09-12 18:08:39
++++ /private/tmp/cognee-patch-b/cognee/infrastructure/locks/managed_data_file_lock.py	2026-09-12 18:05:59
+@@ -0,0 +1,91 @@
++"""Cross-process lifecycle lock for provider-managed local data files."""
++
++import asyncio
++import fcntl
++import hashlib
++import os
++import stat
++from collections.abc import AsyncIterator
++from contextlib import asynccontextmanager
++from contextvars import ContextVar
++from pathlib import Path
++
++from cognee.infrastructure.files.storage import get_storage_config
++
++
++_POLL_INTERVAL_SECONDS = 0.05
++_holder: ContextVar[tuple[int, asyncio.Task] | None] = ContextVar(
++    "managed_data_file_lock_holder", default=None
++)
++
++
++def _lock_path() -> Path:
++    data_root = Path(get_storage_config()["data_root_directory"]).expanduser().resolve()
++    digest = hashlib.sha256(str(data_root).encode("utf-8")).hexdigest()
++    return data_root.parent / f".cognee-managed-data-{digest}.lock"
++
++
++def _open_lock_file(path: Path) -> int:
++    path.parent.mkdir(parents=True, exist_ok=True)
++    flags = os.O_CREAT | os.O_RDWR | os.O_CLOEXEC
++    if hasattr(os, "O_NOFOLLOW"):
++        flags |= os.O_NOFOLLOW
++    descriptor = os.open(path, flags, 0o600)
++    metadata = os.fstat(descriptor)
++    if not stat.S_ISREG(metadata.st_mode):
++        os.close(descriptor)
++        raise RuntimeError("Managed data lock is not a regular file")
++    if metadata.st_uid != os.geteuid():
++        os.close(descriptor)
++        raise RuntimeError("Managed data lock has an unexpected owner")
++    if stat.S_IMODE(metadata.st_mode) != 0o600:
++        os.close(descriptor)
++        raise RuntimeError("Managed data lock has an unexpected mode")
++    return descriptor
++
++
++async def _acquire(descriptor: int, timeout_seconds: float) -> None:
++    if timeout_seconds <= 0:
++        raise ValueError("Managed data lock timeout must be positive")
++    loop = asyncio.get_running_loop()
++    deadline = loop.time() + timeout_seconds
++    while True:
++        try:
++            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
++            return
++        except BlockingIOError:
++            if loop.time() >= deadline:
++                raise TimeoutError("Managed data file lock timed out")
++            await asyncio.sleep(min(_POLL_INTERVAL_SECONDS, deadline - loop.time()))
++
++
++@asynccontextmanager
++async def managed_data_file_lock(timeout_seconds: float = 120.0) -> AsyncIterator[None]:
++    """Serialize local managed-file writes and their relational commits.
++
++    Reentrancy applies only to the same asyncio task in the same process. Child
++    tasks inherit context variables but still acquire their own kernel lock.
++    """
++
++    task = asyncio.current_task()
++    if task is None:
++        raise RuntimeError("Managed data file lock requires an asyncio task")
++    identity = (os.getpid(), task)
++    if _holder.get() == identity:
++        yield
++        return
++
++    descriptor = _open_lock_file(_lock_path())
++    acquired = False
++    token = None
++    try:
++        await _acquire(descriptor, timeout_seconds)
++        acquired = True
++        token = _holder.set(identity)
++        yield
++    finally:
++        if token is not None:
++            _holder.reset(token)
++        if acquired:
++            fcntl.flock(descriptor, fcntl.LOCK_UN)
++        os.close(descriptor)

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/run-tasks-data-item.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/run-tasks-data-item.patch
@@ -1,0 +1,48 @@
+--- /private/tmp/cognee-patch-a/cognee/modules/pipelines/operations/run_tasks_data_item.py	2026-09-12 18:05:01
++++ /private/tmp/cognee-patch-b/cognee/modules/pipelines/operations/run_tasks_data_item.py	2026-09-12 18:05:59
+@@ -11,6 +11,7 @@
+ 
+ import cognee.modules.ingestion as ingestion
+ from cognee.infrastructure.databases.relational import get_relational_engine
++from cognee.infrastructure.locks import managed_data_file_lock
+ from cognee.infrastructure.files.utils.open_data_file import open_data_file
+ from cognee.shared.logging_utils import get_logger
+ from cognee.modules.users.models import User
+@@ -101,6 +102,20 @@
+     return result
+ 
+ 
++async def _drain_and_close_item_events(
++    events: AsyncGenerator[Any, None],
++    ctx: Optional[PipelineContext],
++    tasks: list[Task],
++    pipeline_run_id: str,
++    progress_state: Optional[Dict[str, Any]],
++) -> Optional[Dict[str, Any]]:
++    """Drain one item generator and close it before its enclosing lock is released."""
++    try:
++        return await _drain_item_events(events, ctx, tasks, pipeline_run_id, progress_state)
++    finally:
++        await events.aclose()
++
++
+ async def run_tasks_data_item_incremental(
+     data_item: Any,
+     dataset: Dataset,
+@@ -393,7 +408,15 @@
+         )
+ 
+     try:
+-        result = await _drain_item_events(events, ctx, tasks, pipeline_run_id, progress_state)
++        if pipeline_name == "add_pipeline":
++            async with managed_data_file_lock():
++                result = await _drain_and_close_item_events(
++                    events, ctx, tasks, pipeline_run_id, progress_state
++                )
++        else:
++            result = await _drain_and_close_item_events(
++                events, ctx, tasks, pipeline_run_id, progress_state
++            )
+     except Exception:
+         # Preserve the original pipeline exception if flushing already-written
+         # edge evidence also fails; rollback still has graph-native run refs.

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/sqlalchemy-delete-recovery.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/sqlalchemy-delete-recovery.patch
@@ -1,0 +1,175 @@
+--- /private/tmp/cognee-patch-a/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py	2026-09-12 18:05:01
++++ /private/tmp/cognee-patch-b/cognee/infrastructure/databases/relational/sqlalchemy/SqlAlchemyAdapter.py	2026-09-12 18:06:16
+@@ -1,5 +1,5 @@
+ import os
+-from urllib.parse import unquote
++from urllib.parse import unquote, urlparse
+ import gc
+ import asyncio
+ from os import path
+@@ -18,6 +18,7 @@
+ from cognee.infrastructure.utils.run_sync import run_sync
+ from cognee.infrastructure.databases.exceptions import EntityNotFoundError
+ from cognee.infrastructure.files.storage import get_file_storage, get_storage_config
++from cognee.infrastructure.locks import managed_data_file_lock
+ 
+ from ..ModelBase import Base
+ 
+@@ -393,7 +394,7 @@
+ 
+             - data_id (UUID): The unique identifier of the data entity to be deleted.
+         """
+-        async with self.get_async_session() as session:
++        async with managed_data_file_lock(), self.get_async_session() as session:
+             if self.engine.dialect.name == "sqlite":
+                 # Foreign key constraints are disabled by default in SQLite (for backwards compatibility),
+                 # so must be enabled for each database connection/session separately.
+@@ -405,7 +406,9 @@
+             try:
+                 data_entity = (
+                     await session.scalars(
+-                        select(Data).where(Data.id == data_id, Data.dataset_id == dataset_id)
++                        select(Data)
++                        .where(Data.id == data_id, Data.dataset_id == dataset_id)
++                        .with_for_update()
+                     )
+                 ).one()
+             except (ValueError, NoResultFound) as e:
+@@ -413,10 +416,26 @@
+                     message=f"Data {data_id} not found in dataset {dataset_id}: {str(e)}"
+                 ) from e
+ 
+-            raw_data_location = data_entity.raw_data_location
+-            original_data_location = data_entity.original_data_location
++            locations = tuple(
++                dict.fromkeys(
++                    location
++                    for location in (
++                        data_entity.raw_data_location,
++                        data_entity.original_data_location,
++                    )
++                    if location
++                )
++            )
++            for location in locations:
++                await self._remove_data_file_if_unreferenced(
++                    session,
++                    location,
++                    excluded_data_id=data_id,
++                )
+ 
+-            await session.execute(delete(Data).where(Data.id == data_id))
++            await session.execute(
++                delete(Data).where(Data.id == data_id, Data.dataset_id == dataset_id)
++            )
+             await session.commit()
+ 
+         # Edge-evidence rows have no foreign key to Data (graph deletion must
+@@ -425,14 +444,6 @@
+ 
+         await delete_edge_evidence(dataset_id, data_id)
+ 
+-        # Storage cleanup runs after the commit so the reference count reflects
+-        # the deletion. Both the derived text (raw_data_location) and the
+-        # stored original (original_data_location) are collected — originals
+-        # live under content-addressed keys shared by identical payloads, so
+-        # each is removed only once nothing references it.
+-        await self.remove_data_file_if_unreferenced(raw_data_location)
+-        await self.remove_data_file_if_unreferenced(original_data_location)
+-
+     async def remove_data_file_if_unreferenced(self, file_location: Optional[str]) -> None:
+         """Remove a cognee-managed stored file once no ``Data`` row references it.
+ 
+@@ -441,42 +452,71 @@
+         shared by design — two rows with identical payloads point at one object
+         — so the reference count spans both location columns of every dataset.
+         """
++        async with self.get_async_session() as session:
++            await self._remove_data_file_if_unreferenced(session, file_location)
++
++    async def _remove_data_file_if_unreferenced(
++        self,
++        session: AsyncSession,
++        file_location: Optional[str],
++        *,
++        excluded_data_id: Optional[UUID] = None,
++    ) -> None:
++        """Remove one unreferenced provider-owned local file within ``session``."""
+         if not file_location:
+             return
+ 
+         storage_config = get_storage_config()
+         data_root = storage_config["data_root_directory"]
+-        if data_root not in file_location:
++        relative_path = self._provider_owned_storage_key(file_location, data_root)
++        if relative_path is None:
+             return
+ 
+-        async with self.get_async_session() as session:
+-            references = (
+-                await session.execute(
+-                    select(func.count())
+-                    .select_from(Data)
+-                    .where(
+-                        or_(
+-                            Data.raw_data_location == file_location,
+-                            Data.original_data_location == file_location,
+-                        )
+-                    )
+-                )
+-            ).scalar()
+-
++        reference_query = select(func.count()).select_from(Data).where(
++            or_(
++                Data.raw_data_location == file_location,
++                Data.original_data_location == file_location,
++            )
++        )
++        if excluded_data_id is not None:
++            reference_query = reference_query.where(Data.id != excluded_data_id)
++        references = (await session.execute(reference_query)).scalar()
+         if references:
+             return
+ 
+-        relative_path = file_location.split(data_root, 1)[1].lstrip("/\\")
+-        if file_location.startswith("file://"):
+-            # file:// locations carry percent-encoding (spaces as %20); storage
+-            # keys are the decoded form.
+-            relative_path = unquote(relative_path)
+-
+         file_storage = get_file_storage(data_root)
+         if await file_storage.file_exists(relative_path):
+             await file_storage.remove(relative_path)
+         else:
+             logger.warning("Stored file to clean up was already gone: %s", file_location)
++
++    @staticmethod
++    def _provider_owned_storage_key(file_location: str, data_root: str) -> Optional[str]:
++        """Return a local storage key only when the resolved path is below the data root."""
++        root_uri = urlparse(data_root)
++        location_uri = urlparse(file_location)
++        if root_uri.scheme not in ("", "file") or root_uri.netloc not in ("", "localhost"):
++            return None
++        if location_uri.scheme not in ("", "file") or location_uri.netloc not in (
++            "",
++            "localhost",
++        ):
++            return None
++
++        root_value = unquote(root_uri.path) if root_uri.scheme == "file" else data_root
++        location_value = (
++            unquote(location_uri.path) if location_uri.scheme == "file" else file_location
++        )
++        resolved_root = os.path.realpath(os.path.expanduser(root_value))
++        resolved_location = os.path.realpath(os.path.expanduser(location_value))
++        try:
++            if os.path.commonpath((resolved_root, resolved_location)) != resolved_root:
++                return None
++        except ValueError:
++            return None
++        if resolved_location == resolved_root:
++            return None
++        return os.path.relpath(resolved_location, resolved_root)
+ 
+     async def get_table(self, table_name: str, schema_name: Optional[str] = "public") -> Table:
+         """

--- a/apps/_infra/cognee/tests/candidates/1.5.4/profile.json
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/profile.json
@@ -5,7 +5,33 @@
     "repository": "https://github.com/topoteretes/cognee",
     "tag": "v1.5.4",
     "commit": "20e0bd88746de2d96e99b4b122361dfc3dad21bc",
-    "runtimeVersion": "1.5.4-local"
+    "runtimeVersion": "1.5.4-local",
+    "repairs": {
+      "cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter": {
+        "patchSha256": "08d46750e34abdc9a0cd76d37318fa886b027ef50bb792b0f25f27f526574b50",
+        "postimageSha256": "3d7f8fdc029226ba33919838a522b0325e616d3c3c7820fde828f90c68c8daaf",
+        "patchPath": "/opt/opencrane/cognee-repair/sqlalchemy-delete-recovery.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/sqlalchemy-delete-recovery.json"
+      },
+      "cognee.infrastructure.locks": {
+        "patchSha256": "0f3ecd0c126b4061bdf5efcc95b54e8ca90f6d0a887d817aa597ea77df0d9b88",
+        "postimageSha256": "5df9e8d38636ae9f0e35978b6327ce1a530d0b949f484b4c1e8dee84fbe61abc",
+        "patchPath": "/opt/opencrane/cognee-repair/locks-export.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/locks-export.json"
+      },
+      "cognee.infrastructure.locks.managed_data_file_lock": {
+        "patchSha256": "91c4006d8f69584b809eb1d3351363e8634d7f5068e4dcbcdcb550916e6fc938",
+        "postimageSha256": "c3fbada36b40460f67832da43bf04b9d7e7ce2f56ed81aa01a0fc2b831fd51e7",
+        "patchPath": "/opt/opencrane/cognee-repair/managed-data-file-lock.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/managed-data-file-lock.json"
+      },
+      "cognee.modules.pipelines.operations.run_tasks_data_item": {
+        "patchSha256": "7eb15e93fa0986d225ce0a3c89001f1c1b671db72c4254a690141edd4c4be312",
+        "postimageSha256": "df8872f1f864b50640f7a083e62c33d29a1c704a8f9df9918702d0b712dedc7b",
+        "patchPath": "/opt/opencrane/cognee-repair/run-tasks-data-item.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/run-tasks-data-item.json"
+      }
+    }
   },
   "image": {
     "repository": "cognee/cognee",

--- a/apps/_infra/cognee/tests/fixtures/source_evidence.py
+++ b/apps/_infra/cognee/tests/fixtures/source_evidence.py
@@ -10,10 +10,13 @@ from pathlib import Path
 
 import cognee
 
+from source_repair_evidence import validated_repairs, verify_repair
+
 
 def _arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--expected", required=True)
+    parser.add_argument("--profile")
     parser.add_argument("--output", required=True)
     return parser.parse_args()
 
@@ -25,11 +28,37 @@ def _module_path(module_name: str) -> Path:
     return Path(spec.origin)
 
 
+def _write_evidence(output: str, evidence: dict) -> None:
+    """Retain the same diagnostic receipt on success and declaration failure."""
+    Path(output).write_text(
+        json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
 def main() -> None:
     args = _arguments()
     expected = json.loads(Path(args.expected).read_text(encoding="utf-8"))
+    profile = json.loads(Path(args.profile).read_text(encoding="utf-8")) if args.profile else None
     actual_version = getattr(cognee, "__version__", None)
     mismatches = []
+    modules = {}
+    repair_evidence = {}
+    profile_image = profile.get("image") if isinstance(profile, dict) else None
+    evidence = {
+        "cogneeVersion": actual_version,
+        "modules": modules,
+        "repairs": repair_evidence,
+        "declaredRepairs": expected.get("repairs", {}),
+        "profileBaseImageDigest": profile_image.get("linuxAmd64Digest")
+        if isinstance(profile_image, dict) else None,
+        "mismatches": mismatches,
+    }
+    try:
+        repairs = validated_repairs(expected, profile)
+    except (AssertionError, AttributeError, TypeError, ValueError) as error:
+        mismatches.append(f"Candidate repair declaration is invalid: {error}")
+        _write_evidence(args.output, evidence)
+        raise AssertionError(mismatches[0]) from error
     if actual_version != expected["version"]:
         mismatches.append(
             f"Cognee version differs: expected {expected['version']}, received {actual_version}"
@@ -39,8 +68,9 @@ def main() -> None:
     if snapshot_directory.exists():
         shutil.rmtree(snapshot_directory)
     snapshot_directory.mkdir()
-    modules = {}
-    for module_name, expected_digest in expected["modules"].items():
+    module_names = dict.fromkeys([*expected["modules"], *repairs])
+    for module_name in module_names:
+        expected_digest = expected["modules"].get(module_name)
         try:
             path = _module_path(module_name)
         except (AssertionError, ImportError, ValueError) as error:
@@ -51,7 +81,14 @@ def main() -> None:
         actual_digest = hashlib.sha256(source).hexdigest()
         snapshot = snapshot_directory / f"{module_name}.py"
         snapshot.write_bytes(source)
-        if actual_digest != expected_digest:
+        if module_name in repairs:
+            try:
+                repair_evidence[module_name] = verify_repair(
+                    module_name, path, actual_digest, repairs[module_name]
+                )
+            except (AssertionError, OSError, ValueError) as error:
+                mismatches.append(f"Candidate repair verification failed for {module_name}: {error}")
+        elif actual_digest != expected_digest:
             mismatches.append(
                 f"Cognee source differs for {module_name}: "
                 f"expected {expected_digest}, received {actual_digest}"
@@ -60,14 +97,11 @@ def main() -> None:
             "path": str(path), "sha256": actual_digest, "snapshot": snapshot.name
         }
 
-    evidence = {
-        "cogneeVersion": actual_version,
-        "modules": modules,
-        "mismatches": mismatches,
-    }
-    Path(args.output).write_text(
-        json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+    unverified_repairs = set(repairs) - set(repair_evidence)
+    if unverified_repairs:
+        mismatches.append("Candidate repairs were not verified: " + ", ".join(sorted(unverified_repairs)))
+
+    _write_evidence(args.output, evidence)
     print(f"EVIDENCE cognee_version={actual_version}")
     for module_name, value in modules.items():
         print(f"EVIDENCE module={module_name} sha256={value.get('sha256', 'unavailable')}")

--- a/apps/_infra/cognee/tests/fixtures/source_repair_evidence.py
+++ b/apps/_infra/cognee/tests/fixtures/source_repair_evidence.py
@@ -1,0 +1,92 @@
+"""Verify explicit candidate repairs without replacing upstream source evidence."""
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+_REPAIR_ROOT = Path("/opt/opencrane/cognee-repair")
+_REPAIRED_SOURCE_SCOPE = "official-tag-source-with-explicit-candidate-repair"
+_REPAIR_FIELDS = {
+    "baseImageDigest", "preimageSha256", "patchSha256", "postimageSha256",
+    "patchPath", "receiptPath",
+}
+
+
+def validated_repairs(
+    expected: dict[str, Any], profile: dict[str, Any] | None
+) -> dict[str, dict[str, str | None]]:
+    """Preserve upstream hashes and require explicit absence for newly added modules."""
+    repairs = expected.get("repairs", {})
+    if not isinstance(repairs, dict):
+        raise AssertionError("Candidate repairs must be keyed by module name")
+    if not repairs:
+        return {}
+    if profile is None:
+        raise AssertionError("Candidate repairs require the verified image profile")
+    source = expected.get("source")
+    if not isinstance(source, dict) or source.get("scope") != _REPAIRED_SOURCE_SCOPE:
+        raise AssertionError("Repaired source must declare the admitted candidate repair scope")
+    base_digest = profile.get("image", {}).get("linuxAmd64Digest")
+    if not isinstance(base_digest, str) or re.fullmatch(r"sha256:[0-9a-f]{64}", base_digest) is None:
+        raise AssertionError("Candidate profile has no immutable base image digest")
+    modules = expected.get("modules", {})
+    if not isinstance(modules, dict):
+        raise AssertionError("Upstream module evidence must be keyed by module name")
+    for module, repair in repairs.items():
+        if not isinstance(repair, dict) or set(repair) != _REPAIR_FIELDS:
+            raise AssertionError("Candidate repair has missing or unexpected evidence fields")
+        if repair["baseImageDigest"] != base_digest:
+            raise AssertionError("Candidate repair base differs from the image profile")
+        for field in ("patchSha256", "postimageSha256"):
+            if not isinstance(repair[field], str) or re.fullmatch(r"[0-9a-f]{64}", repair[field]) is None:
+                raise AssertionError("Candidate repair has an invalid source or patch digest")
+        preimage = repair["preimageSha256"]
+        if module in modules:
+            if not isinstance(preimage, str) or re.fullmatch(r"[0-9a-f]{64}", preimage) is None or preimage != modules[module]:
+                raise AssertionError("Candidate repair replaced its upstream preimage evidence")
+        elif preimage is not None:
+            raise AssertionError("A new candidate module must declare an absent preimage")
+        if not all(isinstance(repair[field], str) for field in ("patchPath", "receiptPath")):
+            raise AssertionError("Candidate repair artifact paths must be strings")
+    return repairs
+
+
+def _repair_file(value: str) -> Path:
+    """Accept only a regular, non-symlink artifact inside the fixed image repair directory."""
+    path = Path(value)
+    if not path.is_absolute() or path.is_symlink() or not path.is_file():
+        raise AssertionError("Candidate repair artifact is not a regular absolute file")
+    resolved = path.resolve(strict=True)
+    try:
+        resolved.relative_to(_REPAIR_ROOT.resolve(strict=True))
+    except ValueError as error:
+        raise AssertionError("Candidate repair artifact escaped its image directory") from error
+    return resolved
+
+
+def verify_repair(
+    module: str, origin: Path, source_digest: str, repair: dict[str, Any]
+) -> dict[str, Any]:
+    """Bind the loaded module bytes to the retained build receipt and patch artifact."""
+    if origin.is_symlink() or not origin.is_file():
+        raise AssertionError("Repaired module origin is not a regular non-symlink file")
+    patch = _repair_file(repair["patchPath"])
+    receipt_path = _repair_file(repair["receiptPath"])
+    if patch.samefile(receipt_path) or patch.samefile(origin) or receipt_path.samefile(origin):
+        raise AssertionError("Repair patch, receipt and module must be distinct files")
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    if receipt != {"module": module, **repair}:
+        raise AssertionError("Candidate repair receipt differs from its declared build evidence")
+    patch_digest = hashlib.sha256(patch.read_bytes()).hexdigest()
+    if patch_digest != repair["patchSha256"]:
+        raise AssertionError("Candidate repair patch digest differs from the build evidence")
+    if source_digest != repair["postimageSha256"]:
+        raise AssertionError("Repaired runtime module differs from its declared postimage")
+    return {
+        "module": module, **repair,
+        "actualPatchSha256": patch_digest, "actualPostimageSha256": source_digest,
+        "verified": True,
+    }

--- a/apps/_infra/cognee/tests/fixtures/test_provider_candidate_patch_1_5_4.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_candidate_patch_1_5_4.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Verify the candidate repair patch and its cross-process file lock."""
+
+import asyncio
+import hashlib
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[5]
+PATCH_DIRECTORY = (
+    REPOSITORY_ROOT / "apps/_infra/cognee/tests/candidates/1.5.4/patches"
+)
+APPLIER_PATH = PATCH_DIRECTORY / "apply-source-patch.py"
+APPLIER_SPEC = importlib.util.spec_from_file_location("candidate_source_patch", APPLIER_PATH)
+if APPLIER_SPEC is None or APPLIER_SPEC.loader is None:
+    raise RuntimeError("Unable to load the candidate source patch helper")
+APPLIER = importlib.util.module_from_spec(APPLIER_SPEC)
+APPLIER_SPEC.loader.exec_module(APPLIER)
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _managed_lock_source() -> str:
+    patch = (PATCH_DIRECTORY / "managed-data-file-lock.patch").read_text(encoding="utf-8")
+    source = APPLIER._apply_unified_patch("", patch)
+    expected = "c3fbada36b40460f67832da43bf04b9d7e7ce2f56ed81aa01a0fc2b831fd51e7"
+    if _sha256(source.encode("utf-8")) != expected:
+        raise AssertionError("Managed lock patch did not produce its declared postimage")
+    return source.replace(
+        "from cognee.infrastructure.files.storage import get_storage_config",
+        "def get_storage_config():\n"
+        "    return {'data_root_directory': os.environ['DATA_ROOT_DIRECTORY']}",
+    )
+
+
+def _load_managed_lock() -> types.ModuleType:
+    module = types.ModuleType("candidate_managed_data_file_lock")
+    exec(compile(_managed_lock_source(), "managed_data_file_lock.py", "exec"), module.__dict__)
+    return module
+
+
+class CandidatePatch154Test(unittest.TestCase):
+    def test_patch_applier_rejects_context_drift(self) -> None:
+        patch = "--- a/example.py\n+++ b/example.py\n@@ -1 +1 @@\n-old\n+new\n"
+        self.assertEqual(APPLIER._apply_unified_patch("old\n", patch), "new\n")
+        with self.assertRaisesRegex(ValueError, "context does not match"):
+            APPLIER._apply_unified_patch("different\n", patch)
+
+    def test_patch_cli_rejects_wrong_preimage_before_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "example.py"
+            patch_path = root / "example.patch"
+            receipt = root / "receipt.json"
+            source.write_text("old\n", encoding="utf-8")
+            patch_path.write_text(
+                "--- a/example.py\n+++ b/example.py\n@@ -1 +1 @@\n-old\n+new\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(APPLIER_PATH),
+                    "--source",
+                    str(source),
+                    "--patch",
+                    str(patch_path),
+                    "--receipt",
+                    str(receipt),
+                    "--module",
+                    "example",
+                    "--base-image-digest",
+                    "sha256:" + "1" * 64,
+                    "--preimage-sha256",
+                    "0" * 64,
+                    "--patch-sha256",
+                    _sha256(patch_path.read_bytes()),
+                    "--postimage-sha256",
+                    _sha256(b"new\n"),
+                ],
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(source.read_text(encoding="utf-8"), "old\n")
+            self.assertFalse(receipt.exists())
+
+    def test_patch_cli_rejects_occupied_absent_preimage_before_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "addition.py"
+            patch_path = root / "addition.patch"
+            receipt = root / "receipt.json"
+            source.write_text("occupied\n", encoding="utf-8")
+            patch_path.write_text(
+                "--- /dev/null\n+++ b/addition.py\n@@ -0,0 +1 @@\n+created\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(APPLIER_PATH),
+                    "--source",
+                    str(source),
+                    "--patch",
+                    str(patch_path),
+                    "--receipt",
+                    str(receipt),
+                    "--module",
+                    "addition",
+                    "--base-image-digest",
+                    "sha256:" + "1" * 64,
+                    "--preimage-absent",
+                    "--patch-sha256",
+                    _sha256(patch_path.read_bytes()),
+                    "--postimage-sha256",
+                    _sha256(b"created\n"),
+                ],
+                capture_output=True,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(source.read_text(encoding="utf-8"), "occupied\n")
+            self.assertFalse(receipt.exists())
+
+    def test_same_task_reenters_while_child_task_contends(self) -> None:
+        module = _load_managed_lock()
+
+        async def exercise() -> None:
+            async with module.managed_data_file_lock(timeout_seconds=0.5):
+                async with module.managed_data_file_lock(timeout_seconds=0.5):
+                    pass
+
+                async def contend() -> None:
+                    async with module.managed_data_file_lock(timeout_seconds=0.1):
+                        raise AssertionError("Child task bypassed the held kernel lock")
+
+                with self.assertRaisesRegex(TimeoutError, "timed out"):
+                    await asyncio.create_task(contend())
+
+            async with module.managed_data_file_lock(timeout_seconds=0.5):
+                pass
+
+        with tempfile.TemporaryDirectory() as directory:
+            data_root = Path(directory) / "data"
+            data_root.mkdir()
+            with mock.patch.dict(
+                os.environ, {"DATA_ROOT_DIRECTORY": str(data_root)}
+            ):
+                asyncio.run(exercise())
+
+    def test_competing_process_waits_for_the_same_root_lock(self) -> None:
+        module = _load_managed_lock()
+
+        async def exercise(runtime_path: Path, data_root: Path) -> None:
+            runner = (
+                "import asyncio, runpy, sys\n"
+                "values = runpy.run_path(sys.argv[1])\n"
+                "async def attempt():\n"
+                "    try:\n"
+                "        async with values['managed_data_file_lock'](0.1):\n"
+                "            print('acquired')\n"
+                "    except TimeoutError:\n"
+                "        print('timeout')\n"
+                "asyncio.run(attempt())\n"
+            )
+            async with module.managed_data_file_lock(timeout_seconds=0.5):
+                process = await asyncio.create_subprocess_exec(
+                    sys.executable,
+                    "-c",
+                    runner,
+                    str(runtime_path),
+                    env={**os.environ, "DATA_ROOT_DIRECTORY": str(data_root)},
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                stdout, stderr = await process.communicate()
+            self.assertEqual(process.returncode, 0, stderr.decode("utf-8"))
+            self.assertEqual(stdout.decode("utf-8").strip(), "timeout")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            data_root = root / "data"
+            data_root.mkdir()
+            runtime_path = root / "managed_data_file_lock.py"
+            runtime_path.write_text(_managed_lock_source(), encoding="utf-8")
+            with mock.patch.dict(
+                os.environ, {"DATA_ROOT_DIRECTORY": str(data_root)}
+            ):
+                asyncio.run(exercise(runtime_path, data_root))
+
+    def test_process_exit_releases_the_same_root_lock(self) -> None:
+        module = _load_managed_lock()
+
+        async def exercise(runtime_path: Path, data_root: Path) -> None:
+            holder_runner = (
+                "import asyncio, runpy, sys\n"
+                "values = runpy.run_path(sys.argv[1])\n"
+                "async def hold():\n"
+                "    async with values['managed_data_file_lock'](1):\n"
+                "        print('acquired', flush=True)\n"
+                "        await asyncio.Event().wait()\n"
+                "asyncio.run(hold())\n"
+            )
+            holder = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "-c",
+                holder_runner,
+                str(runtime_path),
+                env={**os.environ, "DATA_ROOT_DIRECTORY": str(data_root)},
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            try:
+                if holder.stdout is None:
+                    raise AssertionError("Synthetic lock holder has no output pipe")
+                signal = await asyncio.wait_for(holder.stdout.readline(), timeout=2)
+                self.assertEqual(signal, b"acquired\n")
+                holder.terminate()
+                await asyncio.wait_for(holder.wait(), timeout=2)
+            finally:
+                if holder.returncode is None:
+                    holder.kill()
+                    await asyncio.wait_for(holder.wait(), timeout=1)
+
+            async def contend_after_exit() -> None:
+                async with module.managed_data_file_lock(timeout_seconds=0.5):
+                    pass
+
+            await asyncio.wait_for(
+                asyncio.create_task(contend_after_exit()), timeout=1
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            data_root = root / "data"
+            data_root.mkdir()
+            runtime_path = root / "managed_data_file_lock.py"
+            runtime_path.write_text(_managed_lock_source(), encoding="utf-8")
+            with mock.patch.dict(
+                os.environ, {"DATA_ROOT_DIRECTORY": str(data_root)}
+            ):
+                asyncio.run(exercise(runtime_path, data_root))
+
+    def test_cancelled_holder_releases_descriptor(self) -> None:
+        module = _load_managed_lock()
+
+        async def exercise() -> None:
+            entered = asyncio.Event()
+            wait_forever = asyncio.Event()
+
+            async def hold() -> None:
+                async with module.managed_data_file_lock(timeout_seconds=0.5):
+                    entered.set()
+                    await wait_forever.wait()
+
+            holder = asyncio.create_task(hold())
+            await entered.wait()
+            holder.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await holder
+            async with module.managed_data_file_lock(timeout_seconds=0.5):
+                pass
+
+        with tempfile.TemporaryDirectory() as directory:
+            data_root = Path(directory) / "data"
+            data_root.mkdir()
+            with mock.patch.dict(
+                os.environ, {"DATA_ROOT_DIRECTORY": str(data_root)}
+            ):
+                asyncio.run(exercise())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/_infra/cognee/tests/fixtures/test_provider_contract_1_5_4.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_contract_1_5_4.py
@@ -246,6 +246,11 @@ class CandidateDatasetIdentityTest(unittest.TestCase):
             with (
                 patch.object(provider_contract, "_arguments", return_value=arguments),
                 patch.object(provider_contract, "ProviderApi", _AuthenticatedApi),
+                patch.object(
+                    provider_contract,
+                    "verify_dataset_provisioning_after_restart",
+                    return_value={},
+                ),
                 patch.object(provider_contract, "recover_identity", _fail_recovery),
                 self.assertRaisesRegex(AssertionError, "distinct chunks"),
             ):

--- a/apps/_infra/cognee/tests/fixtures/test_provider_dataset_provisioning_1_5_4.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_dataset_provisioning_1_5_4.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Verify the 1.5.4 dataset provisioning qualification stays fail closed."""
+
+import argparse
+import json
+import tempfile
+import threading
+import unittest
+import uuid
+from collections import Counter
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from v1_5_4 import provider_contract
+from v1_5_4 import provider_dataset_provisioning_contract as contract
+
+
+OWNER_ID = str(uuid.uuid4())
+
+
+class _Api:
+    def __init__(self) -> None:
+        self.base_url = "http://cognee:8000"
+        self._access_token = "synthetic-token"
+        self.created_names: list[str] = []
+        self.rows: dict[str, dict[str, str]] = {}
+        self._lock = threading.Lock()
+
+    def create_dataset(self, name: str) -> dict[str, str]:
+        with self._lock:
+            self.created_names.append(name)
+            row = self.rows.setdefault(
+                name,
+                {
+                    "id": str(uuid.uuid5(uuid.UUID(OWNER_ID), name)),
+                    "name": name,
+                    "ownerId": OWNER_ID,
+                },
+            )
+            return dict(row)
+
+    def json(self, method: str, path: str, value: Any | None = None) -> Any:
+        if (method, path, value) != ("GET", "/api/v1/datasets", None):
+            raise AssertionError("unexpected provider call")
+        with self._lock:
+            return [dict(row) for row in self.rows.values()]
+
+
+class _Connection:
+    instances: list["_Connection"] = []
+
+    def __init__(self, host: str, port: int, timeout: int) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.requests: list[tuple[str, str, bytes, dict[str, str]]] = []
+        self.closed = False
+        self.instances.append(self)
+
+    def request(
+        self, method: str, path: str, body: bytes, headers: dict[str, str]
+    ) -> None:
+        self.requests.append((method, path, body, headers))
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class ProviderDatasetProvisioning154Test(unittest.TestCase):
+    def test_authenticated_initial_phase_persists_provisioning_evidence(self) -> None:
+        dataset_evidence = {
+            "stable": {
+                "datasetId": str(uuid.uuid4()),
+                "name": "ocm-stable",
+                "ownerId": OWNER_ID,
+            }
+        }
+
+        class _AuthenticatedApi:
+            def __init__(self, _base_url: str) -> None:
+                pass
+
+            def authenticate(self, _email: str, _password: str, register: bool) -> None:
+                if not register:
+                    raise AssertionError("Initial qualification did not register its user")
+
+        with tempfile.TemporaryDirectory() as directory:
+            state_path = Path(directory) / "state.json"
+            output_path = Path(directory) / "output.json"
+            arguments = argparse.Namespace(
+                phase="initial",
+                mode="acl-enabled",
+                namespace="synthetic-run",
+                output=str(output_path),
+                state=str(state_path),
+                base_url="http://cognee:8000",
+                drop_proxy="drop-proxy:8091",
+            )
+            with (
+                patch.object(provider_contract, "_arguments", return_value=arguments),
+                patch.object(provider_contract, "ProviderApi", _AuthenticatedApi),
+                patch.object(
+                    provider_contract,
+                    "qualify_dataset_provisioning",
+                    return_value=dataset_evidence,
+                ),
+                patch.object(
+                    provider_contract,
+                    "prepare_isolation",
+                    return_value={"authorizedDatasetId": str(uuid.uuid4())},
+                ),
+                patch.object(
+                    provider_contract,
+                    "prepare_identity",
+                    side_effect=lambda _api, evidence, _proxy: evidence,
+                ),
+            ):
+                provider_contract.main()
+
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            output = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(state["datasetProvisioning"], dataset_evidence)
+            self.assertEqual(output, state)
+
+    def test_qualification_uses_one_saved_name_for_each_effect(self) -> None:
+        api = _Api()
+
+        def drop_response(target: _Api, name: str) -> None:
+            target.create_dataset(name)
+
+        evidence = contract.qualify_dataset_provisioning(
+            api, "synthetic-run", drop_response=drop_response
+        )
+
+        counts = Counter(api.created_names)
+        self.assertEqual(sorted(counts.values()), [1, 2, 4])
+        self.assertEqual(set(counts), {item["name"] for item in evidence.values()})
+        self.assertEqual({item["ownerId"] for item in evidence.values()}, {OWNER_ID})
+        self.assertEqual(len({item["datasetId"] for item in evidence.values()}), 3)
+
+    def test_restart_requires_every_exact_saved_coordinate(self) -> None:
+        api = _Api()
+        names = [contract._opaque_name("synthetic-run", case) for case in range(3)]
+        evidence = {
+            case: contract._coordinate(api.create_dataset(name))
+            for case, name in zip(
+                ("stable", "concurrent", "droppedResponse"), names, strict=True
+            )
+        }
+
+        self.assertEqual(
+            contract.verify_dataset_provisioning_after_restart(api, evidence),
+            evidence,
+        )
+
+        api.rows[names[1]] = {
+            **api.rows[names[1]],
+            "id": str(uuid.uuid4()),
+        }
+        with self.assertRaisesRegex(AssertionError, "unique saved dataset coordinate"):
+            contract.verify_dataset_provisioning_after_restart(api, evidence)
+
+    def test_reconciliation_rejects_absence_and_duplicate_owned_rows(self) -> None:
+        api = _Api()
+        name = contract._opaque_name("synthetic-run", "lost")
+        with self.assertRaisesRegex(AssertionError, "did not become visible"):
+            contract._recover_dropped_create(
+                api, name, OWNER_ID, attempts=2, interval_seconds=0
+            )
+
+        api.rows["first"] = {"id": str(uuid.uuid4()), "name": name, "ownerId": OWNER_ID}
+        api.rows["second"] = {"id": str(uuid.uuid4()), "name": name, "ownerId": OWNER_ID}
+        with self.assertRaisesRegex(AssertionError, "duplicate rows"):
+            contract._recover_dropped_create(
+                api, name, OWNER_ID, attempts=1, interval_seconds=0
+            )
+
+    def test_reconciliation_ignores_same_name_owned_by_another_user(self) -> None:
+        api = _Api()
+        name = contract._opaque_name("synthetic-run", "lost")
+        expected = {"id": str(uuid.uuid4()), "name": name, "ownerId": OWNER_ID}
+        api.rows["foreign"] = {
+            "id": str(uuid.uuid4()),
+            "name": name,
+            "ownerId": str(uuid.uuid4()),
+        }
+        api.rows["expected"] = expected
+
+        self.assertEqual(
+            contract._recover_dropped_create(
+                api, name, OWNER_ID, attempts=1, interval_seconds=0
+            ),
+            {
+                "datasetId": expected["id"],
+                "name": name,
+                "ownerId": OWNER_ID,
+            },
+        )
+
+    def test_dropped_request_closes_without_reading_provider_response(self) -> None:
+        api = _Api()
+        _Connection.instances.clear()
+        with patch.object(contract.http.client, "HTTPConnection", _Connection):
+            contract._send_dataset_create_without_reading_response(api, "ocm-saved")
+
+        self.assertEqual(len(_Connection.instances), 1)
+        connection = _Connection.instances[0]
+        self.assertEqual(
+            (connection.host, connection.port, connection.timeout),
+            ("cognee", 8000, 30),
+        )
+        self.assertTrue(connection.closed)
+        self.assertEqual(len(connection.requests), 1)
+        method, path, body, headers = connection.requests[0]
+        self.assertEqual((method, path), ("POST", "/api/v1/datasets"))
+        self.assertEqual(body, b'{"name":"ocm-saved"}')
+        self.assertEqual(headers["content-length"], str(len(body)))
+        self.assertEqual(headers["content-type"], "application/json")
+
+    def test_coordinate_requires_wire_owner_and_valid_uuids(self) -> None:
+        dataset_id = str(uuid.uuid4())
+        invalid = (
+            {"id": dataset_id, "name": "ocm-name", "owner_id": OWNER_ID},
+            {"id": "not-a-uuid", "name": "ocm-name", "ownerId": OWNER_ID},
+            {"id": dataset_id, "name": "ocm-name", "ownerId": "not-a-uuid"},
+        )
+        for value in invalid:
+            with self.subTest(value=value):
+                with self.assertRaises((AssertionError, ValueError)):
+                    contract._coordinate(value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/_infra/cognee/tests/fixtures/test_provider_deletion_1_5_4.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_deletion_1_5_4.py
@@ -25,11 +25,12 @@ class _Api:
         self.dataset_id = dataset_id
         self.data_id = data_id
         self.deleted = []
+        self.row_present = True
 
     def list_data(self, dataset_id: str) -> list[dict[str, str]]:
         if dataset_id != self.dataset_id:
             raise AssertionError("wrong dataset")
-        return []
+        return [{"id": self.data_id, "datasetId": self.dataset_id}] if self.row_present else []
 
     def assert_raw_absent(self, dataset_id: str, data_id: str) -> None:
         if (dataset_id, data_id) != (self.dataset_id, self.data_id):
@@ -37,6 +38,7 @@ class _Api:
 
     def delete(self, dataset_id: str, data_id: str) -> None:
         self.deleted.append((dataset_id, data_id))
+        self.row_present = False
 
 
 class _MemberApi:
@@ -58,13 +60,25 @@ class _CommittedDeleteAdapter:
         self.row_present = True
         self.real_cleanup_calls = []
 
-    async def remove_data_file_if_unreferenced(self, location: str) -> None:
+    async def _remove_data_file_if_unreferenced(
+        self,
+        _session: object,
+        location: str,
+        *,
+        excluded_data_id: uuid.UUID | None = None,
+    ) -> None:
+        if excluded_data_id is None:
+            raise AssertionError("deletion did not exclude its own Data row")
         self.real_cleanup_calls.append(location)
 
     async def delete_data_entity(self, _data_id: uuid.UUID, _dataset_id: uuid.UUID) -> None:
+        await self._remove_data_file_if_unreferenced(
+            object(), self.raw_location, excluded_data_id=_data_id
+        )
+        await self._remove_data_file_if_unreferenced(
+            object(), self.original_location, excluded_data_id=_data_id
+        )
         self.row_present = False
-        await self.remove_data_file_if_unreferenced(self.raw_location)
-        await self.remove_data_file_if_unreferenced(self.original_location)
 
 
 class ProviderDeletion154Test(unittest.TestCase):
@@ -93,11 +107,11 @@ class ProviderDeletion154Test(unittest.TestCase):
                         _MemberApi(member, content), dataset_id, content_digest
                     )
 
-    def test_injection_occurs_after_commit_and_restores_the_adapter_method(self) -> None:
+    def test_cleanup_failure_keeps_row_and_restores_the_adapter_method(self) -> None:
         dataset_id = str(uuid.uuid4())
         data_id = str(uuid.uuid4())
         adapter = _CommittedDeleteAdapter("file:///root/raw.txt", "file:///root/original.txt")
-        original_method = adapter.remove_data_file_if_unreferenced
+        original_method = adapter._remove_data_file_if_unreferenced
 
         calls = asyncio.run(
             MODULE._delete_with_injected_original_cleanup_failure(
@@ -108,11 +122,11 @@ class ProviderDeletion154Test(unittest.TestCase):
             )
         )
 
-        self.assertFalse(adapter.row_present)
+        self.assertTrue(adapter.row_present)
         self.assertEqual(calls, [adapter.raw_location, adapter.original_location])
         self.assertEqual(adapter.real_cleanup_calls, [adapter.raw_location])
         self.assertEqual(
-            adapter.remove_data_file_if_unreferenced.__func__, original_method.__func__
+            adapter._remove_data_file_if_unreferenced.__func__, original_method.__func__
         )
 
     def test_restart_retry_raises_machine_readable_failure_when_bytes_remain(self) -> None:
@@ -130,13 +144,14 @@ class ProviderDeletion154Test(unittest.TestCase):
                     "datasetId": dataset_id,
                     "dataId": data_id,
                     "contentSha256": digest,
+                    "rawPath": str(original),
                     "originalPath": str(original),
                 }
             }
             api = _Api(dataset_id, data_id)
             with patch.dict(os.environ, {"DATA_ROOT_DIRECTORY": directory}):
                 with self.assertRaises(MODULE.DeletionContractFailure) as raised:
-                    MODULE.verify_deletion_failure_after_restart(api, evidence)
+                    MODULE._verify_interrupted_deletion(api, evidence["postCommitFailure"])
 
         self.assertEqual(api.deleted, [(dataset_id, data_id)])
         machine_evidence = json.loads(str(raised.exception))
@@ -161,6 +176,7 @@ class ProviderDeletion154Test(unittest.TestCase):
                     "datasetId": dataset_id,
                     "dataId": data_id,
                     "contentSha256": digest,
+                    "rawPath": str(original),
                     "originalPath": str(original),
                 }
             }
@@ -168,16 +184,19 @@ class ProviderDeletion154Test(unittest.TestCase):
 
             def remove_on_retry(_dataset_id: str, _data_id: str) -> None:
                 original.unlink()
+                api.row_present = False
 
             api.delete = remove_on_retry
             with patch.dict(os.environ, {"DATA_ROOT_DIRECTORY": directory}):
-                result = MODULE.verify_deletion_failure_after_restart(api, evidence)
+                result = MODULE._verify_interrupted_deletion(
+                    api, evidence["postCommitFailure"]
+                )
 
         self.assertEqual(result["outcome"], "pass")
         self.assertTrue(result["originalBytesPresentAfterRestart"])
         self.assertFalse(result["originalBytesPresentAfterRecovery"])
 
-    def test_restart_passes_when_startup_already_removed_owned_original(self) -> None:
+    def test_restart_retries_row_when_files_are_already_absent(self) -> None:
         dataset_id = str(uuid.uuid4())
         data_id = str(uuid.uuid4())
         digest = MODULE.hashlib.sha256(b"removed during startup").hexdigest()
@@ -188,16 +207,19 @@ class ProviderDeletion154Test(unittest.TestCase):
                     "datasetId": dataset_id,
                     "dataId": data_id,
                     "contentSha256": digest,
+                    "rawPath": str(original),
                     "originalPath": str(original),
                 }
             }
             api = _Api(dataset_id, data_id)
             with patch.dict(os.environ, {"DATA_ROOT_DIRECTORY": directory}):
-                result = MODULE.verify_deletion_failure_after_restart(api, evidence)
+                result = MODULE._verify_interrupted_deletion(
+                    api, evidence["postCommitFailure"]
+                )
 
-        self.assertEqual(api.deleted, [])
+        self.assertEqual(api.deleted, [(dataset_id, data_id)])
         self.assertEqual(result["outcome"], "pass")
-        self.assertFalse(result["samePublicCoordinateAccepted"])
+        self.assertTrue(result["samePublicCoordinateAccepted"])
         self.assertFalse(result["originalBytesPresentAfterRestart"])
         self.assertFalse(result["originalBytesPresentAfterRecovery"])
 
@@ -214,13 +236,16 @@ class ProviderDeletion154Test(unittest.TestCase):
                     "datasetId": dataset_id,
                     "dataId": data_id,
                     "contentSha256": digest,
+                    "rawPath": str(original),
                     "originalPath": str(original),
                 }
             }
             api = _Api(dataset_id, data_id)
             with patch.dict(os.environ, {"DATA_ROOT_DIRECTORY": str(root)}):
                 with self.assertRaisesRegex(AssertionError, "escaped DATA_ROOT_DIRECTORY"):
-                    MODULE.verify_deletion_failure_after_restart(api, evidence)
+                    MODULE._verify_interrupted_deletion(
+                        api, evidence["postCommitFailure"]
+                    )
 
         self.assertEqual(api.deleted, [])
 

--- a/apps/_infra/cognee/tests/fixtures/test_provider_deletion_1_5_4.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_deletion_1_5_4.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import os
 import tempfile
+import types
 import unittest
 import uuid
 from pathlib import Path
@@ -82,6 +83,51 @@ class _CommittedDeleteAdapter:
 
 
 class ProviderDeletion154Test(unittest.TestCase):
+    def test_path_probe_inherits_the_provider_cleanup_helper_chain(self) -> None:
+        calls = []
+
+        class ProviderAdapter:
+            def __init__(self) -> None:
+                raise AssertionError("Path probes must not create a database engine")
+
+            async def remove_data_file_if_unreferenced(self, location: str) -> None:
+                async with self.get_async_session() as session:
+                    await self._remove_data_file_if_unreferenced(session, location)
+
+            async def _remove_data_file_if_unreferenced(
+                self, session: object, location: str
+            ) -> None:
+                result = await session.execute(object())
+                if result.scalar() != 0:
+                    raise AssertionError("Path probes must stub only an absent reference")
+                calls.append(location)
+                # This double verifies method inheritance, not the provider's containment rule.
+                if location.endswith("/managed.bin"):
+                    MODULE._local_file_path(location).unlink()
+
+        module_name = (
+            "cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter"
+        )
+        provider_module = types.ModuleType(module_name)
+        provider_module.SQLAlchemyAdapter = ProviderAdapter
+        with tempfile.TemporaryDirectory() as directory:
+            data_root = Path(directory) / "data"
+            data_root.mkdir()
+            with (
+                patch.dict("sys.modules", {module_name: provider_module}),
+                patch.dict(os.environ, {"DATA_ROOT_DIRECTORY": str(data_root)}),
+            ):
+                evidence = asyncio.run(MODULE._path_safety_probes())
+
+        self.assertEqual(len(calls), 7)
+        self.assertTrue(evidence["managedRemoved"])
+        self.assertTrue(evidence["substringSiblingRetained"])
+        self.assertTrue(evidence["substringDecoyRetained"])
+        self.assertEqual(
+            evidence["retainedCases"],
+            ["parentTraversal", "symlinkEscape", "storageRoot", "remoteFileHost", "remoteScheme"],
+        )
+
     def test_member_discovery_requires_camel_case_dataset_owner(self) -> None:
         dataset_id = str(uuid.uuid4())
         data_id = str(uuid.uuid4())

--- a/apps/_infra/cognee/tests/fixtures/test_provider_source_evidence.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_source_evidence.py
@@ -1,0 +1,189 @@
+"""Prove candidate repair evidence cannot conceal changed upstream modules or artifacts."""
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import source_repair_evidence as REPAIRS
+
+
+class ProviderSourceEvidenceTest(unittest.TestCase):
+    """Exercise repair validation and the complete attestation driver using synthetic files."""
+
+    def setUp(self) -> None:
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.repair_root = self.root / "repairs"
+        self.repair_root.mkdir()
+        self.addCleanup(patch.stopall)
+        patch.object(REPAIRS, "_REPAIR_ROOT", self.repair_root).start()
+        self.module = "upstream.adapter"
+        self.origin = self.root / "adapter.py"
+        self.origin.write_bytes(b"candidate adapter bytes\n")
+        self.patch_path = self.repair_root / "repair.patch"
+        self.patch_path.write_bytes(b"synthetic patch artifact\n")
+        self.receipt = self.repair_root / "receipt.json"
+        self.repair = {
+            "baseImageDigest": "sha256:" + "b" * 64,
+            "preimageSha256": "a" * 64,
+            "patchSha256": hashlib.sha256(self.patch_path.read_bytes()).hexdigest(),
+            "postimageSha256": hashlib.sha256(self.origin.read_bytes()).hexdigest(),
+            "patchPath": str(self.patch_path),
+            "receiptPath": str(self.receipt),
+        }
+        self.expected = {
+            "version": "test-version",
+            "source": {"scope": "official-tag-source-with-explicit-candidate-repair"},
+            "modules": {self.module: self.repair["preimageSha256"]},
+            "repairs": {self.module: self.repair},
+        }
+        self.profile = {"image": {"linuxAmd64Digest": self.repair["baseImageDigest"]}}
+        self._write_receipt()
+
+    def _write_receipt(self) -> None:
+        """Write the exact receipt shape produced by the candidate build."""
+        self.receipt.write_text(json.dumps({"module": self.module, **self.repair}))
+
+    def _verify(self) -> dict:
+        """Validate both declared identity and the corresponding actual artifact bytes."""
+        REPAIRS.validated_repairs(self.expected, self.profile)
+        return REPAIRS.verify_repair(
+            self.module, self.origin, hashlib.sha256(self.origin.read_bytes()).hexdigest(),
+            self.repair,
+        )
+
+    def _run_driver(self, origins: dict[str, Path]) -> dict:
+        """Run main without installing Cognee or contacting any provider."""
+        spec = importlib.util.spec_from_file_location(
+            "candidate_source_driver", Path(__file__).with_name("source_evidence.py")
+        )
+        if spec is None or spec.loader is None:
+            raise AssertionError("Source evidence driver could not be loaded")
+        module = importlib.util.module_from_spec(spec)
+        with patch.dict("sys.modules", {"cognee": types.SimpleNamespace(__version__="test-version")}):
+            spec.loader.exec_module(module)
+        expected_path = self.root / "expected.json"
+        profile_path = self.root / "profile.json"
+        output_path = self.root / "source-evidence.json"
+        expected_path.write_text(json.dumps(self.expected))
+        profile_path.write_text(json.dumps(self.profile))
+        arguments = argparse.Namespace(
+            expected=str(expected_path), profile=str(profile_path), output=str(output_path)
+        )
+        with patch.object(module, "_arguments", return_value=arguments), \
+                patch.object(module, "_module_path", side_effect=origins.__getitem__), \
+                patch("builtins.print"):
+            module.main()
+        return json.loads(output_path.read_text())
+
+    def test_retains_upstream_preimage_and_verified_runtime_repair(self) -> None:
+        result = self._run_driver({self.module: self.origin})
+        self.assertEqual(self.expected["modules"][self.module], "a" * 64)
+        self.assertEqual(result["modules"][self.module]["sha256"], self.repair["postimageSha256"])
+        self.assertEqual(result["repairs"][self.module]["preimageSha256"], "a" * 64)
+        self.assertTrue(result["repairs"][self.module]["verified"])
+
+    def test_added_module_requires_explicit_absent_preimage_and_is_attested(self) -> None:
+        self.expected["modules"] = {}
+        self.repair["preimageSha256"] = None
+        self._write_receipt()
+        result = self._run_driver({self.module: self.origin})
+        self.assertIsNone(result["repairs"][self.module]["preimageSha256"])
+        self.assertIn(self.module, result["modules"])
+
+    def test_unknown_module_cannot_claim_an_upstream_preimage(self) -> None:
+        self.expected["modules"] = {}
+        with self.assertRaisesRegex(AssertionError, "absent preimage"):
+            self._verify()
+
+    def test_upstream_module_cannot_claim_absence(self) -> None:
+        self.repair["preimageSha256"] = None
+        with self.assertRaisesRegex(AssertionError, "upstream preimage"):
+            self._verify()
+
+    def test_repair_cannot_replace_another_upstream_module_hash(self) -> None:
+        unchanged = self.root / "unchanged.py"
+        unchanged.write_bytes(b"unexpected modification\n")
+        self.expected["modules"]["upstream.unchanged"] = "c" * 64
+        with self.assertRaisesRegex(AssertionError, "Cognee source differs for upstream.unchanged"):
+            self._run_driver({self.module: self.origin, "upstream.unchanged": unchanged})
+
+    def test_wrong_profile_base_is_rejected(self) -> None:
+        self.profile["image"]["linuxAmd64Digest"] = "sha256:" + "c" * 64
+        with self.assertRaisesRegex(AssertionError, "base differs"):
+            self._verify()
+
+    def test_declaration_failure_retains_machine_readable_repair_evidence(self) -> None:
+        self.profile["image"]["linuxAmd64Digest"] = "sha256:" + "c" * 64
+        with self.assertRaisesRegex(AssertionError, "base differs"):
+            self._run_driver({self.module: self.origin})
+        evidence = json.loads((self.root / "source-evidence.json").read_text())
+        self.assertEqual(evidence["declaredRepairs"][self.module], self.repair)
+        self.assertEqual(evidence["profileBaseImageDigest"], self.profile["image"]["linuxAmd64Digest"])
+        self.assertIn("base differs", evidence["mismatches"][0])
+        self.assertEqual(evidence["repairs"], {})
+
+    def test_repair_requires_a_profile(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "image profile"):
+            REPAIRS.validated_repairs(self.expected, None)
+
+    def test_unchanged_provider_needs_no_repair_profile(self) -> None:
+        self.expected.pop("repairs")
+        self.assertEqual(REPAIRS.validated_repairs(self.expected, None), {})
+
+    def test_repaired_provider_requires_the_admitted_repair_scope(self) -> None:
+        for source in ({}, {"scope": "official-tag-source-expectations"}, {"scope": "arbitrary-claim"}):
+            with self.subTest(source=source):
+                self.expected["source"] = source
+                with self.assertRaisesRegex(AssertionError, "admitted candidate repair scope"):
+                    self._verify()
+
+    def test_receipt_rejects_missing_or_extra_fields(self) -> None:
+        for invalid in ({"module": self.module}, {"module": self.module, **self.repair, "extra": True}):
+            with self.subTest(invalid=invalid):
+                self.receipt.write_text(json.dumps(invalid))
+                with self.assertRaisesRegex(AssertionError, "receipt differs"):
+                    self._verify()
+
+    def test_patch_and_runtime_changes_are_rejected(self) -> None:
+        self.patch_path.write_bytes(b"changed patch\n")
+        with self.assertRaisesRegex(AssertionError, "patch digest"):
+            self._verify()
+        self.patch_path.write_bytes(b"synthetic patch artifact\n")
+        self.origin.write_bytes(b"changed module\n")
+        with self.assertRaisesRegex(AssertionError, "postimage"):
+            self._verify()
+
+    def test_repair_artifact_must_stay_inside_its_directory(self) -> None:
+        outside = self.root / "outside.patch"
+        outside.write_bytes(self.patch_path.read_bytes())
+        self.repair["patchPath"] = str(outside)
+        self._write_receipt()
+        with self.assertRaisesRegex(AssertionError, "escaped"):
+            self._verify()
+
+    def test_repair_artifact_cannot_be_a_symlink(self) -> None:
+        link = self.repair_root / "link.patch"
+        link.symlink_to(self.patch_path)
+        self.repair["patchPath"] = str(link)
+        self._write_receipt()
+        with self.assertRaisesRegex(AssertionError, "regular absolute file"):
+            self._verify()
+
+    def test_patch_and_module_cannot_be_hardlinks_to_the_same_file(self) -> None:
+        self.patch_path.unlink()
+        os.link(self.origin, self.patch_path)
+        with self.assertRaisesRegex(AssertionError, "distinct files"):
+            self._verify()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_contract.py
+++ b/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_contract.py
@@ -10,6 +10,10 @@ FIXTURE_DIRECTORY = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(FIXTURE_DIRECTORY))
 
 from provider_api import ProviderApi  # noqa: E402
+from v1_5_4.provider_dataset_provisioning_contract import (  # noqa: E402
+    qualify_dataset_provisioning,
+    verify_dataset_provisioning_after_restart,
+)
 from v1_5_4.provider_identity_contract import prepare_identity, recover_identity  # noqa: E402
 from v1_5_4.provider_isolation_contract import prepare_isolation  # noqa: E402
 
@@ -75,13 +79,22 @@ def main() -> None:
                 register=args.phase == "initial",
             )
         if args.phase == "initial":
+            dataset_provisioning = None
+            if args.mode == "acl-enabled":
+                dataset_provisioning = qualify_dataset_provisioning(api, args.namespace)
             evidence = prepare_isolation(api, args.namespace, args.mode)
             if args.mode == "acl-enabled":
+                evidence["datasetProvisioning"] = dataset_provisioning
                 evidence = prepare_identity(api, evidence, args.drop_proxy)
             state_path.write_text(
                 json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
             )
         elif args.phase == "recovery":
+            validated_evidence["datasetProvisioning"] = (
+                verify_dataset_provisioning_after_restart(
+                    api, validated_evidence.get("datasetProvisioning")
+                )
+            )
             evidence = recover_identity(api, validated_evidence)
             state_path.write_text(
                 json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"

--- a/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_dataset_provisioning_contract.py
+++ b/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_dataset_provisioning_contract.py
@@ -1,0 +1,198 @@
+"""Qualify deterministic and recoverable Cognee 1.5.4 dataset creation."""
+
+import hashlib
+import http.client
+import json
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, Protocol
+from urllib.parse import urlsplit
+
+
+class DatasetProvisioningApi(Protocol):
+    """Expose the authenticated dataset calls used by this candidate fixture."""
+
+    base_url: str
+    _access_token: str | None
+
+    def create_dataset(self, name: str) -> dict[str, Any]: ...
+
+    def json(self, method: str, path: str, value: Any | None = None) -> Any: ...
+
+
+DatasetCoordinate = dict[str, str]
+DropDatasetResponse = Callable[[DatasetProvisioningApi, str], None]
+
+
+def _opaque_name(namespace: str, case: str) -> str:
+    """Derive a stable test name without placing user or tenant text in it."""
+    digest = hashlib.sha256(f"{namespace}:{case}".encode()).hexdigest()
+    return f"ocm-{digest}"
+
+
+def _coordinate(value: Any) -> DatasetCoordinate:
+    if not isinstance(value, dict):
+        raise AssertionError("Dataset response is not an object")
+    dataset_id = value.get("id")
+    name = value.get("name")
+    owner_id = value.get("ownerId")
+    if not all(isinstance(item, str) and item for item in (dataset_id, name, owner_id)):
+        raise AssertionError("Dataset response has no UUID, name, or owner")
+    uuid.UUID(dataset_id)
+    uuid.UUID(owner_id)
+    return {"datasetId": dataset_id, "name": name, "ownerId": owner_id}
+
+
+def _saved_coordinate(value: Any) -> DatasetCoordinate:
+    if not isinstance(value, dict) or set(value) != {"datasetId", "name", "ownerId"}:
+        raise AssertionError("Saved dataset coordinate has an invalid shape")
+    dataset_id = value.get("datasetId")
+    name = value.get("name")
+    owner_id = value.get("ownerId")
+    if not all(isinstance(item, str) and item for item in (dataset_id, name, owner_id)):
+        raise AssertionError("Saved dataset coordinate has no UUID, name, or owner")
+    uuid.UUID(dataset_id)
+    uuid.UUID(owner_id)
+    return {"datasetId": dataset_id, "name": name, "ownerId": owner_id}
+
+
+def _listed_coordinates(api: DatasetProvisioningApi) -> list[DatasetCoordinate]:
+    response = api.json("GET", "/api/v1/datasets")
+    if not isinstance(response, list):
+        raise AssertionError("Dataset listing is not a list")
+    return [_coordinate(item) for item in response]
+
+
+def _unique_owned_name(
+    api: DatasetProvisioningApi, name: str, owner_id: str
+) -> DatasetCoordinate | None:
+    matches = [
+        item
+        for item in _listed_coordinates(api)
+        if item["name"] == name and item["ownerId"] == owner_id
+    ]
+    if len(matches) > 1:
+        raise AssertionError("Dataset listing contains duplicate rows for the saved name and owner")
+    return matches[0] if matches else None
+
+
+def _send_dataset_create_without_reading_response(
+    api: DatasetProvisioningApi, name: str
+) -> None:
+    """Send one create command, then close before the client reads its response."""
+    endpoint = urlsplit(api.base_url)
+    if endpoint.scheme != "http" or not endpoint.hostname:
+        raise AssertionError("Dropped-response qualification requires the internal HTTP endpoint")
+    token = api._access_token
+    if not isinstance(token, str) or not token:
+        raise AssertionError("Dropped-response qualification requires authentication")
+    payload = json.dumps({"name": name}, separators=(",", ":")).encode()
+    connection = http.client.HTTPConnection(
+        endpoint.hostname,
+        endpoint.port or 80,
+        timeout=30,
+    )
+    try:
+        connection.request(
+            "POST",
+            f"{endpoint.path.rstrip('/')}/api/v1/datasets",
+            body=payload,
+            headers={
+                "accept": "application/json",
+                "authorization": f"Bearer {token}",
+                "content-length": str(len(payload)),
+                "content-type": "application/json",
+            },
+        )
+    finally:
+        connection.close()
+
+
+def _recover_dropped_create(
+    api: DatasetProvisioningApi,
+    name: str,
+    owner_id: str,
+    *,
+    attempts: int = 50,
+    interval_seconds: float = 0.1,
+) -> DatasetCoordinate:
+    for attempt in range(attempts):
+        coordinate = _unique_owned_name(api, name, owner_id)
+        if coordinate is not None:
+            return coordinate
+        if attempt + 1 < attempts:
+            time.sleep(interval_seconds)
+    raise AssertionError("Dropped dataset create did not become visible during reconciliation")
+
+
+def _same_coordinate(
+    values: list[DatasetCoordinate], expected_name: str, expected_owner_id: str
+) -> DatasetCoordinate:
+    if not values:
+        raise AssertionError("Dataset creation returned no coordinates")
+    expected = values[0]
+    if any(value != expected for value in values[1:]):
+        raise AssertionError("Duplicate dataset creation returned different coordinates")
+    if expected["name"] != expected_name or expected["ownerId"] != expected_owner_id:
+        raise AssertionError("Dataset creation changed the saved name or authenticated owner")
+    return expected
+
+
+def qualify_dataset_provisioning(
+    api: DatasetProvisioningApi,
+    namespace: str,
+    *,
+    drop_response: DropDatasetResponse = _send_dataset_create_without_reading_response,
+) -> dict[str, DatasetCoordinate]:
+    """Prove same-owner replay, concurrent replay, and dropped-response adoption."""
+    stable_name = _opaque_name(namespace, "stable")
+    stable_values = [_coordinate(api.create_dataset(stable_name)) for _ in range(2)]
+    stable = _same_coordinate(stable_values, stable_name, stable_values[0]["ownerId"])
+    if _unique_owned_name(api, stable_name, stable["ownerId"]) != stable:
+        raise AssertionError("Stable dataset identity is not uniquely listed for its owner")
+    print("CASE dataset_create_replay_keeps_same_owner_coordinate PASS")
+
+    concurrent_name = _opaque_name(namespace, "concurrent")
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        concurrent_values = list(
+            pool.map(lambda _index: _coordinate(api.create_dataset(concurrent_name)), range(4))
+        )
+    concurrent = _same_coordinate(concurrent_values, concurrent_name, stable["ownerId"])
+    if _unique_owned_name(api, concurrent_name, stable["ownerId"]) != concurrent:
+        raise AssertionError("Concurrent dataset replay did not leave one owned coordinate")
+    print("CASE concurrent_dataset_create_replay_keeps_one_coordinate PASS")
+
+    dropped_name = _opaque_name(namespace, "dropped-response")
+    drop_response(api, dropped_name)
+    dropped = _recover_dropped_create(api, dropped_name, stable["ownerId"])
+    print("CASE dropped_dataset_create_response_recovers_saved_name_and_owner PASS")
+
+    return {
+        "stable": stable,
+        "concurrent": concurrent,
+        "droppedResponse": dropped,
+    }
+
+
+def verify_dataset_provisioning_after_restart(
+    api: DatasetProvisioningApi, evidence: Any
+) -> dict[str, DatasetCoordinate]:
+    """Require every saved dataset coordinate after a fresh authentication."""
+    expected_cases = ("stable", "concurrent", "droppedResponse")
+    if not isinstance(evidence, dict) or set(evidence) != set(expected_cases):
+        raise AssertionError("Saved dataset provisioning evidence has an invalid case set")
+    saved = {case: _saved_coordinate(evidence[case]) for case in expected_cases}
+    listed = _listed_coordinates(api)
+    for case, expected in saved.items():
+        matches = [
+            item
+            for item in listed
+            if item["name"] == expected["name"] and item["ownerId"] == expected["ownerId"]
+        ]
+        if matches != [expected]:
+            raise AssertionError(
+                f"Restart did not retain the unique saved dataset coordinate for {case}"
+            )
+    print("CASE dataset_coordinates_survive_provider_restart PASS")
+    return saved

--- a/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_deletion_contract.py
+++ b/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_deletion_contract.py
@@ -41,11 +41,6 @@ class _NoReferenceSession:
         return _ScalarResult()
 
 
-class _NoReferenceAdapter:
-    def get_async_session(self) -> _NoReferenceSession:
-        return _NoReferenceSession()
-
-
 class _InjectedCleanupFailure(RuntimeError):
     pass
 
@@ -82,6 +77,16 @@ async def _path_safety_probes() -> dict[str, Any]:
         SQLAlchemyAdapter,
     )
 
+    class _PathSafetyAdapter(SQLAlchemyAdapter):
+        """Keep installed cleanup methods while replacing database construction and queries."""
+
+        def __init__(self) -> None:
+            # These probes require no database engine; only the reference count is synthetic.
+            pass
+
+        def get_async_session(self) -> _NoReferenceSession:
+            return _NoReferenceSession()
+
     data_root = Path(os.environ["DATA_ROOT_DIRECTORY"]).resolve()
     probe_id = uuid.uuid4().hex
     managed_directory = data_root / "opencrane-deletion-probes" / probe_id
@@ -100,8 +105,8 @@ async def _path_safety_probes() -> dict[str, Any]:
     substring_decoy.parent.mkdir(parents=True)
     substring_decoy.write_bytes(marker)
 
-    adapter = _NoReferenceAdapter()
-    cleanup = SQLAlchemyAdapter.remove_data_file_if_unreferenced
+    adapter = _PathSafetyAdapter()
+    cleanup = adapter.remove_data_file_if_unreferenced
     managed_location = managed_file.as_uri()
     sibling_location = outside_file.as_uri()
     traversal_location = (
@@ -109,11 +114,11 @@ async def _path_safety_probes() -> dict[str, Any]:
     )
     symlink_location = (symlink_path / outside_file.name).as_uri()
     try:
-        await cleanup(adapter, managed_location)
+        await cleanup(managed_location)
         if managed_file.exists():
             raise AssertionError("Installed cleanup helper did not remove a managed file")
 
-        await cleanup(adapter, sibling_location)
+        await cleanup(sibling_location)
         if not outside_file.is_file() or outside_file.read_bytes() != marker:
             raise AssertionError("Data-root substring matching removed an external sibling file")
         if not substring_decoy.is_file() or substring_decoy.read_bytes() != marker:
@@ -127,7 +132,7 @@ async def _path_safety_probes() -> dict[str, Any]:
             ("remoteFileHost", "file://other-host/provider-owned.bin"),
             ("remoteScheme", "s3://provider-bucket/provider-owned.bin"),
         ):
-            await cleanup(adapter, location)
+            await cleanup(location)
             retained.append(name)
         if outside_file.read_bytes() != marker:
             raise AssertionError("A containment probe changed the external file")

--- a/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_deletion_contract.py
+++ b/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_deletion_contract.py
@@ -6,6 +6,7 @@ import json
 import os
 import shutil
 import uuid
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote, urlparse
@@ -49,6 +50,10 @@ class _InjectedCleanupFailure(RuntimeError):
     pass
 
 
+class _InjectedCommitFailure(RuntimeError):
+    pass
+
+
 def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
@@ -84,12 +89,16 @@ async def _path_safety_probes() -> dict[str, Any]:
     managed_file = managed_directory / "managed.bin"
     outside_file = outside_directory / "outside.bin"
     symlink_path = managed_directory / "outside-link"
+    sibling_suffix = str(outside_file).split(str(data_root), 1)[1].lstrip("/\\")
+    substring_decoy = data_root / sibling_suffix
     marker = hashlib.sha256(probe_id.encode("utf-8")).digest()
     managed_directory.mkdir(parents=True)
     outside_directory.mkdir(parents=True)
     managed_file.write_bytes(marker)
     outside_file.write_bytes(marker)
     symlink_path.symlink_to(outside_directory, target_is_directory=True)
+    substring_decoy.parent.mkdir(parents=True)
+    substring_decoy.write_bytes(marker)
 
     adapter = _NoReferenceAdapter()
     cleanup = SQLAlchemyAdapter.remove_data_file_if_unreferenced
@@ -107,20 +116,21 @@ async def _path_safety_probes() -> dict[str, Any]:
         await cleanup(adapter, sibling_location)
         if not outside_file.is_file() or outside_file.read_bytes() != marker:
             raise AssertionError("Data-root substring matching removed an external sibling file")
+        if not substring_decoy.is_file() or substring_decoy.read_bytes() != marker:
+            raise AssertionError("Data-root substring matching removed an in-root decoy file")
 
-        rejected = []
+        retained = []
         for name, location in (
             ("parentTraversal", traversal_location),
             ("symlinkEscape", symlink_location),
+            ("storageRoot", data_root.as_uri()),
+            ("remoteFileHost", "file://other-host/provider-owned.bin"),
+            ("remoteScheme", "s3://provider-bucket/provider-owned.bin"),
         ):
-            try:
-                await cleanup(adapter, location)
-            except ValueError:
-                rejected.append(name)
-            else:
-                raise AssertionError(f"Installed local storage accepted {name}")
+            await cleanup(adapter, location)
+            retained.append(name)
         if outside_file.read_bytes() != marker:
-            raise AssertionError("A rejected containment probe changed the external file")
+            raise AssertionError("A containment probe changed the external file")
 
         return {
             "scope": (
@@ -131,11 +141,176 @@ async def _path_safety_probes() -> dict[str, Any]:
             "managedRemoved": True,
             "substringSiblingLocation": sibling_location,
             "substringSiblingRetained": True,
-            "rejectedCases": rejected,
+            "substringDecoyRetained": True,
+            "retainedCases": retained,
         }
     finally:
         shutil.rmtree(managed_directory, ignore_errors=True)
         shutil.rmtree(outside_directory, ignore_errors=True)
+        shutil.rmtree(substring_decoy.parent, ignore_errors=True)
+
+
+async def _lock_and_generator_probes() -> dict[str, Any]:
+    """Exercise the installed task/process lock and item-generator cleanup paths."""
+
+    from cognee.infrastructure.locks import managed_data_file_lock
+    from cognee.modules.pipelines.operations.run_tasks_data_item import (
+        _drain_and_close_item_events,
+    )
+
+    child_timed_out = False
+    process_timed_out = False
+    async with managed_data_file_lock(timeout_seconds=1):
+        async def contend() -> None:
+            async with managed_data_file_lock(timeout_seconds=0.1):
+                raise AssertionError("Child task bypassed the managed-file lock")
+
+        try:
+            await asyncio.create_task(contend())
+        except TimeoutError:
+            child_timed_out = True
+
+        runner = (
+            "import asyncio\n"
+            "from cognee.infrastructure.locks import managed_data_file_lock\n"
+            "async def attempt():\n"
+            "    try:\n"
+            "        async with managed_data_file_lock(0.1):\n"
+            "            print('acquired')\n"
+            "    except TimeoutError:\n"
+            "        print('timeout')\n"
+            "asyncio.run(attempt())\n"
+        )
+        process = await asyncio.create_subprocess_exec(
+            "python",
+            "-c",
+            runner,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate()
+        if process.returncode != 0:
+            raise AssertionError(
+                f"Managed-file lock process probe failed: {stderr.decode('utf-8')}"
+            )
+        process_timed_out = stdout.decode("utf-8").strip() == "timeout"
+
+    async with managed_data_file_lock(timeout_seconds=1):
+        pass
+    if not child_timed_out or not process_timed_out:
+        raise AssertionError("Managed-file lock did not serialize task and process contenders")
+
+    holder_runner = (
+        "import asyncio\n"
+        "from cognee.infrastructure.locks import managed_data_file_lock\n"
+        "async def hold():\n"
+        "    async with managed_data_file_lock(1):\n"
+        "        print('acquired', flush=True)\n"
+        "        await asyncio.Event().wait()\n"
+        "asyncio.run(hold())\n"
+    )
+    holder = await asyncio.create_subprocess_exec(
+        "python",
+        "-c",
+        holder_runner,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        if holder.stdout is None:
+            raise AssertionError("Synthetic lock holder did not expose its output pipe")
+        acquired_signal = await asyncio.wait_for(holder.stdout.readline(), timeout=2)
+        if acquired_signal != b"acquired\n":
+            raise AssertionError("Synthetic child did not acquire the managed-file lock")
+        holder.terminate()
+        await asyncio.wait_for(holder.wait(), timeout=2)
+    finally:
+        if holder.returncode is None:
+            holder.terminate()
+            try:
+                await asyncio.wait_for(holder.wait(), timeout=1)
+            except TimeoutError:
+                holder.kill()
+                await asyncio.wait_for(holder.wait(), timeout=1)
+    async def acquire_after_process_exit() -> bool:
+        async with managed_data_file_lock(timeout_seconds=1):
+            return True
+
+    released_after_process_exit = await asyncio.wait_for(
+        asyncio.create_task(acquire_after_process_exit()), timeout=2
+    )
+
+    generator_closed = asyncio.Event()
+    generator_started = asyncio.Event()
+    generator_wait = asyncio.Event()
+
+    async def waiting_generator():
+        try:
+            generator_started.set()
+            yield {"started": True}
+            await generator_wait.wait()
+        finally:
+            generator_closed.set()
+
+    async def drain_waiting_generator() -> None:
+        async with managed_data_file_lock(timeout_seconds=1):
+            await _drain_and_close_item_events(
+                waiting_generator(), None, [], "lock-probe", None
+            )
+
+    drain = asyncio.create_task(drain_waiting_generator())
+    await asyncio.wait_for(generator_started.wait(), timeout=1)
+    drain.cancel()
+    try:
+        await drain
+    except asyncio.CancelledError:
+        pass
+    if not generator_closed.is_set():
+        raise AssertionError("Cancelled add item did not close its generator")
+
+    async def acquire_after_unwind() -> bool:
+        async with managed_data_file_lock(timeout_seconds=1):
+            return True
+
+    released_after_cancellation = await asyncio.create_task(acquire_after_unwind())
+
+    failed_generator_closed = False
+
+    async def failing_generator():
+        nonlocal failed_generator_closed
+        try:
+            yield {"started": True}
+            raise _InjectedCleanupFailure("injected add item failure")
+        finally:
+            failed_generator_closed = True
+
+    async def drain_failing_generator() -> None:
+        async with managed_data_file_lock(timeout_seconds=1):
+            await _drain_and_close_item_events(
+                failing_generator(), None, [], "lock-probe", None
+            )
+
+    try:
+        await drain_failing_generator()
+    except _InjectedCleanupFailure:
+        pass
+    else:
+        raise AssertionError("Injected add item failure was not propagated")
+    if not failed_generator_closed:
+        raise AssertionError("Failed add item did not close its generator")
+    released_after_failure = await asyncio.create_task(acquire_after_unwind())
+
+    return {
+        "sameTaskReentrant": True,
+        "childTaskTimedOut": child_timed_out,
+        "competingProcessTimedOut": process_timed_out,
+        "syntheticHolderExitCode": holder.returncode,
+        "releasedAfterProcessExit": released_after_process_exit,
+        "cancelledGeneratorClosed": True,
+        "failedGeneratorClosed": True,
+        "releasedAfterCancellation": released_after_cancellation,
+        "releasedAfterFailure": released_after_failure,
+    }
 
 
 async def _data_locations(dataset_id: str, data_id: str) -> tuple[str, str] | None:
@@ -159,30 +334,178 @@ async def _data_locations(dataset_id: str, data_id: str) -> tuple[str, str] | No
     return str(row.raw_data_location), str(row.original_data_location)
 
 
+async def _create_document(
+    api: "ProviderApi", dataset_name: str, filename: str, marker: bytes
+) -> tuple[str, str, str]:
+    dataset = await asyncio.to_thread(api.create_dataset, dataset_name)
+    dataset_id = str(dataset["id"])
+    await asyncio.to_thread(api.add, dataset_id, filename, marker)
+    digest = hashlib.sha256(marker).hexdigest()
+    data_id = await asyncio.to_thread(_only_member_id, api, dataset_id, digest)
+    return dataset_id, data_id, digest
+
+
+async def _require_document_absent(
+    api: "ProviderApi", dataset_id: str, data_id: str
+) -> None:
+    members = await asyncio.to_thread(api.list_data, dataset_id)
+    if any(member.get("id") == data_id for member in members):
+        raise AssertionError("Concurrent deletion retained a Data row")
+    await asyncio.to_thread(api.assert_raw_absent, dataset_id, data_id)
+
+
+async def _shared_location_concurrency_probes(
+    api: "ProviderApi", namespace: str
+) -> dict[str, Any]:
+    """Prove shared files survive either serialized add/delete order."""
+
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.infrastructure.locks import managed_data_file_lock
+
+    data_root = Path(os.environ["DATA_ROOT_DIRECTORY"])
+    marker = f"opencrane shared delete marker {uuid.uuid4().hex}\n".encode("utf-8")
+    first = await _create_document(
+        api, f"opencrane-delete-delete-a-{namespace}-{uuid.uuid4().hex}", "shared.txt", marker
+    )
+    second = await _create_document(
+        api, f"opencrane-delete-delete-b-{namespace}-{uuid.uuid4().hex}", "shared.txt", marker
+    )
+    first_locations = await _data_locations(first[0], first[1])
+    second_locations = await _data_locations(second[0], second[1])
+    if first_locations is None or second_locations is None:
+        raise AssertionError("Delete/delete qualification lost a prepared Data row")
+    if first_locations[1] != second_locations[1]:
+        raise AssertionError("Identical uploads did not share the original-data location")
+    shared_path = _require_owned_path(_local_file_path(first_locations[1]), data_root)
+    await asyncio.gather(
+        asyncio.to_thread(api.delete, first[0], first[1]),
+        asyncio.to_thread(api.delete, second[0], second[1]),
+    )
+    await _require_document_absent(api, first[0], first[1])
+    await _require_document_absent(api, second[0], second[1])
+    if shared_path.exists():
+        raise AssertionError("Concurrent last-reference deletes orphaned the shared file")
+
+    delete_first_marker = (
+        f"opencrane delete-first add marker {uuid.uuid4().hex}\n"
+    ).encode("utf-8")
+    delete_first_source = await _create_document(
+        api,
+        f"opencrane-delete-first-source-{namespace}-{uuid.uuid4().hex}",
+        "shared.txt",
+        delete_first_marker,
+    )
+    delete_first_target = str(
+        (await asyncio.to_thread(
+            api.create_dataset,
+            f"opencrane-delete-first-target-{namespace}-{uuid.uuid4().hex}",
+        ))["id"]
+    )
+    async with managed_data_file_lock(timeout_seconds=1):
+        add_task = asyncio.create_task(
+            asyncio.to_thread(
+                api.add,
+                delete_first_target,
+                "shared.txt",
+                delete_first_marker,
+            )
+        )
+        await asyncio.sleep(0.1)
+        if add_task.done():
+            raise AssertionError("Add pipeline bypassed the managed-file lock")
+        await get_relational_engine().delete_data_entity(
+            uuid.UUID(delete_first_source[1]), uuid.UUID(delete_first_source[0])
+        )
+    await add_task
+    await _require_document_absent(api, delete_first_source[0], delete_first_source[1])
+    delete_first_target_id = await asyncio.to_thread(
+        _only_member_id,
+        api,
+        delete_first_target,
+        hashlib.sha256(delete_first_marker).hexdigest(),
+    )
+    target_locations = await _data_locations(delete_first_target, delete_first_target_id)
+    if target_locations is None:
+        raise AssertionError("Delete-first ordering did not commit the waiting add")
+    target_original = _require_owned_path(
+        _local_file_path(target_locations[1]), data_root
+    )
+    if not target_original.is_file():
+        raise AssertionError("Delete-first ordering committed a row without its original file")
+    if _sha256(target_original) != hashlib.sha256(delete_first_marker).hexdigest():
+        raise AssertionError("Delete-first ordering changed the committed original file")
+
+    add_first_marker = f"opencrane add-first marker {uuid.uuid4().hex}\n".encode("utf-8")
+    add_first_source = await _create_document(
+        api,
+        f"opencrane-add-first-source-{namespace}-{uuid.uuid4().hex}",
+        "shared.txt",
+        add_first_marker,
+    )
+    add_first_target = await _create_document(
+        api,
+        f"opencrane-add-first-target-{namespace}-{uuid.uuid4().hex}",
+        "shared.txt",
+        add_first_marker,
+    )
+    await asyncio.to_thread(api.delete, add_first_source[0], add_first_source[1])
+    add_first_locations = await _data_locations(add_first_target[0], add_first_target[1])
+    if add_first_locations is None:
+        raise AssertionError("Add-first ordering lost the surviving Data row")
+    add_first_original = _require_owned_path(
+        _local_file_path(add_first_locations[1]), data_root
+    )
+    if not add_first_original.is_file():
+        raise AssertionError("Add-first ordering left a committed row without its original file")
+    if _sha256(add_first_original) != hashlib.sha256(add_first_marker).hexdigest():
+        raise AssertionError("Add-first ordering changed the committed original file")
+
+    await asyncio.to_thread(api.delete, delete_first_target, delete_first_target_id)
+    await asyncio.to_thread(api.delete, add_first_target[0], add_first_target[1])
+    return {
+        "contentSha256": hashlib.sha256(marker).hexdigest(),
+        "deleteDeleteSerialized": True,
+        "deleteFirstAddBlocked": True,
+        "deleteFirstCommittedSource": True,
+        "addFirstRetainedSharedSource": True,
+        "sharedFileRemovedAfterLastDelete": True,
+    }
+
+
 async def _delete_with_injected_original_cleanup_failure(
     dataset_id: str,
     data_id: str,
     original_location: str,
     adapter: Any = None,
 ) -> list[str]:
-    """Run the installed adapter and fail when its post-commit original cleanup starts."""
+    """Fail the original-file cleanup while the installed adapter still owns its row."""
 
     if adapter is None:
         from cognee.infrastructure.databases.relational import get_relational_engine
 
         adapter = get_relational_engine()
     cleanup_calls = []
-    original_cleanup = adapter.remove_data_file_if_unreferenced
+    original_cleanup = adapter._remove_data_file_if_unreferenced
 
-    async def fail_at_original(location: str | None) -> None:
+    async def fail_at_original(
+        session: Any,
+        location: str | None,
+        *,
+        excluded_data_id: uuid.UUID | None = None,
+    ) -> None:
         cleanup_calls.append(str(location))
         if str(location) == original_location:
             raise _InjectedCleanupFailure("injected original-file cleanup failure")
-        await original_cleanup(location)
+        await original_cleanup(
+            session,
+            location,
+            excluded_data_id=excluded_data_id,
+        )
 
-    had_instance_override = "remove_data_file_if_unreferenced" in adapter.__dict__
-    prior_override = adapter.__dict__.get("remove_data_file_if_unreferenced")
-    adapter.remove_data_file_if_unreferenced = fail_at_original
+    method_name = "_remove_data_file_if_unreferenced"
+    had_instance_override = method_name in adapter.__dict__
+    prior_override = adapter.__dict__.get(method_name)
+    setattr(adapter, method_name, fail_at_original)
     try:
         try:
             await adapter.delete_data_entity(uuid.UUID(data_id), uuid.UUID(dataset_id))
@@ -192,13 +515,57 @@ async def _delete_with_injected_original_cleanup_failure(
             raise AssertionError("Injected post-commit cleanup failure was not reached")
     finally:
         if had_instance_override:
-            adapter.remove_data_file_if_unreferenced = prior_override
+            setattr(adapter, method_name, prior_override)
         else:
-            del adapter.remove_data_file_if_unreferenced
+            delattr(adapter, method_name)
 
     if original_location not in cleanup_calls:
         raise AssertionError("Installed adapter did not attempt original-file cleanup")
     return cleanup_calls
+
+
+async def _delete_with_injected_commit_failure(
+    dataset_id: str,
+    data_id: str,
+    adapter: Any = None,
+) -> None:
+    """Fail the final relational commit after both managed files have been removed."""
+
+    if adapter is None:
+        from cognee.infrastructure.databases.relational import get_relational_engine
+
+        adapter = get_relational_engine()
+    original_session_factory = adapter.get_async_session
+
+    @asynccontextmanager
+    async def failing_session():
+        async with original_session_factory() as session:
+            original_commit = session.commit
+
+            async def fail_commit() -> None:
+                raise _InjectedCommitFailure("injected final relational commit failure")
+
+            session.commit = fail_commit
+            try:
+                yield session
+            finally:
+                session.commit = original_commit
+
+    had_instance_override = "get_async_session" in adapter.__dict__
+    prior_override = adapter.__dict__.get("get_async_session")
+    adapter.get_async_session = failing_session
+    try:
+        try:
+            await adapter.delete_data_entity(uuid.UUID(data_id), uuid.UUID(dataset_id))
+        except _InjectedCommitFailure:
+            pass
+        else:
+            raise AssertionError("Injected final relational commit failure was not reached")
+    finally:
+        if had_instance_override:
+            adapter.get_async_session = prior_override
+        else:
+            del adapter.get_async_session
 
 
 def _only_member_id(api: "ProviderApi", dataset_id: str, content_digest: str) -> str:
@@ -220,80 +587,128 @@ def _only_member_id(api: "ProviderApi", dataset_id: str, content_digest: str) ->
 def qualify_deletion_failure_and_path_safety(
     api: "ProviderApi", state: dict[str, Any]
 ) -> dict[str, Any]:
-    """Prepare a committed-row deletion with an intentionally failed file cleanup."""
+    """Prepare retryable file-cleanup and final-commit interruptions."""
 
     namespace = str(state.get("authorizedDatasetId", "unknown"))[:8]
-    dataset_id = str(
-        api.create_dataset(f"opencrane-delete-fault-{namespace}-{uuid.uuid4().hex}")["id"]
-    )
-    marker = (
-        f"opencrane synthetic deletion recovery marker {uuid.uuid4().hex}\n" * 4
-    ).encode("utf-8")
-    content_digest = hashlib.sha256(marker).hexdigest()
-    api.add(dataset_id, "deletion-fault.txt", marker)
-    data_id = _only_member_id(api, dataset_id, content_digest)
 
-    async def prepare() -> dict[str, Any]:
-        path_safety = await _path_safety_probes()
+    def create_document(case_name: str) -> tuple[str, str, str]:
+        dataset_id = str(
+            api.create_dataset(
+                f"opencrane-delete-{case_name}-{namespace}-{uuid.uuid4().hex}"
+            )["id"]
+        )
+        marker = (
+            f"opencrane synthetic {case_name} deletion marker {uuid.uuid4().hex}\n" * 4
+        ).encode("utf-8")
+        content_digest = hashlib.sha256(marker).hexdigest()
+        api.add(dataset_id, f"{case_name}.txt", marker)
+        return dataset_id, _only_member_id(api, dataset_id, content_digest), content_digest
+
+    cleanup_case = create_document("cleanup-failure")
+    commit_case = create_document("commit-failure")
+
+    async def prepare_case(
+        coordinates: tuple[str, str, str], failure_kind: str
+    ) -> dict[str, Any]:
+        dataset_id, data_id, content_digest = coordinates
         locations = await _data_locations(dataset_id, data_id)
         if locations is None:
             raise AssertionError("Fault fixture Data row was absent before deletion")
         raw_location, original_location = locations
         data_root = Path(os.environ["DATA_ROOT_DIRECTORY"])
+        raw_path = _require_owned_path(_local_file_path(raw_location), data_root)
         original_path = _require_owned_path(_local_file_path(original_location), data_root)
         if _sha256(original_path) != content_digest:
             raise AssertionError("Stored original bytes did not match the synthetic upload")
 
-        cleanup_calls = await _delete_with_injected_original_cleanup_failure(
-            dataset_id, data_id, original_location
-        )
-        if await _data_locations(dataset_id, data_id) is not None:
-            raise AssertionError("Injected cleanup failure rolled back the committed Data deletion")
-        if not original_path.is_file() or _sha256(original_path) != content_digest:
-            raise AssertionError("Injected cleanup failure did not retain the original bytes")
+        cleanup_calls: list[str] = []
+        if failure_kind == "originalCleanup":
+            cleanup_calls = await _delete_with_injected_original_cleanup_failure(
+                dataset_id, data_id, original_location
+            )
+            if not original_path.is_file() or _sha256(original_path) != content_digest:
+                raise AssertionError("Cleanup interruption did not retain the original bytes")
+        else:
+            await _delete_with_injected_commit_failure(dataset_id, data_id)
+            if raw_path.exists() or original_path.exists():
+                raise AssertionError("Final-commit interruption occurred before file cleanup")
 
+        if await _data_locations(dataset_id, data_id) is None:
+            raise AssertionError("Interrupted deletion lost its relational retry coordinate")
         return {
-            "pathSafety": path_safety,
-            "postCommitFailure": {
-                "datasetId": dataset_id,
-                "dataId": data_id,
-                "contentSha256": content_digest,
-                "rawDataLocation": raw_location,
-                "originalDataLocation": original_location,
-                "originalPath": str(original_path),
-                "cleanupCalls": cleanup_calls,
-                "rowPresentBefore": True,
-                "rowPresentAfter": False,
-                "originalBytesPresentAfter": True,
-                "injectedAt": "original_data_location cleanup after relational commit",
+            "datasetId": dataset_id,
+            "dataId": data_id,
+            "contentSha256": content_digest,
+            "rawDataLocation": raw_location,
+            "originalDataLocation": original_location,
+            "rawPath": str(raw_path),
+            "originalPath": str(original_path),
+            "cleanupCalls": cleanup_calls,
+            "rowPresentBefore": True,
+            "rowPresentAfter": True,
+            "rawBytesPresentAfter": raw_path.is_file(),
+            "originalBytesPresentAfter": original_path.is_file(),
+            "injectedAt": failure_kind,
+        }
+
+    async def prepare() -> dict[str, Any]:
+        return {
+            "pathSafety": await _path_safety_probes(),
+            "managedFileLock": await _lock_and_generator_probes(),
+            "sharedLocationConcurrency": await _shared_location_concurrency_probes(
+                api, namespace
+            ),
+            "interruptions": {
+                "originalCleanup": await prepare_case(cleanup_case, "originalCleanup"),
+                "finalCommit": await prepare_case(commit_case, "finalCommit"),
             },
         }
 
     evidence = asyncio.run(prepare())
-    if any(member.get("id") == data_id for member in api.list_data(dataset_id)):
-        raise AssertionError("Public dataset read still listed the committed-deleted Data row")
-    api.assert_raw_absent(dataset_id, data_id)
+    for dataset_id, data_id, _digest in (cleanup_case, commit_case):
+        if not any(member.get("id") == data_id for member in api.list_data(dataset_id)):
+            raise AssertionError("Interrupted deletion disappeared from the public dataset read")
     print("CASE installed_cleanup_path_containment PASS")
-    print("CASE post_commit_cleanup_failure_is_preserved_for_restart PASS")
+    print("CASE interrupted_cleanup_preserves_retry_coordinates PASS")
+    print("CASE interrupted_final_commit_preserves_retry_coordinates PASS")
     return evidence
 
 
 def verify_deletion_failure_after_restart(
     api: "ProviderApi", evidence: dict[str, Any]
 ) -> dict[str, Any]:
-    """Retry the same public coordinate and reject success while bytes remain."""
+    """Retry every interrupted public coordinate and require complete source removal."""
 
-    failure = evidence.get("postCommitFailure")
+    interruptions = evidence.get("interruptions")
+    if not isinstance(interruptions, dict) or set(interruptions) != {
+        "originalCleanup",
+        "finalCommit",
+    }:
+        raise AssertionError("Deletion restart evidence has invalid interruption cases")
+
+    results = {
+        name: _verify_interrupted_deletion(api, failure)
+        for name, failure in interruptions.items()
+    }
+    print("CASE interrupted_deletion_recovers_after_restart_and_retry PASS")
+    return {"outcome": "pass", "interruptions": results}
+
+
+def _verify_interrupted_deletion(
+    api: "ProviderApi", failure: Any
+) -> dict[str, Any]:
     if not isinstance(failure, dict):
-        raise AssertionError("Deletion restart evidence has no postCommitFailure object")
+        raise AssertionError("Deletion restart evidence has an invalid interruption object")
     dataset_id = failure.get("datasetId")
     data_id = failure.get("dataId")
     content_digest = failure.get("contentSha256")
+    raw_path_value = failure.get("rawPath")
     original_path_value = failure.get("originalPath")
     if not all(isinstance(value, str) and value for value in (
         dataset_id,
         data_id,
         content_digest,
+        raw_path_value,
         original_path_value,
     )):
         raise AssertionError("Deletion restart evidence has invalid coordinates")
@@ -302,28 +717,32 @@ def verify_deletion_failure_after_restart(
     uuid.UUID(data_id)
     if len(content_digest) != 64:
         raise AssertionError("Deletion restart evidence has an invalid content digest")
+    data_root = Path(os.environ["DATA_ROOT_DIRECTORY"])
+    raw_path = _require_owned_path(Path(raw_path_value), data_root, must_exist=False)
     original_path = _require_owned_path(
         Path(original_path_value),
-        Path(os.environ["DATA_ROOT_DIRECTORY"]),
+        data_root,
         must_exist=False,
     )
-    if any(member.get("id") == data_id for member in api.list_data(dataset_id)):
-        raise AssertionError("Committed-deleted Data row reappeared after provider restart")
-    api.assert_raw_absent(dataset_id, data_id)
+    if not any(member.get("id") == data_id for member in api.list_data(dataset_id)):
+        raise AssertionError("Interrupted Data row was absent after provider restart")
 
-    bytes_after_restart = original_path.is_file()
-    if original_path.exists() and not bytes_after_restart:
+    raw_after_restart = raw_path.is_file()
+    original_after_restart = original_path.is_file()
+    if raw_path.exists() and not raw_after_restart:
+        raise AssertionError("Provider raw-data location is not a regular file")
+    if original_path.exists() and not original_after_restart:
         raise AssertionError("Provider original-data location is not a regular file")
-    if bytes_after_restart and _sha256(original_path) != content_digest:
+    if original_after_restart and _sha256(original_path) != content_digest:
         raise AssertionError("Retained original bytes changed before the public retry")
 
-    retry_attempted = False
-    if bytes_after_restart:
-        retry_attempted = True
-        api.delete(dataset_id, data_id)
-        api.assert_raw_absent(dataset_id, data_id)
-    bytes_after_recovery = original_path.is_file()
-    if bytes_after_recovery and _sha256(original_path) != content_digest:
+    api.delete(dataset_id, data_id)
+    if any(member.get("id") == data_id for member in api.list_data(dataset_id)):
+        raise AssertionError("Public retry retained the interrupted Data row")
+    api.assert_raw_absent(dataset_id, data_id)
+    raw_after_recovery = raw_path.is_file()
+    original_after_recovery = original_path.is_file()
+    if original_after_recovery and _sha256(original_path) != content_digest:
         raise AssertionError("Public deletion retry changed retained bytes without removing them")
 
     result = {
@@ -331,19 +750,20 @@ def verify_deletion_failure_after_restart(
         "dataId": data_id,
         "contentSha256": content_digest,
         "originalPath": str(original_path),
-        "rowAbsentAfterRestart": True,
-        "samePublicCoordinateAccepted": retry_attempted,
-        "originalBytesPresentAfterRestart": bytes_after_restart,
-        "originalBytesPresentAfterRecovery": bytes_after_recovery,
+        "rowPresentAfterRestart": True,
+        "samePublicCoordinateAccepted": True,
+        "rawBytesPresentAfterRestart": raw_after_restart,
+        "originalBytesPresentAfterRestart": original_after_restart,
+        "rawBytesPresentAfterRecovery": raw_after_recovery,
+        "originalBytesPresentAfterRecovery": original_after_recovery,
     }
-    if bytes_after_recovery:
+    if raw_after_recovery or original_after_recovery:
         result["outcome"] = "fail"
         result["reason"] = (
             "The same public deletion coordinate was accepted after restart while the exact "
-            "provider-owned original bytes remained."
+            "provider-owned source bytes remained."
         )
         raise DeletionContractFailure(result)
 
     result["outcome"] = "pass"
-    print("CASE post_commit_cleanup_failure_recovers_after_restart_or_retry PASS")
     return result

--- a/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_deletion_contract.py
+++ b/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_deletion_contract.py
@@ -208,6 +208,7 @@ async def _lock_and_generator_probes() -> dict[str, Any]:
     holder_runner = (
         "import asyncio\n"
         "from cognee.infrastructure.locks import managed_data_file_lock\n"
+        "print('ready', flush=True)\n"
         "async def hold():\n"
         "    async with managed_data_file_lock(1):\n"
         "        print('acquired', flush=True)\n"
@@ -224,6 +225,10 @@ async def _lock_and_generator_probes() -> dict[str, Any]:
     try:
         if holder.stdout is None:
             raise AssertionError("Synthetic lock holder did not expose its output pipe")
+        # Importing the installed provider can take longer than acquiring an uncontended lock.
+        ready_signal = await asyncio.wait_for(holder.stdout.readline(), timeout=30)
+        if ready_signal != b"ready\n":
+            raise AssertionError("Synthetic child did not finish provider startup")
         acquired_signal = await asyncio.wait_for(holder.stdout.readline(), timeout=2)
         if acquired_signal != b"acquired\n":
             raise AssertionError("Synthetic child did not acquire the managed-file lock")

--- a/apps/_infra/cognee/tests/memory-contract-1.5.4.sh
+++ b/apps/_infra/cognee/tests/memory-contract-1.5.4.sh
@@ -31,6 +31,7 @@ rm -f \
   "$output_dir/source-evidence.json" \
   "$output_dir/negative-control.json" \
   "$output_dir/positive-initial.json" \
+  "$output_dir/positive-deletion-restart.json" \
   "$output_dir/positive-recovery.json" \
   "$output_dir/positive-state.json" \
   "$output_dir/negative-state.json" \
@@ -69,13 +70,17 @@ _sync_output()
 _write_failure_receipt()
 {
   local status="$1"
+  local positive_receipt="$output_dir/positive-deletion-restart.json"
+  if [[ ! -f "$positive_receipt" ]]; then
+    positive_receipt="$output_dir/positive-recovery.json"
+  fi
   python3 "$fixture_dir/evidence_summary.py" \
     --image "$image" \
     --image-inspect "$output_dir/image-inspect.json" \
     --source "$output_dir/source-evidence.json" \
     --negative "$output_dir/negative-control.json" \
     --positive-initial "$output_dir/positive-initial.json" \
-    --positive "$output_dir/positive-recovery.json" \
+    --positive "$positive_receipt" \
     --stub-log "$output_dir/stub-requests.jsonl" \
     --drop-log "$output_dir/commit-then-drop.jsonl" \
     --output "$output_dir/evidence.json" \
@@ -164,6 +169,7 @@ docker run --rm \
   --entrypoint python \
   "$image" /contract/source_evidence.py \
   --expected /candidate/expected-source-hashes.json \
+  --profile /candidate/profile.json \
   --output /contract-output/source-evidence.json \
   | tee "$output_dir/source-evidence.log"
 
@@ -287,7 +293,7 @@ docker exec "$positive" python /contract/v1_5_4/provider_contract.py \
   --mode acl-enabled \
   --namespace "$run_suffix" \
   --state /contract-output/positive-state.json \
-  --output /contract-output/positive-recovery.json \
+  --output /contract-output/positive-deletion-restart.json \
   | tee "$output_dir/deletion-restart.log"
 
 current_case="machine_readable_evidence_receipt"
@@ -298,7 +304,7 @@ python3 "$fixture_dir/evidence_summary.py" \
   --source "$output_dir/source-evidence.json" \
   --negative "$output_dir/negative-control.json" \
   --positive-initial "$output_dir/positive-initial.json" \
-  --positive "$output_dir/positive-recovery.json" \
+  --positive "$output_dir/positive-deletion-restart.json" \
   --stub-log "$output_dir/stub-requests.jsonl" \
   --drop-log "$output_dir/commit-then-drop.jsonl" \
   --output "$output_dir/evidence.json" \

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,38 @@
 # OpenCrane — Active Plan
 
+## Recover interrupted memory deletion — source reviewed, local checks passed
+
+This independent M1 slice starts directly from draft #871 at
+`749b50058f6503653d203b5a7caf98926076cf08`, on `feat/0.12-memory-delete-recovery`.
+The remote MCP connection wave remains in its separate worktree. Its personal connection UI has
+passed local tests, build and independent review; its runtime SQL acceptance remains blocked on
+the earlier specific source approval.
+
+The unpatched Cognee 1.5.4 candidate commits deletion of its Data row before deleting both stored
+files. If file cleanup fails, restart loses the information needed to finish. The candidate repair
+keeps and locks that row until cleanup succeeds, checks references across both file-location fields,
+and rejects paths outside the provider's storage root. Missing files count as completed cleanup.
+The candidate image must verify the upstream source, each patch and the resulting source bytes.
+One provider-owned local file lock covers ingestion and deletion against the same storage root and
+relational store. It prevents concurrent operations from losing a shared file or leaving it behind.
+Cancellation and process death must release the lock, and a child task cannot inherit its parent's
+ownership. The candidate remains limited to Linux, local file storage and its default SQLite store.
+
+Architecture preflight permits this candidate-only implementation. The existing image qualification
+must also prove interruption before either file removal, interruption before the final commit,
+restart using the same public document coordinate, shared-reference retention, path containment,
+and concurrent shared-file delete/delete and delete/add. The 15 focused source-verification tests
+pass: the receipt preserves official preimages, records new modules explicitly, verifies the patch
+and running source, rejects unrelated source drift, and retains machine-readable evidence when a
+repair declaration fails. The complete local Cognee test and lint run passes all 45 tests, shell syntax
+and Python compilation. Architecture preflight/post-review and independent source, build and harness
+reviews pass. All four patches were independently reconstructed and compiled against the official
+source. Style, Prisma ownership and module-growth checks have no errors. Source whitespace checks pass; the patch artifacts contain only required blank context markers. Exact-image CI still
+must run every interruption, restart and concurrency case before provider qualification is complete.
+The memory gateway gains no file paths,
+storage access or second deletion mechanism. Production image pins, charts and memory mutations
+remain unchanged. No live provider, credentials, cluster or testv5 data are touched.
+
 ## MCP readiness CI repair — 2026-09-12
 
 The first exact-head run for draft #871 found missing readiness data in existing conversation test
@@ -12,11 +45,11 @@ Linux Removing-state capture, including the corrected “No credential required�
 Validation passes all 114 application tests, application type checks, 44 real PostgreSQL application
 cases and the three SQL authority scripts. The disposable PostgreSQL database and Node test process
 both use UTC, matching CI; this prevents local time-zone offsets from changing timestamp-without-time-zone
-authority evidence. Style and Prisma ownership checks have no errors. A new exact-head CI run remains
-required for the real Kurrent recovery proof and Linux visual comparison. No testv5 or live provider
+authority evidence. Style and Prisma ownership checks have no errors. The latest read confirms that
+exact-head CI passes its selected jobs, including real Kurrent recovery and Linux visuals. No testv5 or live provider
 changes are included.
 
-## Explicit MCP connection readiness — source reviewed, CI pending
+## Explicit MCP connection readiness — source reviewed, CI passed
 
 Draft [#871](https://github.com/elewa-git/opencrane/pull/871) publishes T1 on
 `feat/0.12-mcp-credential-readiness`, based directly on memory correction
@@ -374,7 +407,7 @@ remain separate gates.
 | --- | --- | --- | --- |
 | 1 | T1 — real tool retrieval | A permitted real record reaches an answer in personal and company-child chats; remote MCP connections and hosted MCP execution have qualified journeys. Results survive reload and restart without repeated dispatch. | IN PROGRESS: company tool selection and participant terminal-result history are implemented. Explicit connection readiness and execution fencing pass source review and local database proof. Standard remote activation/discovery/calls, hosted MCP execution and real integration qualification remain. |
 | 2 | T2 — approved external actions | A person reviews an exact action and arguments; one approval permits that effect once. Denial, expiry, changed arguments and revoked authority prevent it. | IN PROGRESS: personal approval, expiry, durable resume and visible decision controls are implemented in draft #857. Company approver/connection binding and real action qualification remain. |
-| 3 | M1 — long-term memory | Explicit remember, cross-conversation recall, correction and forget work with consent and isolated datasets. | IN PROGRESS: qualify the pinned provider's isolation, identity, restart and deletion contracts on disposable CI data before implementing personal dataset provisioning and explicit Remember. |
+| 3 | M1 — long-term memory | Explicit remember, cross-conversation recall, correction and forget work with consent and isolated datasets. | IN PROGRESS: both the pinned provider and unpatched 1.5.4 candidate fail safe deletion. The candidate repair retains restart coordinates and coordinates shared-file ingestion/deletion; 45 local tests and independent review pass, with exact-image CI still required. Product Remember, recall, correction and Forget remain unimplemented. |
 | 4 | U1 — visible work controls | People can follow waiting, running and terminal work, make supported decisions and cancel eligible work after refresh. | IN PROGRESS: requester-only personal Stop and durable cleanup pass independent review and exact-head CI in draft #862; qualify the live journey. Other-participant controls remain a separate actor-policy decision. |
 | 5 | U2 — rich interaction | Durable choices, free text, structured results and A2UI remain usable and accessible after refresh. | PAUSED: runtime-question source work awaits its separate explicit approval; partial implementation is not validated delivery. Structured results and A2UI remain. |
 | 6 | F1 — documents and generated files | A scanned document can inform an answer, and a generated file remains downloadable by its authorized audience. | IN PROGRESS: Ready-file Open/Preview/Download is implemented and exact-head CI passes in #868. PDF-informed answers are source complete in #869 and exact-head CI passes, including real-store recovery and Linux visuals; live qualification remains. Generated file production follows. |

--- a/plan.md
+++ b/plan.md
@@ -33,6 +33,12 @@ The memory gateway gains no file paths,
 storage access or second deletion mechanism. Production image pins, charts and memory mutations
 remain unchanged. No live provider, credentials, cluster or testv5 data are touched.
 
+Draft #872 publishes the candidate source. Its first exact-image run (`34703119458`) stopped
+during image construction: the upstream image's non-root user could not create the repair-evidence
+directory under `/opt`. The candidate Dockerfile now uses root only to install the source repairs
+and evidence, then returns to the upstream `cognee` user before the existing extension setup.
+The runtime-user smoke assertion remains unchanged; deletion qualification still awaits CI.
+
 ## MCP readiness CI repair — 2026-09-12
 
 The first exact-head run for draft #871 found missing readiness data in existing conversation test

--- a/plan.md
+++ b/plan.md
@@ -37,7 +37,22 @@ Draft #872 publishes the candidate source. Its first exact-image run (`347031194
 during image construction: the upstream image's non-root user could not create the repair-evidence
 directory under `/opt`. The candidate Dockerfile now uses root only to install the source repairs
 and evidence, then returns to the upstream `cognee` user before the existing extension setup.
-The runtime-user smoke assertion remains unchanged; deletion qualification still awaits CI.
+The next exact-image run (`34703714519`, job `103579931845`) builds successfully, passes the
+non-root runtime smoke check and reports no source-attestation mismatches. It then stops in the
+path-safety fixture because its old adapter double cannot call the repaired provider's private
+cleanup helper. The fixture now inherits the installed adapter's helper chain and replaces only
+database construction and the reference-count query. Its seven focused tests pass, including a
+regression for that inherited call. All provider containment assertions remain required;
+deletion qualification still awaits a successful successor CI run.
+
+The candidate harness now also requires same-name dataset identity across repeated and concurrent
+creation, recovery of an unread create response through the saved name and owner, and the same
+coordinates after the existing provider restart. All 53 local Cognee tests and lint pass. These
+checks cover successful creation and response loss, not interruption between the provider's dataset
+commit and separate access grants. That partial-grant recovery gap remains a required provider
+repair before product provisioning; a lost synchronous cognify response also remains unresolved
+without correlated completion evidence. The next personal-memory source wave starts separately
+with stable gateway DTOs and gateway-only provider authentication.
 
 ## MCP readiness CI repair — 2026-09-12
 

--- a/plan.md
+++ b/plan.md
@@ -54,6 +54,15 @@ repair before product provisioning; a lost synchronous cognify response also rem
 without correlated completion evidence. The next personal-memory source wave starts separately
 with stable gateway DTOs and gateway-only provider authentication.
 
+At `36e1717bbc0bd395c474b2e1534958630f34e020`, exact-image run `34705105949`, candidate job
+`103583745894`, passes dataset identity/replay/response-loss and restart checks, scoped search,
+document identity and add recovery, and first/last-reference deletion. It then times out waiting
+two seconds for a synthetic lock-holder process to import Cognee and signal acquisition. The fixture
+now waits up to 30 seconds for an explicit post-import readiness signal, then retains the separate
+two-second acquisition deadline and termination/reacquisition assertions. This changes the process
+test's startup allowance, not the provider lock or its deadline; full interrupted-deletion and
+concurrency qualification still require a successful successor run.
+
 ## MCP readiness CI repair — 2026-09-12
 
 The first exact-head run for draft #871 found missing readiness data in existing conversation test


### PR DESCRIPTION
Cognee 1.5.4 deletes a document's database row before removing its stored files. If file cleanup fails, a restart loses the coordinate needed to finish deletion. This candidate repair keeps the row until cleanup succeeds and uses one provider-owned local file lock around ingestion and deletion, so concurrent operations preserve shared files and remove their last reference safely.

The existing candidate qualification now exercises interrupted cleanup and commit, restart through the same public document coordinate, shared-file delete/delete and both add/delete orders, and lock release after cancellation or process exit. Build and runtime receipts retain the official source preimages and separately verify each patch and resulting module. Failed declaration checks retain machine-readable diagnostic evidence. Dataset checks require the saved name, owner and UUID to survive repeated/concurrent creation, one unread creation response, and provider restart.

Stack order: #870, then #871, then this PR. The base is `feat/0.12-mcp-credential-readiness` at `749b50058f6503653d203b5a7caf98926076cf08`. This is independent of the unpublished standard remote MCP connection work.

The candidate scope is fresh Linux/amd64 LocalFileStorage, default SQLite, one shared relational store and one local volume. Production image pins, charts and memory gateway behavior are unchanged. Remember, recall, correction and Forget are still unfinished product journeys.

The image build uses root only to install the source repair and its evidence, then returns to the upstream `cognee` user before extension setup. Runtime smoke still requires that non-root identity.

Validation completed:

- Latest `npx nx run cognee:test --skipNxCache`: all 53 tests passed, including the source-evidence, path-probe and dataset-recovery harness tests. `npx nx run cognee:lint --skipNxCache` passed shell syntax and Python compilation. These are local fixture checks; they do not execute the provider image.
- Independent reconstruction and compilation from three exact official v1.5.4 preimages and one explicitly absent module matched all four declared postimages.
- Architecture preflight and provider patch post-review passed. Independent source-evidence, candidate build, qualification-harness, path-probe correction and dataset-provisioning fixture reviews passed with no remaining findings.
- Style and Prisma ownership checks passed with zero errors across 247 production TypeScript files. Module-growth reported zero production files in its scope; the candidate's provider patches received the separate architecture review above. The whitespace check passed for source and documentation; the patch artifacts contain required blank context markers and were checked through exact postimage reconstruction.
- Live PR stack integrity passed.

At `36e1717bbc0bd395c474b2e1534958630f34e020`, run `34705105949` passed source attestation, dataset creation/replay/response-loss and restart, scoped search, document identity and Add recovery, and first/last-reference deletion. It then timed out waiting two seconds for a synthetic lock-holder process to import Cognee and signal acquisition. The reviewed fixture now has a bounded 30-second post-import readiness handshake, followed by the unchanged two-second acquisition deadline and termination/reacquisition assertions. The seven focused deletion harness tests and Cognee lint/compilation pass after this correction. A successor exact-image run must still finish interrupted deletion and concurrency qualification.

Dataset response-loss evidence does not prove recovery after partial ACL grant creation. That separate provider gap and uncertain cognify completion remain required work before personal memory activation. The existing production 1.2.1 deletion failure is preserved; this candidate does not bypass the production publication gate. No local Docker, live model/tool/provider call, deployment or testv5 data change was performed. Testv5/live qualification remains a separate gate.

## Review order

#831 → #843 → #849 → #850 → #851 → #852 → #853 → #854 → #855 → #856 → #857 → #858 → #862 → #863 → #867 → #868 → #869 → #870 → #871 → #872.
