### PR TITLE
Establish private memory gateway contracts and provider sessions

### DIFF
--- a/docs/agents/app-specific.md
+++ b/docs/agents/app-specific.md
@@ -54,6 +54,7 @@ app's source.
 | [`libs/backend/server/infra/oci-registry`](../../libs/backend/server/infra/oci-registry/README.md) | Digest-checked OCI Distribution client used by image admission. |
 | [`libs/backend/server/infra/organization-membership-gateway`](../../libs/backend/server/infra/organization-membership-gateway/README.md) | HTTPS and projected-token transport to Fleet membership and billing authority. |
 | [`libs/backend/observability`](../../libs/backend/observability/README.md) | Cross-cutting structured logging and execution tracing. |
+| [`libs/backend/memory-gateway/main`](../../libs/backend/memory-gateway/main/README.md) | Private memory provider authentication and protocol handling, composed only by the memory-gateway app. |
 | [`libs/backend/conversation-computer/review-surface`](../../libs/backend/conversation-computer/review-surface/README.md) | Sandbox-local, lease-authenticated file, command, preview, and Chromium review adapters. |
 
 The durable product authority is `Conversation -> immutable KurrentDB entry stream`. An

--- a/libs/backend/README.md
+++ b/libs/backend/README.md
@@ -23,6 +23,7 @@ libs/backend/
     src/core/                 domain services and use cases
     src/__tests__/             capability tests
   server/infra/<capability>/   server runtime and external-I/O seams
+  memory-gateway/main/        private provider authentication and protocol handling
   observability/               structured logging and execution tracing
 ```
 
@@ -74,3 +75,4 @@ new source-only backend library does not need its own Dockerfile.
 - Agent capabilities: [agents](./agents/README.md)
 - Server runtime seams: [server/infra](./server/infra/README.md)
 - Telemetry: [observability](./observability/README.md)
+- Private memory provider: [memory gateway](./memory-gateway/README.md)

--- a/libs/backend/memory-gateway/README.md
+++ b/libs/backend/memory-gateway/README.md
@@ -1,0 +1,26 @@
+# Memory gateway
+
+> [backend](../README.md) › memory-gateway
+
+This group owns the private memory gateway's provider connection. Cognee stores remembered text;
+the OpenCrane server decides whose memory an operation may access.
+
+| Package | Responsibility |
+| --- | --- |
+| [main](./main/README.md) | Provider authentication, protocol translation and private request handling. |
+
+```text
+apps/memory-gateway
+        │ will compose
+        ▼
+      main ── authenticated requests ──► Cognee
+```
+
+Libraries here may use shared contracts, logging and workload identity. They do not import the
+server's personal-memory domain or own saved operations, consent or dataset selection.
+
+## See also
+
+- Parent: [backend](../README.md)
+- Deployable: [memory gateway](../../../apps/memory-gateway/README.md)
+- Server transport: [memory gateway client](../server/infra/memory-gateway-client/README.md)

--- a/libs/backend/memory-gateway/main/README.md
+++ b/libs/backend/memory-gateway/main/README.md
@@ -1,0 +1,57 @@
+# @opencrane/backend/memory-gateway — the private memory provider connection
+
+> [backend](../../README.md) › [memory-gateway](../README.md) › main
+
+## What it owns
+
+This library supplies the private memory gateway's provider connection. Its authentication client
+logs in to Cognee, holds the login token in memory and refreshes it once when the provider rejects
+an expired session. Its HTTP client bounds requests and responses and removes provider details from
+errors. Dataset/document translation and app composition remain in progress.
+
+```text
+OpenCrane server ── authenticated gateway request ──► memory-gateway app
+                                                           │ planned composition
+                                                           ▼
+                                            ┌────────────────────────┐
+                                            │ this library ◄── HERE  │
+                                            └──────────────┬─────────┘
+                                                           │ provider session
+                                                           ▼
+                                                         Cognee
+```
+
+**In this flow:** [OpenCrane](../../../../apps/opencrane/README.md) ·
+[memory-gateway app](../../../../apps/memory-gateway/README.md) ·
+[Cognee](../../../../apps/_infra/cognee/README.md).
+
+Provider credentials and login tokens stay in the gateway process. A failed or ambiguous provider
+response must remain a failure: it cannot become an empty recall or trigger an unbounded retry.
+
+## Public surface
+
+The library has no published runtime exports yet. The internal `_CreateCogneeProviderSession`
+factory supplies `ensureReady()` and `exchange()` to the future request handler. These methods use
+an injected credential reader; callers receive response bytes and status, never the login token.
+
+## Boundary
+
+The gateway app will compose this library. The server uses its separate gateway client, and receives
+no Cognee login credential. Saved operation keys, consent, retries and fact metadata stay with the
+server's personal-memory domain and existing Absurd workflow engine.
+
+Simultaneous authentication failures share one refresh, and a late failure cannot discard a newer
+session. Only a provider 401 permits one replay of the request's saved bytes. A timeout or uncertain
+response does not trigger another mutation. Optional first-install registration must be explicitly
+enabled; a rejected credential for an existing account remains a readiness failure.
+
+## Dependency direction
+
+Tagged `type:lib`, `layer:infra`, `scope:memory-gateway`. It may depend on its own scope, shared
+contracts and workload identity, and cannot import an app, frontend package or backend domain.
+
+## See also
+
+- Parent: [memory gateway](../README.md)
+- Server-side client: [memory gateway client](../../server/infra/memory-gateway-client/README.md)
+- Personal authority: [personal memory](../../agents/personal/memory/main/README.md)

--- a/libs/backend/memory-gateway/main/project.json
+++ b/libs/backend/memory-gateway/main/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "backend-memory-gateway",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/backend/memory-gateway/main/src",
+  "projectType": "library",
+  "tags": [
+    "type:lib",
+    "layer:infra",
+    "scope:memory-gateway"
+  ],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/memory-gateway/main" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/memory-gateway/main" } }
+  }
+}

--- a/libs/backend/memory-gateway/main/src/index.ts
+++ b/libs/backend/memory-gateway/main/src/index.ts
@@ -1,0 +1,2 @@
+/** Public exports for the private memory gateway's provider and request handling. */
+export {};

--- a/libs/backend/memory-gateway/main/src/provider/auth/__tests__/cognee-provider-session.test.ts
+++ b/libs/backend/memory-gateway/main/src/provider/auth/__tests__/cognee-provider-session.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CogneeProviderSessionError } from "../cognee-provider-session-error";
+import { _CreateCogneeProviderSession } from "../cognee-provider-session";
+import { CogneeProviderSessionFailureCodes, type CogneeProviderCredentialReader, type CogneeProviderSessionOptions } from "../cognee-provider-session.types";
+import type { CogneeProviderFetch } from "../../http/cognee-provider-http.types";
+
+const _EMAIL = "memory-gateway@example.com";
+const _PASSWORD = "synthetic-password";
+
+function _Credentials(): CogneeProviderCredentialReader
+{
+	return { async read() { return { email: _EMAIL, password: _PASSWORD }; } };
+}
+
+function _Options(fetch: CogneeProviderFetch, changes: Partial<CogneeProviderSessionOptions> = {}): CogneeProviderSessionOptions
+{
+	return {
+		baseUrl: "http://cognee:8000",
+		credentialReader: _Credentials(),
+		requestTimeoutMilliseconds: 100,
+		maximumResponseBytes: 4_096,
+		allowFirstInstallRegistration: false,
+		fetch,
+		...changes,
+	};
+}
+
+function _Login(token: string): Response
+{
+	return Response.json({ access_token: token, token_type: "bearer" });
+}
+
+function _Path(input: string | URL | Request): string
+{
+	return new URL(input instanceof Request ? input.url : input).pathname;
+}
+
+function _Authorization(init: RequestInit | undefined): string | null
+{
+	return new Headers(init?.headers).get("authorization");
+}
+
+describe("Cognee provider session", function _CogneeProviderSessionTests()
+{
+	it("uses the exact form login and retains the bearer only inside the session", async function _LoginContract()
+	{
+		const requests: Array<{ path: string; init: RequestInit | undefined }> = [];
+		const fetchMock = vi.fn(async function _Fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>
+		{
+			requests.push({ path: _Path(input), init });
+			return _Login("private-bearer");
+		});
+		const session = _CreateCogneeProviderSession(_Options(fetchMock));
+
+		await Promise.all([session.ensureReady(), session.ensureReady()]);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(requests[0]?.path).toBe("/api/v1/auth/login");
+		expect(requests[0]?.init).toMatchObject({ method: "POST", redirect: "error" });
+		expect(new Headers(requests[0]?.init?.headers).get("content-type")).toBe("application/x-www-form-urlencoded");
+		expect(requests[0]?.init?.body).toBe("username=memory-gateway%40example.com&password=synthetic-password");
+		expect(_Authorization(requests[0]?.init)).toBeNull();
+		expect(session).not.toHaveProperty("bearerToken");
+	});
+
+	it("performs the enabled first-install login, registration, and second login once", async function _Registration()
+	{
+		const calls: Array<{ path: string; body: BodyInit | null | undefined }> = [];
+		const fetchMock = vi.fn(async function _Fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>
+		{
+			const path = _Path(input);
+			calls.push({ path, body: init?.body });
+			if (calls.length === 1)
+				return new Response("existing lookup absent", { status: 400 });
+			if (calls.length === 2)
+				return new Response("created", { status: 201 });
+			return _Login("registered-bearer");
+		});
+		const session = _CreateCogneeProviderSession(_Options(fetchMock, { allowFirstInstallRegistration: true }));
+
+		await session.ensureReady();
+		await session.ensureReady();
+
+		expect(calls.map(function _CallPath(call) { return call.path; })).toEqual([
+			"/api/v1/auth/login",
+			"/api/v1/auth/register",
+			"/api/v1/auth/login",
+		]);
+		expect(calls[1]?.body).toBe(JSON.stringify({ email: _EMAIL, password: _PASSWORD }));
+	});
+
+	it("does not replace an existing account or repeat registration after wrong credentials", async function _WrongPassword()
+	{
+		const paths: string[] = [];
+		const fetchMock = vi.fn(async function _Fetch(input: string | URL | Request): Promise<Response>
+		{
+			const path = _Path(input);
+			paths.push(path);
+			return new Response(path.endsWith("register") ? "provider says existing secret token-x" : "bad synthetic-password", { status: 400 });
+		});
+		const session = _CreateCogneeProviderSession(_Options(fetchMock, { allowFirstInstallRegistration: true }));
+
+		const first = await session.ensureReady().catch(function _Failure(error: unknown) { return error; });
+		const second = await session.ensureReady().catch(function _Failure(error: unknown) { return error; });
+
+		expect(paths).toEqual(["/api/v1/auth/login", "/api/v1/auth/register", "/api/v1/auth/login"]);
+		expect(first).toMatchObject({ code: CogneeProviderSessionFailureCodes.RegistrationRejected });
+		expect(second).toMatchObject({ code: CogneeProviderSessionFailureCodes.AuthenticationRejected });
+		expect(String(first)).not.toContain(_PASSWORD);
+		expect(String(first)).not.toContain("token-x");
+		expect(String(second)).not.toContain(_PASSWORD);
+	});
+
+	it("shares one refresh across concurrent HTTP 401 responses", async function _ConcurrentRefresh()
+	{
+		let loginCount = 0;
+		let oldRequests = 0;
+		let releaseOldResponses: (() => void) | undefined;
+		const oldResponsesReady = new Promise<void>(function _Wait(resolve) { releaseOldResponses = resolve; });
+		const fetchMock = vi.fn(async function _Fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>
+		{
+			if (_Path(input).endsWith("/login"))
+			{
+				loginCount += 1;
+				return _Login(loginCount === 1 ? "old-token" : "new-token");
+			}
+			if (_Authorization(init) === "Bearer old-token")
+			{
+				oldRequests += 1;
+				if (oldRequests === 2)
+					releaseOldResponses?.();
+				await oldResponsesReady;
+				return new Response("unauthorized", { status: 401 });
+			}
+			return new Response("accepted", { status: 200 });
+		});
+		const session = _CreateCogneeProviderSession(_Options(fetchMock));
+
+		const command = { method: "POST", path: "/api/v1/add", headers: { "content-type": "application/json" }, body: "same-command" };
+		const results = await Promise.all([session.exchange(command), session.exchange(command)]);
+
+		expect(loginCount).toBe(2);
+		expect(oldRequests).toBe(2);
+		expect(results.map(function _Status(response) { return response.status; })).toEqual([200, 200]);
+		const effectCalls = fetchMock.mock.calls.filter(function _Effect(call) { return _Path(call[0]) === "/api/v1/add"; });
+		expect(effectCalls).toHaveLength(4);
+		expect(effectCalls.map(function _Body(call) { return call[1]?.body; })).toEqual(["same-command", "same-command", "same-command", "same-command"]);
+	});
+
+	it("uses a newer session when an older HTTP 401 arrives late", async function _StaleUnauthorized()
+	{
+		let loginCount = 0;
+		let oldCallCount = 0;
+		let reportSlowStarted: (() => void) | undefined;
+		const slowStarted = new Promise<void>(function _Wait(resolve) { reportSlowStarted = resolve; });
+		let releaseSlow: (() => void) | undefined;
+		const slowResponse = new Promise<void>(function _Wait(resolve) { releaseSlow = resolve; });
+		const fetchMock = vi.fn(async function _Fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>
+		{
+			if (_Path(input).endsWith("/login"))
+			{
+				loginCount += 1;
+				return _Login(loginCount === 1 ? "old-token" : "new-token");
+			}
+			if (_Authorization(init) === "Bearer old-token")
+			{
+				oldCallCount += 1;
+				if (oldCallCount === 1)
+				{
+					reportSlowStarted?.();
+					await slowResponse;
+				}
+				return new Response("unauthorized", { status: 401 });
+			}
+			return new Response("accepted", { status: 200 });
+		});
+		const session = _CreateCogneeProviderSession(_Options(fetchMock));
+		await session.ensureReady();
+
+		const slow = session.exchange({ method: "GET", path: "/api/v1/datasets" });
+		await slowStarted;
+		const fast = await session.exchange({ method: "GET", path: "/api/v1/datasets" });
+		releaseSlow?.();
+		const late = await slow;
+
+		expect([fast.status, late.status]).toEqual([200, 200]);
+		expect(loginCount).toBe(2);
+	});
+
+	it("replays at most once and drops only the rejected current session", async function _OneReplay()
+	{
+		let loginCount = 0;
+		let effectCount = 0;
+		const fetchMock = vi.fn(async function _Fetch(input: string | URL | Request): Promise<Response>
+		{
+			if (_Path(input).endsWith("/login"))
+			{
+				loginCount += 1;
+				return _Login(`token-${loginCount}`);
+			}
+			effectCount += 1;
+			return new Response("unauthorized", { status: 401 });
+		});
+		const session = _CreateCogneeProviderSession(_Options(fetchMock));
+
+		await expect(session.exchange({ method: "POST", path: "/api/v1/add", body: "effect" })).rejects.toMatchObject({ code: CogneeProviderSessionFailureCodes.AuthenticationRejected });
+		expect(effectCount).toBe(2);
+		expect(loginCount).toBe(2);
+		await session.ensureReady();
+		expect(loginCount).toBe(3);
+	});
+
+	it("never replays a timed-out mutation", async function _Timeout()
+	{
+		let effectCount = 0;
+		const fetchMock = vi.fn(async function _Fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>
+		{
+			if (_Path(input).endsWith("/login"))
+				return _Login("private-token");
+			effectCount += 1;
+			return new Promise<Response>(function _UntilAbort(_resolve, reject)
+			{
+				init?.signal?.addEventListener("abort", function _Abort() { reject(init.signal?.reason); }, { once: true });
+			});
+		});
+		const session = _CreateCogneeProviderSession(_Options(fetchMock, { requestTimeoutMilliseconds: 5 }));
+
+		await expect(session.exchange({ method: "POST", path: "/api/v1/add", body: "effect" })).rejects.toMatchObject({ code: CogneeProviderSessionFailureCodes.Timeout });
+		expect(effectCount).toBe(1);
+	});
+
+	it("never replays a mutation after a network failure", async function _NetworkFailure()
+	{
+		let effectCount = 0;
+		const fetchMock = vi.fn(async function _Fetch(input: string | URL | Request): Promise<Response>
+		{
+			if (_Path(input).endsWith("/login"))
+				return _Login("private-token");
+			effectCount += 1;
+			throw new Error("provider disconnected after receiving private content");
+		});
+		const session = _CreateCogneeProviderSession(_Options(fetchMock));
+
+		const error = await session.exchange({ method: "POST", path: "/api/v1/add", body: "private content" }).catch(function _Failure(failure: unknown) { return failure; });
+
+		expect(error).toMatchObject({ code: CogneeProviderSessionFailureCodes.Network });
+		expect(String(error)).not.toContain("private content");
+		expect(effectCount).toBe(1);
+	});
+
+	it("returns a bounded non-auth response without changing its disposition", async function _Response()
+	{
+		const fetchMock = vi.fn(async function _Fetch(input: string | URL | Request): Promise<Response>
+		{
+			if (_Path(input).endsWith("/login"))
+				return _Login("private-token");
+			return new Response("not found", { status: 404, headers: { "content-type": "text/plain" } });
+		});
+		const session = _CreateCogneeProviderSession(_Options(fetchMock));
+
+		const response = await session.exchange({ method: "GET", path: "/api/v1/datasets/missing" });
+
+		expect(response).toEqual({ status: 404, contentType: "text/plain", body: new TextEncoder().encode("not found") });
+	});
+
+	it("rejects malformed login JSON and response overflow without exposing provider data", async function _LoginBounds()
+	{
+		const malformedFetch = vi.fn(async function _Malformed(): Promise<Response>
+		{
+			return Response.json({ access_token: "secret-token", token_type: "bearer", unexpected: "private" });
+		});
+		const malformed = _CreateCogneeProviderSession(_Options(malformedFetch));
+		const malformedError = await malformed.ensureReady().catch(function _Failure(error: unknown) { return error; });
+		expect(malformedError).toMatchObject({ code: CogneeProviderSessionFailureCodes.MalformedResponse });
+		expect(String(malformedError)).not.toContain("secret-token");
+		expect(String(malformedError)).not.toContain("private");
+
+		const oversizeFetch = vi.fn(async function _Oversize(): Promise<Response>
+		{
+			return new Response("secret-token", { status: 200, headers: { "content-length": "5000" } });
+		});
+		const oversize = _CreateCogneeProviderSession(_Options(oversizeFetch, { maximumResponseBytes: 10 }));
+		const oversizeError = await oversize.ensureReady().catch(function _Failure(error: unknown) { return error; });
+		expect(oversizeError).toMatchObject({ code: CogneeProviderSessionFailureCodes.ResponseTooLarge });
+		expect(String(oversizeError)).not.toContain("secret-token");
+
+		const unsafeTokenFetch = vi.fn(async function _UnsafeToken(): Promise<Response>
+		{
+			return Response.json({ access_token: "secret-token\nforwarded", token_type: "bearer" });
+		});
+		const unsafeToken = _CreateCogneeProviderSession(_Options(unsafeTokenFetch));
+		await expect(unsafeToken.ensureReady()).rejects.toMatchObject({ code: CogneeProviderSessionFailureCodes.MalformedResponse });
+	});
+
+	it("turns credential reader failures into a fixed secret-free outcome", async function _CredentialFailure()
+	{
+		const credentialReader = {
+			async read()
+			{
+				throw new Error("mounted synthetic-password could not be read");
+			},
+		};
+		const fetchMock = vi.fn(async function _Unexpected(): Promise<Response> { throw new Error("unexpected fetch"); });
+		const session = _CreateCogneeProviderSession(_Options(fetchMock, { credentialReader }));
+
+		const error = await session.ensureReady().catch(function _Failure(failure: unknown) { return failure; });
+
+		expect(error).toBeInstanceOf(CogneeProviderSessionError);
+		expect(error).toMatchObject({ code: CogneeProviderSessionFailureCodes.CredentialsUnavailable });
+		expect(String(error)).not.toContain(_PASSWORD);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects absolute paths and authentication overrides before reading credentials", async function _UnsafeRequest()
+	{
+		const read = vi.fn(async function _Read() { return { email: _EMAIL, password: _PASSWORD }; });
+		const fetchMock = vi.fn(async function _Unexpected(): Promise<Response> { throw new Error("unexpected fetch"); });
+		const session = _CreateCogneeProviderSession(_Options(fetchMock, { credentialReader: { read } }));
+
+		await expect(session.exchange({ method: "GET", path: "https://other.example/api/v1/datasets" })).rejects.toMatchObject({ code: CogneeProviderSessionFailureCodes.UnsafeRequest });
+		await expect(session.exchange({ method: "GET", path: "/api/v1/datasets", headers: { Authorization: "Bearer caller-token" } })).rejects.toMatchObject({ code: CogneeProviderSessionFailureCodes.UnsafeRequest });
+		expect(read).not.toHaveBeenCalled();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/memory-gateway/main/src/provider/auth/cognee-provider-session-error.ts
+++ b/libs/backend/memory-gateway/main/src/provider/auth/cognee-provider-session-error.ts
@@ -1,0 +1,16 @@
+import { CogneeProviderSessionFailureCodes } from "./cognee-provider-session.types";
+
+/** Secret-free provider session failure safe for readiness and operation classification. */
+export class CogneeProviderSessionError extends Error
+{
+	/** Stable category containing no provider body, credential, or bearer material. */
+	readonly code: CogneeProviderSessionFailureCodes;
+
+	/** Create one failure whose message contains only its stable category. */
+	constructor(code: CogneeProviderSessionFailureCodes)
+	{
+		super(`Cognee provider session failed: ${code}`);
+		this.name = "CogneeProviderSessionError";
+		this.code = code;
+	}
+}

--- a/libs/backend/memory-gateway/main/src/provider/auth/cognee-provider-session.ts
+++ b/libs/backend/memory-gateway/main/src/provider/auth/cognee-provider-session.ts
@@ -1,0 +1,194 @@
+import { CogneeProviderSessionError } from "./cognee-provider-session-error";
+import { CogneeProviderSessionFailureCodes } from "./cognee-provider-session.types";
+import type { CogneeProviderCredentials, CogneeProviderSession, CogneeProviderSessionOptions } from "./cognee-provider-session.types";
+import { _ParseCogneeProviderCredentials, _ParseCogneeProviderLoginResponse } from "./cognee-provider-session.validator";
+import { _CreateCogneeProviderHttpClient, _ValidateCogneeProviderHttpCommand } from "../http/cognee-provider-http";
+import type { CogneeProviderHttpClient, CogneeProviderHttpCommand, CogneeProviderHttpResponse } from "../http/cognee-provider-http.types";
+
+/** Authenticated bearer and generation retained only inside one process. */
+interface SessionState
+{
+	/** Ephemeral Cognee bearer. */
+	readonly bearerToken: string;
+	/** Monotonic local generation used to reject stale HTTP 401 observations. */
+	readonly generation: number;
+}
+
+/** Decode a bounded pinned JSON response without retaining parser details. */
+function _Json(response: CogneeProviderHttpResponse): unknown
+{
+	try
+	{
+		const text = new TextDecoder("utf-8", { fatal: true }).decode(response.body);
+		return JSON.parse(text) as unknown;
+	}
+	catch
+	{
+		throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.MalformedResponse);
+	}
+}
+
+/** Return true only for the pinned provider's credential-rejection statuses. */
+function _CredentialsRejected(status: number): boolean
+{
+	return status === 400 || status === 401;
+}
+
+/** In-process owner of Cognee login, refresh serialization, and one HTTP 401 replay. */
+class _CogneeProviderSession implements CogneeProviderSession
+{
+	/** Bounded HTTP exchange that never stores a bearer. */
+	private readonly _http: CogneeProviderHttpClient;
+	/** Last successful session, when one exists. */
+	private _current: SessionState | undefined;
+	/** Shared login operation for concurrent startup or HTTP 401 recovery. */
+	private _refresh: Promise<SessionState> | undefined;
+	/** Next local session generation. */
+	private _nextGeneration = 1;
+	/** Whether the one explicitly enabled registration attempt has been consumed. */
+	private _registrationAttempted = false;
+
+	/** Create a session around the injected credential and HTTP owners. */
+	constructor(private readonly _options: CogneeProviderSessionOptions)
+	{
+		this._http = _CreateCogneeProviderHttpClient(_options);
+	}
+
+	/** Establish a valid provider login without returning its bearer token. */
+	async ensureReady(): Promise<void>
+	{
+		await this._Session();
+	}
+
+	/** Send one request and replay only an HTTP 401 with a refreshed session. */
+	async exchange(command: CogneeProviderHttpCommand): Promise<CogneeProviderHttpResponse>
+	{
+		_ValidateCogneeProviderHttpCommand(command, new URL(this._options.baseUrl));
+		const initial = await this._Session();
+		const first = await this._http.send(command, initial.bearerToken);
+		if (first.status !== 401)
+			return first;
+
+		const refreshed = await this._RefreshAfterUnauthorized(initial);
+		const replay = await this._http.send(command, refreshed.bearerToken);
+		if (replay.status !== 401)
+			return replay;
+		this._DiscardIfCurrent(refreshed);
+		throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.AuthenticationRejected);
+	}
+
+	/** Return the active session or join the one shared login operation. */
+	private async _Session(): Promise<SessionState>
+	{
+		if (this._current !== undefined)
+			return this._current;
+		const allowRegistration = this._options.allowFirstInstallRegistration && !this._registrationAttempted;
+		return this._Refresh(allowRegistration);
+	}
+
+	/** Refresh an observed session unless the HTTP 401 belongs to an older generation. */
+	private async _RefreshAfterUnauthorized(rejected: SessionState): Promise<SessionState>
+	{
+		if (this._current !== undefined && this._current.generation !== rejected.generation)
+			return this._current;
+		this._DiscardIfCurrent(rejected);
+		return this._Refresh(false);
+	}
+
+	/** Share one login operation and publish only its complete bearer result. */
+	private async _Refresh(allowRegistration: boolean): Promise<SessionState>
+	{
+		if (this._refresh !== undefined)
+			return this._refresh;
+		const operation = this._CreateSession(allowRegistration);
+		this._refresh = operation;
+		try
+		{
+			return await operation;
+		}
+		finally
+		{
+			if (this._refresh === operation)
+				this._refresh = undefined;
+		}
+	}
+
+	/** Read credentials and complete the approved login or first-install sequence. */
+	private async _CreateSession(allowRegistration: boolean): Promise<SessionState>
+	{
+		const credentials = await this._Credentials();
+		let bearerToken: string;
+		try
+		{
+			bearerToken = await this._Login(credentials);
+		}
+		catch (error)
+		{
+			const canRegister = allowRegistration && error instanceof CogneeProviderSessionError && error.code === CogneeProviderSessionFailureCodes.AuthenticationRejected;
+			if (!canRegister)
+				throw error;
+			this._registrationAttempted = true;
+			await this._Register(credentials);
+			bearerToken = await this._Login(credentials);
+		}
+		const session = { bearerToken, generation: this._nextGeneration++ };
+		this._current = session;
+		return session;
+	}
+
+	/** Read and validate the mounted service credential without forwarding reader errors. */
+	private async _Credentials(): Promise<CogneeProviderCredentials>
+	{
+		let value: unknown;
+		try
+		{
+			value = await this._options.credentialReader.read();
+		}
+		catch
+		{
+			throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.CredentialsUnavailable);
+		}
+		const credentials = _ParseCogneeProviderCredentials(value);
+		if (credentials === null)
+			throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.CredentialsUnavailable);
+		return credentials;
+	}
+
+	/** Execute the exact pinned form login and return its ephemeral bearer. */
+	private async _Login(credentials: CogneeProviderCredentials): Promise<string>
+	{
+		const body = new URLSearchParams({ username: credentials.email, password: credentials.password }).toString();
+		const response = await this._http.send({ method: "POST", path: "/api/v1/auth/login", headers: { "content-type": "application/x-www-form-urlencoded" }, body });
+		if (response.status !== 200)
+		{
+			const code = _CredentialsRejected(response.status) ? CogneeProviderSessionFailureCodes.AuthenticationRejected : CogneeProviderSessionFailureCodes.AuthenticationUnavailable;
+			throw new CogneeProviderSessionError(code);
+		}
+		const login = _ParseCogneeProviderLoginResponse(_Json(response));
+		if (login === null)
+			throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.MalformedResponse);
+		return login.accessToken;
+	}
+
+	/** Execute the one explicitly enabled first-install JSON registration. */
+	private async _Register(credentials: CogneeProviderCredentials): Promise<void>
+	{
+		const body = JSON.stringify({ email: credentials.email, password: credentials.password });
+		const response = await this._http.send({ method: "POST", path: "/api/v1/auth/register", headers: { "content-type": "application/json" }, body });
+		if (response.status !== 201)
+			throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.RegistrationRejected);
+	}
+
+	/** Clear a rejected bearer only when it is still the current generation. */
+	private _DiscardIfCurrent(rejected: SessionState): void
+	{
+		if (this._current?.generation === rejected.generation)
+			this._current = undefined;
+	}
+}
+
+/** Build the package-private session consumed by memory-gateway provider handlers. */
+export function _CreateCogneeProviderSession(options: CogneeProviderSessionOptions): CogneeProviderSession
+{
+	return new _CogneeProviderSession(options);
+}

--- a/libs/backend/memory-gateway/main/src/provider/auth/cognee-provider-session.types.ts
+++ b/libs/backend/memory-gateway/main/src/provider/auth/cognee-provider-session.types.ts
@@ -1,0 +1,81 @@
+import type { CogneeProviderFetch, CogneeProviderHttpCommand, CogneeProviderHttpResponse } from "../http/cognee-provider-http.types";
+
+/** Provider credentials read from immutable application-owned files for one login attempt. */
+export interface CogneeProviderCredentials
+{
+	/** Cognee service-user email sent only to the provider login or registration route. */
+	readonly email: string;
+	/** Cognee service-user password sent only to the provider login or registration route. */
+	readonly password: string;
+}
+
+/** Reads the mounted Cognee service credential without caching it in the session owner. */
+export interface CogneeProviderCredentialReader
+{
+	/** Read the current immutable credential for one login attempt. */
+	read(): Promise<CogneeProviderCredentials>;
+}
+
+/**
+ * Stable failure categories returned by the in-process Cognee session owner.
+ *
+ * They select readiness and request error handling inside memory-gateway. They are not provider
+ * wire values and are not persisted. Member strings may appear in secret-free logs or health
+ * diagnostics, so changing one is an internal operational contract change.
+ */
+export enum CogneeProviderSessionFailureCodes
+{
+	/** The mounted credential could not be read or did not satisfy the service-user shape. */
+	CredentialsUnavailable = "credentials_unavailable",
+	/** Cognee rejected the configured email and password; no authenticated session exists. */
+	AuthenticationRejected = "authentication_rejected",
+	/** Cognee could not complete login for a reason other than rejected credentials. */
+	AuthenticationUnavailable = "authentication_unavailable",
+	/** Explicit first-install registration did not create the configured service user. */
+	RegistrationRejected = "registration_rejected",
+	/** Cognee returned a login response outside the pinned 1.5.4 JSON contract. */
+	MalformedResponse = "malformed_response",
+	/** A provider response exceeded the configured in-memory response limit. */
+	ResponseTooLarge = "response_too_large",
+	/** The complete provider exchange exceeded its configured time limit. */
+	Timeout = "timeout",
+	/** The caller cancelled the provider exchange before completion. */
+	Aborted = "aborted",
+	/** The provider exchange failed without an HTTP response. */
+	Network = "network",
+	/** A request tried to escape the configured origin or override session authentication. */
+	UnsafeRequest = "unsafe_request",
+}
+
+/** Construction values for one in-process Cognee provider session. */
+export interface CogneeProviderSessionOptions
+{
+	/** Provider origin used for all login, registration, and authenticated exchanges. */
+	readonly baseUrl: string;
+	/** Reads the mounted credential for each login attempt. */
+	readonly credentialReader: CogneeProviderCredentialReader;
+	/** Per-exchange timeout covering response-body consumption. */
+	readonly requestTimeoutMilliseconds: number;
+	/** Maximum bytes accepted from any provider response. */
+	readonly maximumResponseBytes: number;
+	/** Enables one login-then-register-then-login attempt before the first session is created. */
+	readonly allowFirstInstallRegistration: boolean;
+	/** Optional fetch replacement used by focused tests. */
+	readonly fetch?: CogneeProviderFetch;
+}
+
+/** Private authenticated Cognee exchange; it never returns credentials or bearer tokens. */
+export interface CogneeProviderSession
+{
+	/** Establish a valid provider login without returning its bearer token. */
+	ensureReady(): Promise<void>;
+	/** Send one bounded request and replay it at most once after an HTTP 401. */
+	exchange(command: CogneeProviderHttpCommand): Promise<CogneeProviderHttpResponse>;
+}
+
+/** Pinned Cognee 1.5.4 login response decoded only inside the session owner. */
+export interface CogneeProviderLoginResponse
+{
+	/** Ephemeral bearer retained only by the session owner. */
+	readonly accessToken: string;
+}

--- a/libs/backend/memory-gateway/main/src/provider/auth/cognee-provider-session.validator.ts
+++ b/libs/backend/memory-gateway/main/src/provider/auth/cognee-provider-session.validator.ts
@@ -1,0 +1,33 @@
+import { z, type ZodType } from "zod";
+
+import type { CogneeProviderCredentials, CogneeProviderLoginResponse } from "./cognee-provider-session.types";
+
+/** Mounted credentials cross a file boundary before reaching this strict service-user model. */
+const _CredentialSchema: ZodType<CogneeProviderCredentials> = z.object({
+	email: z.string().email().max(320),
+	password: z.string().min(1).max(4_096),
+}).strict();
+
+/** Cognee login JSON is untrusted provider data and must match the pinned response exactly. */
+const _LoginResponseSchema = z.object({
+	access_token: z.string().min(1).max(65_536).regex(/^[A-Za-z0-9._~+/-]+={0,2}$/u),
+	token_type: z.literal("bearer"),
+}).strict();
+
+/** Return validated mounted credentials without exposing Zod's value-bearing errors. */
+export function _ParseCogneeProviderCredentials(value: unknown): CogneeProviderCredentials | null
+{
+	const result = _CredentialSchema.safeParse(value);
+	if (!result.success)
+		return null;
+	return result.data;
+}
+
+/** Return the ephemeral bearer from an exact pinned login response. */
+export function _ParseCogneeProviderLoginResponse(value: unknown): CogneeProviderLoginResponse | null
+{
+	const result = _LoginResponseSchema.safeParse(value);
+	if (!result.success)
+		return null;
+	return { accessToken: result.data.access_token };
+}

--- a/libs/backend/memory-gateway/main/src/provider/http/__tests__/cognee-provider-http.test.ts
+++ b/libs/backend/memory-gateway/main/src/provider/http/__tests__/cognee-provider-http.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CogneeProviderSessionFailureCodes } from "../../auth/cognee-provider-session.types";
+import { _CreateCogneeProviderHttpClient } from "../cognee-provider-http";
+import type { CogneeProviderFetch } from "../cognee-provider-http.types";
+
+function _Client(fetch: CogneeProviderFetch, maximumResponseBytes = 32, requestTimeoutMilliseconds = 100)
+{
+	return _CreateCogneeProviderHttpClient({ baseUrl: "http://cognee:8000", fetch, maximumResponseBytes, requestTimeoutMilliseconds });
+}
+
+describe("Cognee provider HTTP", function _CogneeProviderHttpTests()
+{
+	it("copies replayable bytes for each request and keeps the bearer out of the command", async function _ReplayableBytes()
+	{
+		const bodies: number[][] = [];
+		const authorizations: Array<string | null> = [];
+		const fetchMock = vi.fn(async function _Fetch(_input: string | URL | Request, init?: RequestInit): Promise<Response>
+		{
+			const body = init?.body as Uint8Array;
+			bodies.push([...body]);
+			authorizations.push(new Headers(init?.headers).get("authorization"));
+			body[0] = 99;
+			return new Response("ok");
+		});
+		const client = _Client(fetchMock);
+		const command = { method: "POST", path: "/api/v1/add", body: new Uint8Array([1, 2, 3]) };
+
+		await client.send(command, "private-token");
+		await client.send(command, "private-token");
+
+		expect(bodies).toEqual([[1, 2, 3], [1, 2, 3]]);
+		expect(authorizations).toEqual(["Bearer private-token", "Bearer private-token"]);
+		expect(command.body).toEqual(new Uint8Array([1, 2, 3]));
+	});
+
+	it("bounds a chunked response without returning partial bytes", async function _ChunkedOverflow()
+	{
+		const fetchMock = vi.fn(async function _Fetch(): Promise<Response>
+		{
+			const body = new ReadableStream<Uint8Array>({
+				start(controller)
+				{
+					controller.enqueue(new Uint8Array([1, 2, 3]));
+					controller.enqueue(new Uint8Array([4, 5, 6]));
+					controller.close();
+				},
+			});
+			return new Response(body);
+		});
+
+		await expect(_Client(fetchMock, 5).send({ method: "GET", path: "/api/v1/datasets" })).rejects.toMatchObject({ code: CogneeProviderSessionFailureCodes.ResponseTooLarge });
+	});
+
+	it("keeps the timeout active while consuming the response body", async function _BodyTimeout()
+	{
+		const fetchMock = vi.fn(async function _Fetch(): Promise<Response>
+		{
+			return new Response(new ReadableStream<Uint8Array>({ start() { return; } }));
+		});
+
+		await expect(_Client(fetchMock, 32, 5).send({ method: "GET", path: "/api/v1/datasets" })).rejects.toMatchObject({ code: CogneeProviderSessionFailureCodes.Timeout });
+	});
+
+	it("rejects unsafe origins, protocol-relative paths, and transport headers", async function _UnsafeInputs()
+	{
+		const fetchMock = vi.fn(async function _Unexpected(): Promise<Response> { throw new Error("unexpected fetch"); });
+		expect(function _CredentialsInOrigin()
+		{
+			_CreateCogneeProviderHttpClient({ baseUrl: "http://user:password@cognee:8000", fetch: fetchMock, maximumResponseBytes: 32, requestTimeoutMilliseconds: 100 });
+		}).toThrow(expect.objectContaining({ code: CogneeProviderSessionFailureCodes.UnsafeRequest }));
+		const client = _Client(fetchMock);
+		await expect(client.send({ method: "GET", path: "//other.example/api/v1/datasets" })).rejects.toMatchObject({ code: CogneeProviderSessionFailureCodes.UnsafeRequest });
+		await expect(client.send({ method: "GET", path: "/api/v1/datasets", headers: { Cookie: "private" } })).rejects.toMatchObject({ code: CogneeProviderSessionFailureCodes.UnsafeRequest });
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/memory-gateway/main/src/provider/http/cognee-provider-http.ts
+++ b/libs/backend/memory-gateway/main/src/provider/http/cognee-provider-http.ts
@@ -1,0 +1,167 @@
+import { ___DoWithoutTrace } from "@opencrane/backend/observability";
+
+import { CogneeProviderSessionError } from "../auth/cognee-provider-session-error";
+import { CogneeProviderSessionFailureCodes } from "../auth/cognee-provider-session.types";
+import type { CogneeProviderHttpClient, CogneeProviderHttpCommand, CogneeProviderHttpOptions, CogneeProviderHttpResponse } from "./cognee-provider-http.types";
+
+/** Headers that would bypass or destabilize the session-owned authenticated request. */
+const _FORBIDDEN_HEADERS = new Set(["authorization", "connection", "content-length", "cookie", "host", "proxy-authorization", "transfer-encoding"]);
+
+/** Parse a provider origin while excluding embedded credentials and path state. */
+function _ProviderOrigin(value: string): URL
+{
+	const parsed = URL.parse(value);
+	if (parsed === null || !["http:", "https:"].includes(parsed.protocol) || parsed.username !== "" || parsed.password !== "" || parsed.pathname !== "/" || parsed.search !== "" || parsed.hash !== "")
+		throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.UnsafeRequest);
+	return parsed;
+}
+
+/** Validate a request path before credential loading or network activity. */
+export function _ValidateCogneeProviderHttpCommand(command: CogneeProviderHttpCommand, origin: URL): URL
+{
+	if (!command.path.startsWith("/") || command.path.startsWith("//"))
+		throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.UnsafeRequest);
+	const target = new URL(command.path, origin);
+	if (target.origin !== origin.origin || target.hash !== "")
+		throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.UnsafeRequest);
+	for (const name of Object.keys(command.headers ?? {}))
+	{
+		if (_FORBIDDEN_HEADERS.has(name.toLowerCase()))
+			throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.UnsafeRequest);
+	}
+	return target;
+}
+
+/** Convert replayable caller bytes into a fresh fetch body for this attempt. */
+function _RequestBody(body: string | Uint8Array | undefined): BodyInit | undefined
+{
+	if (body === undefined || typeof body === "string")
+		return body;
+	return body.slice() as BodyInit;
+}
+
+/** Build request headers while mapping invalid caller values to one safe outcome. */
+function _RequestHeaders(command: CogneeProviderHttpCommand, bearerToken: string | undefined): Headers
+{
+	try
+	{
+		const headers = new Headers(command.headers);
+		if (!headers.has("accept"))
+			headers.set("accept", "application/json");
+		if (bearerToken !== undefined)
+			headers.set("authorization", `Bearer ${bearerToken}`);
+		return headers;
+	}
+	catch
+	{
+		throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.UnsafeRequest);
+	}
+}
+
+/** Classify a rejected fetch or body read without retaining the thrown value. */
+function _ThrowExchangeFailure(error: unknown, signal: AbortSignal): never
+{
+	if (error instanceof CogneeProviderSessionError)
+		throw error;
+	if (signal.aborted)
+	{
+		const reasonName = signal.reason instanceof Error ? signal.reason.name : "";
+		const code = reasonName === "TimeoutError" ? CogneeProviderSessionFailureCodes.Timeout : CogneeProviderSessionFailureCodes.Aborted;
+		throw new CogneeProviderSessionError(code);
+	}
+	throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.Network);
+}
+
+/** Consume one response while cancellation remains attached to its reader. */
+async function _ReadBoundedResponse(response: Response, maximumBytes: number, signal: AbortSignal): Promise<Uint8Array>
+{
+	const declared = response.headers.get("content-length");
+	if (declared !== null)
+	{
+		const parsed = Number(declared);
+		if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > maximumBytes)
+		{
+			if (response.body !== null)
+				await Promise.allSettled([response.body.cancel()]);
+			throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.ResponseTooLarge);
+		}
+	}
+	if (response.body === null)
+		return new Uint8Array();
+
+	const reader = response.body.getReader();
+	let aborted = signal.aborted;
+	function _AbortRead(): void
+	{
+		aborted = true;
+		void Promise.allSettled([reader.cancel()]);
+	}
+	signal.addEventListener("abort", _AbortRead, { once: true });
+	const chunks: Uint8Array[] = [];
+	let byteLength = 0;
+	try
+	{
+		while (true)
+		{
+			if (aborted)
+				signal.throwIfAborted();
+			const result = await reader.read();
+			if (aborted)
+				signal.throwIfAborted();
+			if (result.done)
+				break;
+			byteLength += result.value.byteLength;
+			if (byteLength > maximumBytes)
+			{
+				await Promise.allSettled([reader.cancel()]);
+				throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.ResponseTooLarge);
+			}
+			chunks.push(result.value);
+		}
+	}
+	finally
+	{
+		signal.removeEventListener("abort", _AbortRead);
+	}
+
+	const body = new Uint8Array(byteLength);
+	let offset = 0;
+	for (const chunk of chunks)
+	{
+		body.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return body;
+}
+
+/** Build one bounded provider HTTP client with no authentication state of its own. */
+export function _CreateCogneeProviderHttpClient(options: CogneeProviderHttpOptions): CogneeProviderHttpClient
+{
+	const origin = _ProviderOrigin(options.baseUrl);
+	if (!Number.isSafeInteger(options.requestTimeoutMilliseconds) || options.requestTimeoutMilliseconds <= 0 || !Number.isSafeInteger(options.maximumResponseBytes) || options.maximumResponseBytes <= 0)
+		throw new CogneeProviderSessionError(CogneeProviderSessionFailureCodes.UnsafeRequest);
+	const fetchRequest = options.fetch ?? fetch;
+
+	return {
+		async send(command: CogneeProviderHttpCommand, bearerToken?: string): Promise<CogneeProviderHttpResponse>
+		{
+			const target = _ValidateCogneeProviderHttpCommand(command, origin);
+			const headers = _RequestHeaders(command, bearerToken);
+			const timeoutSignal = AbortSignal.timeout(options.requestTimeoutMilliseconds);
+			const signal = command.signal === undefined ? timeoutSignal : AbortSignal.any([command.signal, timeoutSignal]);
+			try
+			{
+				return await ___DoWithoutTrace(async function _SendAndConsumeProviderResponse(): Promise<CogneeProviderHttpResponse>
+				{
+					const response = await fetchRequest(target, { method: command.method, headers, body: _RequestBody(command.body), signal, redirect: "error" });
+					const body = await _ReadBoundedResponse(response, options.maximumResponseBytes, signal);
+					return { status: response.status, contentType: response.headers.get("content-type"), body };
+				});
+			}
+			catch (error)
+			{
+				return _ThrowExchangeFailure(error, signal);
+			}
+		},
+	};
+}

--- a/libs/backend/memory-gateway/main/src/provider/http/cognee-provider-http.types.ts
+++ b/libs/backend/memory-gateway/main/src/provider/http/cognee-provider-http.types.ts
@@ -1,0 +1,48 @@
+/** Fetch shape injected into the provider HTTP owner by tests and application composition. */
+export type CogneeProviderFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+/** One replayable request to the private Cognee provider. */
+export interface CogneeProviderHttpCommand
+{
+	/** HTTP method required by the pinned Cognee route. */
+	readonly method: string;
+	/** Absolute-path reference beneath the configured provider origin. */
+	readonly path: string;
+	/** Non-authentication headers required by the pinned Cognee route. */
+	readonly headers?: Readonly<Record<string, string>>;
+	/** Replayable request bytes or text; streams are excluded because a 401 retry needs a fresh body. */
+	readonly body?: string | Uint8Array;
+	/** Optional caller cancellation combined with the provider request timeout. */
+	readonly signal?: AbortSignal;
+}
+
+/** Bounded provider response returned without exposing authentication state. */
+export interface CogneeProviderHttpResponse
+{
+	/** HTTP response status from Cognee. */
+	readonly status: number;
+	/** Declared media type, when Cognee supplied one. */
+	readonly contentType: string | null;
+	/** Complete response bytes after the HTTP owner enforces its configured ceiling. */
+	readonly body: Uint8Array;
+}
+
+/** Internal HTTP exchange used by the provider session owner. */
+export interface CogneeProviderHttpClient
+{
+	/** Validate, send, and consume one request, optionally attaching the session-owned bearer. */
+	send(command: CogneeProviderHttpCommand, bearerToken?: string): Promise<CogneeProviderHttpResponse>;
+}
+
+/** Construction values for the bounded provider HTTP exchange. */
+export interface CogneeProviderHttpOptions
+{
+	/** Provider origin with no path, credentials, query, or fragment. */
+	readonly baseUrl: string;
+	/** Maximum time for connection, response headers, and complete response consumption. */
+	readonly requestTimeoutMilliseconds: number;
+	/** Maximum response bytes retained in memory. */
+	readonly maximumResponseBytes: number;
+	/** Optional fetch replacement used by focused tests. */
+	readonly fetch?: CogneeProviderFetch;
+}

--- a/libs/backend/memory-gateway/main/tsconfig.json
+++ b/libs/backend/memory-gateway/main/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libs/backend/memory-gateway/main/vitest.config.ts
+++ b/libs/backend/memory-gateway/main/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../vitest.cache";
+
+/** Tests the private memory gateway without contacting a provider. */
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../tsconfig.vitest.json"] })] });

--- a/libs/contracts/README.md
+++ b/libs/contracts/README.md
@@ -79,6 +79,14 @@ only a finite phase; its strict validator rejects unknown phases and added field
 means no invocation in this attempt, not a failed progress read. It never authorizes a call or exposes
 a tool's identity, arguments or result.
 
+The `memory/gateway/` folder owns the private HTTP contract between the OpenCrane server and the
+memory gateway. Its eight routes cover dataset lookup, bounded document storage and recovery,
+blocking processing, passage search, and exact document deletion. Strict validators keep Cognee field
+aliases, credentials, owner records, storage locations, and provider errors outside this contract.
+Mutation errors always state whether provider delivery is known; read errors cannot carry that
+evidence. A dataset or processing receipt reports only that gateway operation and never activates a
+personal-memory dataset or adopts a fact.
+
 ## Public surface
 
 - `RunToolProgress`, `RunToolProgressPhases` and `___RunToolProgressSchema` — the safe phase shared by personal status and its activity presenter.
@@ -138,6 +146,10 @@ a tool's identity, arguments or result.
 - `MemoryFactProvenanceSourceKinds` and `ExecutionSubject` — stable memory-source vocabulary and the
   evidence-bound agent identity, principal, membership, capability, run, computer-lease, requester,
   and admission coordinates shared by run snapshots and service gates.
+- `MEMORY_GATEWAY_ROUTE_PATHS`, the `MemoryGateway*` request/response DTOs, and their
+  `___MemoryGateway*Schema` validators — the strict private server-to-gateway contract. It carries
+  only opaque dataset and document coordinates, bounded fact/query text, digests, and fixed failure
+  evidence; provider credentials and storage details never cross it.
 - `AGENT_CONTROLLER_PROJECTED_TOKEN_AUDIENCE`, `AGENT_CONTROLLER_SERVICE_ACCOUNT_NAME`, and
   `AgentControllerRunAttempt*` — the private controller handshake for claiming one authorised run,
   reporting the Kubernetes-issued Job identity, and committing that identity under the same database

--- a/libs/contracts/src/index.ts
+++ b/libs/contracts/src/index.ts
@@ -15,6 +15,8 @@ export type * from "@opencrane/models/authorization";
 export * from "./organization/cluster-tenant.types";
 export * from "./organization/group.types";
 export * from "./memory/memory.types";
+export * from "./memory/gateway/memory-gateway.types";
+export * from "./memory/gateway/memory-gateway.validator";
 export * from "./mcp/mcp-operator.types";
 export * from "./mcp/mcp-executor-identity.types";
 export * from "./model-routing/model-routing.types";

--- a/libs/contracts/src/memory/gateway/__tests__/memory-gateway.validator.test.ts
+++ b/libs/contracts/src/memory/gateway/__tests__/memory-gateway.validator.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import { MemoryMutationDeliveryStates } from "../../memory.types";
+import { MEMORY_GATEWAY_LIMITS, MEMORY_GATEWAY_ROUTE_PATHS, MemoryGatewayErrorCodes } from "../memory-gateway.types";
+import { ___MemoryGatewayDatasetCognifyRequestSchema, ___MemoryGatewayDatasetCognifyResponseSchema, ___MemoryGatewayDatasetEnsureRequestSchema, ___MemoryGatewayDatasetEnsureResponseSchema, ___MemoryGatewayDatasetListRequestSchema, ___MemoryGatewayDatasetListResponseSchema, ___MemoryGatewayDocumentAddRequestSchema, ___MemoryGatewayDocumentAddResponseSchema, ___MemoryGatewayDocumentDeleteRequestSchema, ___MemoryGatewayDocumentListRequestSchema, ___MemoryGatewayDocumentListResponseSchema, ___MemoryGatewayDocumentRawDigestRequestSchema, ___MemoryGatewayDocumentRawDigestResponseSchema, ___MemoryGatewayMutationErrorSchema, ___MemoryGatewayReadErrorSchema, ___MemoryGatewaySearchRequestSchema, ___MemoryGatewaySearchResponseSchema } from "../memory-gateway.validator";
+
+/** UUIDs used to prove that document and chunk identities remain separate. */
+const _IDS = {
+	dataset: "926bde93-cf68-4d4f-8bf5-a6e177730767",
+	document: "0f95e716-a573-465c-95e2-4cb763bfb4c2",
+	chunk: "0bbf22d8-8b88-40d8-a9ea-d162748fbf52",
+	secondDocument: "a9ea54f3-c174-44ed-b656-b1ed13308585",
+	secondChunk: "1a44c7c2-2797-4526-b0a3-806f6ce47a5d",
+} as const;
+
+/** Opaque dataset name accepted by the gateway contract. */
+const _DATASET_NAME = "a".repeat(MEMORY_GATEWAY_LIMITS.DatasetNameMinimumCharacters);
+
+/** SHA-256 value accepted by digest fields. */
+const _DIGEST = `sha256:${"a".repeat(64)}`;
+
+/** Return a valid document metadata projection. */
+function _Document(documentId: string = _IDS.document): { readonly documentId: string; readonly name: string; readonly mimeType: string }
+{
+	return { documentId, name: "fact-a.txt", mimeType: "text/plain" };
+}
+
+/** Return one valid ranked fact. */
+function _Fact(chunkId: string = _IDS.chunk, documentId: string = _IDS.document): { readonly chunkId: string; readonly documentId: string; readonly content: string }
+{
+	return { chunkId, documentId, content: "Remember the blue crane migration note." };
+}
+
+describe("memory gateway route vocabulary", function _DescribeRoutes()
+{
+	it("uses one stable OpenCrane-owned route family", function _AssertRoutes()
+	{
+		expect(MEMORY_GATEWAY_ROUTE_PATHS).toEqual({
+			DatasetEnsure: "/api/v1/memory/datasets/ensure",
+			DatasetList: "/api/v1/memory/datasets/list",
+			DocumentAdd: "/api/v1/memory/documents/add",
+			DocumentList: "/api/v1/memory/documents/list",
+			DocumentRawDigest: "/api/v1/memory/documents/raw-digest",
+			DatasetCognify: "/api/v1/memory/datasets/cognify",
+			Search: "/api/v1/memory/search",
+			DocumentDelete: "/api/v1/memory/datasets/{datasetId}/documents/{documentId}",
+		});
+	});
+});
+
+describe("memory gateway dataset contracts", function _DescribeDatasets()
+{
+	it("accepts strict ensure and list requests and responses", function _AcceptDatasetContracts()
+	{
+		expect(___MemoryGatewayDatasetEnsureRequestSchema.parse({ datasetName: _DATASET_NAME })).toEqual({ datasetName: _DATASET_NAME });
+		expect(___MemoryGatewayDatasetEnsureResponseSchema.parse({ dataset: { datasetId: _IDS.dataset, datasetName: _DATASET_NAME } })).toEqual({ dataset: { datasetId: _IDS.dataset, datasetName: _DATASET_NAME } });
+		expect(___MemoryGatewayDatasetListRequestSchema.parse({ datasetName: _DATASET_NAME })).toEqual({ datasetName: _DATASET_NAME });
+		expect(___MemoryGatewayDatasetListResponseSchema.parse({ datasets: [{ datasetId: _IDS.dataset, datasetName: _DATASET_NAME }] }).datasets).toHaveLength(1);
+	});
+
+	it("rejects readable names, provider aliases, owner fields, and multiple exact-name results", function _RejectUnsafeDatasetShapes()
+	{
+		expect(___MemoryGatewayDatasetEnsureRequestSchema.safeParse({ datasetName: "jente-personal-memory" }).success).toBe(false);
+		expect(___MemoryGatewayDatasetEnsureResponseSchema.safeParse({ dataset: { id: _IDS.dataset, name: _DATASET_NAME } }).success).toBe(false);
+		expect(___MemoryGatewayDatasetEnsureResponseSchema.safeParse({ dataset: { datasetId: _IDS.dataset, datasetName: _DATASET_NAME, ownerId: _IDS.document } }).success).toBe(false);
+		expect(___MemoryGatewayDatasetListResponseSchema.safeParse({ datasets: [{ datasetId: _IDS.dataset, datasetName: _DATASET_NAME }, { datasetId: _IDS.document, datasetName: _DATASET_NAME }] }).success).toBe(false);
+	});
+});
+
+describe("memory gateway document contracts", function _DescribeDocuments()
+{
+	it("accepts add, list, digest, cognify, and delete coordinates", function _AcceptDocumentContracts()
+	{
+		expect(___MemoryGatewayDocumentAddRequestSchema.parse({ datasetId: _IDS.dataset, content: "fact", contentDigest: _DIGEST })).toEqual({ datasetId: _IDS.dataset, content: "fact", contentDigest: _DIGEST });
+		expect(___MemoryGatewayDocumentAddResponseSchema.parse({ datasetId: _IDS.dataset, documentId: _IDS.document, contentDigest: _DIGEST })).toEqual({ datasetId: _IDS.dataset, documentId: _IDS.document, contentDigest: _DIGEST });
+		expect(___MemoryGatewayDocumentListRequestSchema.parse({ datasetId: _IDS.dataset })).toEqual({ datasetId: _IDS.dataset });
+		expect(___MemoryGatewayDocumentListResponseSchema.parse({ datasetId: _IDS.dataset, documents: [_Document()] })).toEqual({ datasetId: _IDS.dataset, documents: [_Document()] });
+		expect(___MemoryGatewayDocumentRawDigestRequestSchema.parse({ datasetId: _IDS.dataset, documentId: _IDS.document })).toEqual({ datasetId: _IDS.dataset, documentId: _IDS.document });
+		expect(___MemoryGatewayDocumentRawDigestResponseSchema.parse({ datasetId: _IDS.dataset, documentId: _IDS.document, contentDigest: _DIGEST, byteLength: 4 })).toEqual({ datasetId: _IDS.dataset, documentId: _IDS.document, contentDigest: _DIGEST, byteLength: 4 });
+		expect(___MemoryGatewayDatasetCognifyRequestSchema.parse({ datasetId: _IDS.dataset })).toEqual({ datasetId: _IDS.dataset });
+		expect(___MemoryGatewayDatasetCognifyResponseSchema.parse({ datasetId: _IDS.dataset })).toEqual({ datasetId: _IDS.dataset });
+		expect(___MemoryGatewayDocumentDeleteRequestSchema.parse({ datasetId: _IDS.dataset, documentId: _IDS.document })).toEqual({ datasetId: _IDS.dataset, documentId: _IDS.document });
+	});
+
+	it("enforces UTF-8 byte bounds instead of JavaScript character counts", function _EnforceTextBytes()
+	{
+		const maximum = "é".repeat(MEMORY_GATEWAY_LIMITS.TextMaximumBytes / 2);
+		const oversized = `${maximum}é`;
+		expect(___MemoryGatewayDocumentAddRequestSchema.safeParse({ datasetId: _IDS.dataset, content: maximum, contentDigest: _DIGEST }).success).toBe(true);
+		expect(___MemoryGatewayDocumentAddRequestSchema.safeParse({ datasetId: _IDS.dataset, content: oversized, contentDigest: _DIGEST }).success).toBe(false);
+	});
+
+	it("rejects duplicate documents, oversized lists, paths, storage fields, and raw content", function _RejectUnsafeDocumentShapes()
+	{
+		const duplicates = { datasetId: _IDS.dataset, documents: [_Document(), _Document()] };
+		const oversized = { datasetId: _IDS.dataset, documents: Array.from({ length: MEMORY_GATEWAY_LIMITS.DocumentResultsMaximum + 1 }, function _MakeDocument(_value, index) { return _Document(`${String(index).padStart(8, "0")}-0000-4000-8000-000000000000`); }) };
+		expect(___MemoryGatewayDocumentListResponseSchema.safeParse(duplicates).success).toBe(false);
+		expect(___MemoryGatewayDocumentListResponseSchema.safeParse(oversized).success).toBe(false);
+		expect(___MemoryGatewayDocumentListResponseSchema.safeParse({ datasetId: _IDS.dataset, documents: [{ ..._Document(), name: "../fact.txt" }] }).success).toBe(false);
+		expect(___MemoryGatewayDocumentListResponseSchema.safeParse({ datasetId: _IDS.dataset, documents: [{ ..._Document(), rawDataLocation: "file:///secret" }] }).success).toBe(false);
+		expect(___MemoryGatewayDocumentRawDigestResponseSchema.safeParse({ datasetId: _IDS.dataset, documentId: _IDS.document, contentDigest: _DIGEST, byteLength: 4, content: "fact" }).success).toBe(false);
+	});
+
+	it("rejects provider aliases, malformed digests, and invalid coordinates", function _RejectDocumentAliases()
+	{
+		expect(___MemoryGatewayDocumentAddRequestSchema.safeParse({ dataset_id: _IDS.dataset, content: "fact", content_digest: _DIGEST }).success).toBe(false);
+		expect(___MemoryGatewayDocumentAddResponseSchema.safeParse({ datasetId: _IDS.dataset, documentId: _IDS.document, contentDigest: `SHA256:${"a".repeat(64)}` }).success).toBe(false);
+		expect(___MemoryGatewayDocumentDeleteRequestSchema.safeParse({ datasetId: _IDS.dataset, documentId: "chunk" }).success).toBe(false);
+		expect(___MemoryGatewayDocumentDeleteRequestSchema.safeParse({ datasetId: _IDS.dataset, documentId: _IDS.dataset }).success).toBe(false);
+		expect(___MemoryGatewayDocumentRawDigestResponseSchema.safeParse({ datasetId: _IDS.dataset, documentId: _IDS.dataset, contentDigest: _DIGEST, byteLength: 4 }).success).toBe(false);
+	});
+});
+
+describe("memory gateway search contracts", function _DescribeSearch()
+{
+	it("accepts bounded queries and preserves repeated document IDs with unique chunks", function _AcceptSearchContracts()
+	{
+		const facts = [_Fact(), _Fact(_IDS.secondChunk, _IDS.document)];
+		expect(___MemoryGatewaySearchRequestSchema.parse({ datasetId: _IDS.dataset, query: "blue crane", topK: 2 })).toEqual({ datasetId: _IDS.dataset, query: "blue crane", topK: 2 });
+		expect(___MemoryGatewaySearchResponseSchema.parse({ datasetId: _IDS.dataset, facts })).toEqual({ datasetId: _IDS.dataset, facts });
+	});
+
+	it("rejects blank or oversized queries and result overflow", function _RejectSearchBounds()
+	{
+		const oversizedQuery = "é".repeat((MEMORY_GATEWAY_LIMITS.QueryMaximumBytes / 2) + 1);
+		const oversizedFacts = Array.from({ length: MEMORY_GATEWAY_LIMITS.SearchResultsMaximum + 1 }, function _MakeFact(_value, index) { return _Fact(`${String(index).padStart(8, "0")}-0000-4000-8000-000000000000`, _IDS.secondDocument); });
+		expect(___MemoryGatewaySearchRequestSchema.safeParse({ datasetId: _IDS.dataset, query: "  ", topK: 1 }).success).toBe(false);
+		expect(___MemoryGatewaySearchRequestSchema.safeParse({ datasetId: _IDS.dataset, query: oversizedQuery, topK: 1 }).success).toBe(false);
+		expect(___MemoryGatewaySearchRequestSchema.safeParse({ datasetId: _IDS.dataset, query: "fact", topK: MEMORY_GATEWAY_LIMITS.SearchResultsMaximum + 1 }).success).toBe(false);
+		expect(___MemoryGatewaySearchResponseSchema.safeParse({ datasetId: _IDS.dataset, facts: oversizedFacts }).success).toBe(false);
+	});
+
+	it("rejects duplicate chunks, document IDs used as chunks, and Cognee response aliases", function _RejectUnsafeSearchCoordinates()
+	{
+		expect(___MemoryGatewaySearchResponseSchema.safeParse({ datasetId: _IDS.dataset, facts: [_Fact(), _Fact(_IDS.chunk, _IDS.secondDocument)] }).success).toBe(false);
+		expect(___MemoryGatewaySearchResponseSchema.safeParse({ datasetId: _IDS.dataset, facts: [_Fact(_IDS.document, _IDS.document)] }).success).toBe(false);
+		expect(___MemoryGatewaySearchResponseSchema.safeParse({ datasetId: _IDS.dataset, facts: [_Fact(_IDS.chunk, _IDS.dataset)] }).success).toBe(false);
+		expect(___MemoryGatewaySearchResponseSchema.safeParse({ dataset_id: _IDS.dataset, search_result: [{ id: _IDS.chunk, document_id: _IDS.document, text: "fact" }] }).success).toBe(false);
+	});
+});
+
+describe("memory gateway error contracts", function _DescribeErrors()
+{
+	it("keeps reads free of delivery evidence and requires it for mutations", function _SeparateErrorEvidence()
+	{
+		expect(___MemoryGatewayReadErrorSchema.parse({ error: MemoryGatewayErrorCodes.NotFound })).toEqual({ error: MemoryGatewayErrorCodes.NotFound });
+		expect(___MemoryGatewayReadErrorSchema.safeParse({ error: MemoryGatewayErrorCodes.NotFound, deliveryState: MemoryMutationDeliveryStates.ProvenNotSent }).success).toBe(false);
+		expect(___MemoryGatewayMutationErrorSchema.parse({ error: MemoryGatewayErrorCodes.ProviderUnavailable, deliveryState: MemoryMutationDeliveryStates.Ambiguous })).toEqual({ error: MemoryGatewayErrorCodes.ProviderUnavailable, deliveryState: MemoryMutationDeliveryStates.Ambiguous });
+		expect(___MemoryGatewayMutationErrorSchema.safeParse({ error: MemoryGatewayErrorCodes.ProviderUnavailable }).success).toBe(false);
+	});
+
+	it("requires proof of no send for gateway refusals while preserving provider ambiguity", function _ValidateRefusalDelivery()
+	{
+		for (const error of [MemoryGatewayErrorCodes.InvalidRequest, MemoryGatewayErrorCodes.Unauthorized])
+		{
+			expect(___MemoryGatewayMutationErrorSchema.safeParse({ error, deliveryState: MemoryMutationDeliveryStates.ProvenNotSent }).success).toBe(true);
+			expect(___MemoryGatewayMutationErrorSchema.safeParse({ error, deliveryState: MemoryMutationDeliveryStates.Ambiguous }).success).toBe(false);
+		}
+		for (const deliveryState of Object.values(MemoryMutationDeliveryStates))
+		{
+			expect(___MemoryGatewayMutationErrorSchema.safeParse({ error: MemoryGatewayErrorCodes.NotFound, deliveryState }).success).toBe(true);
+		}
+	});
+
+	it("rejects provider messages and unknown failure categories", function _RejectProviderErrorData()
+	{
+		expect(___MemoryGatewayReadErrorSchema.safeParse({ error: "upstream_timeout", detail: "provider body" }).success).toBe(false);
+		expect(___MemoryGatewayMutationErrorSchema.safeParse({ error: MemoryGatewayErrorCodes.Conflict, deliveryState: "maybe", content: "fact" }).success).toBe(false);
+	});
+});

--- a/libs/contracts/src/memory/gateway/memory-gateway.types.ts
+++ b/libs/contracts/src/memory/gateway/memory-gateway.types.ts
@@ -1,0 +1,226 @@
+import type { MemoryMutationDeliveryStates } from "../memory.types";
+
+/** Stable route paths used only between the OpenCrane server and the private memory gateway. */
+export const MEMORY_GATEWAY_ROUTE_PATHS = {
+	DatasetEnsure: "/api/v1/memory/datasets/ensure",
+	DatasetList: "/api/v1/memory/datasets/list",
+	DocumentAdd: "/api/v1/memory/documents/add",
+	DocumentList: "/api/v1/memory/documents/list",
+	DocumentRawDigest: "/api/v1/memory/documents/raw-digest",
+	DatasetCognify: "/api/v1/memory/datasets/cognify",
+	Search: "/api/v1/memory/search",
+	DocumentDelete: "/api/v1/memory/datasets/{datasetId}/documents/{documentId}",
+} as const;
+
+/** Shared limits enforced by both ends of the private memory-gateway connection. */
+export const MEMORY_GATEWAY_LIMITS = {
+	DatasetNameMinimumCharacters: 43,
+	DatasetNameMaximumCharacters: 128,
+	DocumentNameMaximumCharacters: 255,
+	MimeTypeMaximumCharacters: 255,
+	TextMaximumBytes: 65_536,
+	QueryMaximumBytes: 4_096,
+	DatasetResultsMaximum: 1,
+	DocumentResultsMaximum: 1_000,
+	SearchResultsMaximum: 20,
+} as const;
+
+/**
+ * Stable failure codes returned by the private memory gateway.
+ *
+ * These values cross the internal HTTP boundary. Renaming a member or serialized value breaks the
+ * OpenCrane server client. They disclose only the failure class and never provider response text.
+ */
+export enum MemoryGatewayErrorCodes
+{
+	/** The request did not satisfy the stable gateway contract and no provider action is allowed. */
+	InvalidRequest = "invalid_request",
+	/** The calling workload did not prove the one server identity accepted by the gateway. */
+	Unauthorized = "unauthorized",
+	/** The requested dataset or document is absent; this alone says nothing about earlier delivery. */
+	NotFound = "not_found",
+	/** Provider evidence conflicts with the requested identity, digest, or unique result. */
+	Conflict = "conflict",
+	/** The provider or its authenticated session is unavailable, so the operation did not complete. */
+	ProviderUnavailable = "provider_unavailable",
+	/** The provider returned a shape or coordinate that the pinned adapter cannot interpret safely. */
+	ProviderProtocol = "provider_protocol",
+}
+
+/** One provider dataset identity projected through the stable gateway contract. */
+export interface MemoryGatewayDataset
+{
+	/** Provider UUID used for every later read or mutation. */
+	readonly datasetId: string;
+	/** Opaque name saved by OpenCrane before dataset provisioning starts. */
+	readonly datasetName: string;
+}
+
+/** Request to ensure the one dataset identified by an already saved opaque name. */
+export interface MemoryGatewayDatasetEnsureRequest
+{
+	/** Opaque pre-saved dataset name; it contains no user or fact text. */
+	readonly datasetName: string;
+}
+
+/** Provider identity observed after a dataset ensure call completes. */
+export interface MemoryGatewayDatasetEnsureResponse
+{
+	/** Dataset returned by the provider adapter. This receipt alone does not activate local memory. */
+	readonly dataset: MemoryGatewayDataset;
+}
+
+/** Request to list datasets matching one already saved opaque name. */
+export interface MemoryGatewayDatasetListRequest
+{
+	/** Exact opaque dataset name used to filter the provider response. */
+	readonly datasetName: string;
+}
+
+/** Zero or one dataset matching an exact opaque name. */
+export interface MemoryGatewayDatasetListResponse
+{
+	/** Matching datasets; more than one is a conflict and cannot be represented here. */
+	readonly datasets: readonly MemoryGatewayDataset[];
+}
+
+/** Safe metadata for one document listed inside an admitted dataset. */
+export interface MemoryGatewayDocument
+{
+	/** Provider Data UUID used with its containing dataset for raw reads and deletion. */
+	readonly documentId: string;
+	/** Provider document name after unsafe path and control characters are rejected. */
+	readonly name: string;
+	/** Media type reported for this document. */
+	readonly mimeType: string;
+}
+
+/** Request to add one bounded text document to an exact dataset. */
+export interface MemoryGatewayDocumentAddRequest
+{
+	/** Provider dataset UUID selected by OpenCrane authority. */
+	readonly datasetId: string;
+	/** Complete UTF-8 fact text sent only to the private gateway. */
+	readonly content: string;
+	/** SHA-256 digest of the complete UTF-8 content. */
+	readonly contentDigest: string;
+}
+
+/** Full identity evidence returned after an added document is recovered by digest. */
+export interface MemoryGatewayDocumentAddResponse
+{
+	/** Provider dataset UUID in which the document was verified. */
+	readonly datasetId: string;
+	/** Provider Data UUID recovered from dataset membership and complete raw bytes. */
+	readonly documentId: string;
+	/** SHA-256 digest recalculated from the complete provider raw bytes. */
+	readonly contentDigest: string;
+}
+
+/** Request to list the documents in one exact dataset. */
+export interface MemoryGatewayDocumentListRequest
+{
+	/** Provider dataset UUID selected by OpenCrane authority. */
+	readonly datasetId: string;
+}
+
+/** Bounded document metadata for one exact dataset. */
+export interface MemoryGatewayDocumentListResponse
+{
+	/** Dataset UUID whose membership was read. */
+	readonly datasetId: string;
+	/** Documents with unique identities; content and storage locations never appear here. */
+	readonly documents: readonly MemoryGatewayDocument[];
+}
+
+/** Request to hash the complete raw bytes of one exact dataset document. */
+export interface MemoryGatewayDocumentRawDigestRequest
+{
+	/** Provider dataset UUID selected by OpenCrane authority. */
+	readonly datasetId: string;
+	/** Provider Data UUID whose raw bytes must belong to the selected dataset. */
+	readonly documentId: string;
+}
+
+/** Metadata-only evidence calculated from one raw provider document. */
+export interface MemoryGatewayDocumentRawDigestResponse
+{
+	/** Provider dataset UUID against which membership was checked. */
+	readonly datasetId: string;
+	/** Provider Data UUID whose complete raw bytes were hashed. */
+	readonly documentId: string;
+	/** SHA-256 digest calculated from the complete raw bytes. */
+	readonly contentDigest: string;
+	/** Number of raw bytes included in the digest. */
+	readonly byteLength: number;
+}
+
+/** Request to run blocking graph and vector processing for one dataset. */
+export interface MemoryGatewayDatasetCognifyRequest
+{
+	/** Provider dataset UUID selected by OpenCrane authority. */
+	readonly datasetId: string;
+}
+
+/** Transport receipt for one immediately completed blocking cognify call. */
+export interface MemoryGatewayDatasetCognifyResponse
+{
+	/** Provider dataset UUID processed by the completed call. This receipt grants no local activation. */
+	readonly datasetId: string;
+}
+
+/** Request to retrieve stored passages from one exact dataset. */
+export interface MemoryGatewaySearchRequest
+{
+	/** Provider dataset UUID frozen into the admitted memory scope. */
+	readonly datasetId: string;
+	/** Non-blank recall query sent only for this authorized operation. */
+	readonly query: string;
+	/** Maximum number of ranked passages the caller will accept. */
+	readonly topK: number;
+}
+
+/** One ranked passage with separate source-document and chunk identities. */
+export interface MemoryGatewaySearchFact
+{
+	/** Provider Data UUID that may later be paired with the dataset for a mutation. */
+	readonly documentId: string;
+	/** Passage UUID; it is never accepted as a document mutation target. */
+	readonly chunkId: string;
+	/** Stored passage text returned transiently to the authorized caller. */
+	readonly content: string;
+}
+
+/** Ranked passages returned for one exact dataset. */
+export interface MemoryGatewaySearchResponse
+{
+	/** Provider dataset UUID echoed only after the provider envelope matches it. */
+	readonly datasetId: string;
+	/** Ranked passages with unique chunk identities, in provider order. */
+	readonly facts: readonly MemoryGatewaySearchFact[];
+}
+
+/** Path coordinates for deleting one exact provider document. */
+export interface MemoryGatewayDocumentDeleteRequest
+{
+	/** Provider dataset UUID selected by OpenCrane authority. */
+	readonly datasetId: string;
+	/** Provider Data UUID to delete; a chunk UUID is not valid here. */
+	readonly documentId: string;
+}
+
+/** A read failure that cannot claim any mutation was attempted. */
+export interface MemoryGatewayReadError
+{
+	/** Fixed failure class that carries no provider or fact content. */
+	readonly error: MemoryGatewayErrorCodes;
+}
+
+/** A failed mutation together with whether its provider delivery is known. */
+export interface MemoryGatewayMutationError
+{
+	/** Fixed failure class that carries no provider or fact content. */
+	readonly error: MemoryGatewayErrorCodes;
+	/** Evidence the durable workflow uses to choose reconciliation or an unchanged retry. */
+	readonly deliveryState: MemoryMutationDeliveryStates;
+}

--- a/libs/contracts/src/memory/gateway/memory-gateway.validator.ts
+++ b/libs/contracts/src/memory/gateway/memory-gateway.validator.ts
@@ -1,0 +1,217 @@
+import { z } from "zod";
+
+import { MemoryMutationDeliveryStates } from "../memory.types";
+import { MEMORY_GATEWAY_LIMITS, MemoryGatewayErrorCodes } from "./memory-gateway.types";
+import type { MemoryGatewayDataset, MemoryGatewayDatasetCognifyRequest, MemoryGatewayDatasetCognifyResponse, MemoryGatewayDatasetEnsureRequest, MemoryGatewayDatasetEnsureResponse, MemoryGatewayDatasetListRequest, MemoryGatewayDatasetListResponse, MemoryGatewayDocument, MemoryGatewayDocumentAddRequest, MemoryGatewayDocumentAddResponse, MemoryGatewayDocumentDeleteRequest, MemoryGatewayDocumentListRequest, MemoryGatewayDocumentListResponse, MemoryGatewayDocumentRawDigestRequest, MemoryGatewayDocumentRawDigestResponse, MemoryGatewayMutationError, MemoryGatewayReadError, MemoryGatewaySearchFact, MemoryGatewaySearchRequest, MemoryGatewaySearchResponse } from "./memory-gateway.types";
+
+/** Encoder used to enforce byte limits without depending on Node.js Buffer. */
+const _Utf8Encoder = new TextEncoder();
+
+/** Exact lowercase SHA-256 format shared by personal-memory recovery evidence. */
+const _ContentDigestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+
+/** Opaque dataset name format that cannot carry user-readable identity. */
+const _DatasetNameSchema = z.string()
+	.min(MEMORY_GATEWAY_LIMITS.DatasetNameMinimumCharacters)
+	.max(MEMORY_GATEWAY_LIMITS.DatasetNameMaximumCharacters)
+	.regex(/^[A-Za-z0-9_-]+$/);
+
+/** Document name format that excludes paths and control characters. */
+const _DocumentNameSchema = z.string()
+	.min(1)
+	.max(MEMORY_GATEWAY_LIMITS.DocumentNameMaximumCharacters)
+	.regex(/^[^\u0000-\u001f\u007f/\\]+$/);
+
+/** Bounded media type with one type/subtype separator and no whitespace. */
+const _MimeTypeSchema = z.string()
+	.min(3)
+	.max(MEMORY_GATEWAY_LIMITS.MimeTypeMaximumCharacters)
+	.regex(/^[^\s/]+\/[^\s/]+$/);
+
+/** Return whether a string occupies a permitted number of UTF-8 bytes. */
+function _HasUtf8Bytes(value: string, minimum: number, maximum: number): boolean
+{
+	const length = _Utf8Encoder.encode(value).byteLength;
+	return length >= minimum && length <= maximum;
+}
+
+/** Return whether every selected string is unique. */
+function _HasUniqueStrings(values: readonly string[]): boolean
+{
+	return new Set(values).size === values.length;
+}
+
+/** Bounded fact text that preserves the caller's exact bytes, including whitespace. */
+const _FactContentSchema = z.string().refine(function _HasBoundedFactBytes(value): boolean
+{
+	return _HasUtf8Bytes(value, 1, MEMORY_GATEWAY_LIMITS.TextMaximumBytes);
+});
+
+/** Non-blank bounded recall query. */
+const _QuerySchema = z.string().refine(function _HasBoundedQueryBytes(value): boolean
+{
+	return value.trim().length > 0 && _HasUtf8Bytes(value, 1, MEMORY_GATEWAY_LIMITS.QueryMaximumBytes);
+});
+
+/** Strict wire schema for one projected provider dataset. */
+export const ___MemoryGatewayDatasetSchema: z.ZodType<MemoryGatewayDataset> = z.object({
+	datasetId: z.string().uuid(),
+	datasetName: _DatasetNameSchema,
+}).strict();
+
+/** Strict request schema for ensuring one saved opaque dataset name. */
+export const ___MemoryGatewayDatasetEnsureRequestSchema: z.ZodType<MemoryGatewayDatasetEnsureRequest> = z.object({
+	datasetName: _DatasetNameSchema,
+}).strict();
+
+/** Strict response schema for a dataset ensure receipt. */
+export const ___MemoryGatewayDatasetEnsureResponseSchema: z.ZodType<MemoryGatewayDatasetEnsureResponse> = z.object({
+	dataset: ___MemoryGatewayDatasetSchema,
+}).strict();
+
+/** Strict request schema for listing one saved opaque dataset name. */
+export const ___MemoryGatewayDatasetListRequestSchema: z.ZodType<MemoryGatewayDatasetListRequest> = z.object({
+	datasetName: _DatasetNameSchema,
+}).strict();
+
+/** Strict response schema for an exact-name dataset lookup. */
+export const ___MemoryGatewayDatasetListResponseSchema: z.ZodType<MemoryGatewayDatasetListResponse> = z.object({
+	datasets: z.array(___MemoryGatewayDatasetSchema)
+		.max(MEMORY_GATEWAY_LIMITS.DatasetResultsMaximum)
+		.refine(function _HasUniqueDatasetIds(datasets): boolean
+		{
+			return _HasUniqueStrings(datasets.map(dataset => dataset.datasetId));
+		}),
+}).strict();
+
+/** Strict wire schema for safe document metadata. */
+export const ___MemoryGatewayDocumentSchema: z.ZodType<MemoryGatewayDocument> = z.object({
+	documentId: z.string().uuid(),
+	name: _DocumentNameSchema,
+	mimeType: _MimeTypeSchema,
+}).strict();
+
+/** Strict request schema for adding one bounded text document. */
+export const ___MemoryGatewayDocumentAddRequestSchema: z.ZodType<MemoryGatewayDocumentAddRequest> = z.object({
+	datasetId: z.string().uuid(),
+	content: _FactContentSchema,
+	contentDigest: _ContentDigestSchema,
+}).strict();
+
+/** Strict response schema for a digest-recovered added document. */
+export const ___MemoryGatewayDocumentAddResponseSchema: z.ZodType<MemoryGatewayDocumentAddResponse> = z.object({
+	datasetId: z.string().uuid(),
+	documentId: z.string().uuid(),
+	contentDigest: _ContentDigestSchema,
+}).strict().refine(function _UsesSeparateAddedDocumentIdentity(response): boolean
+{
+	return response.datasetId !== response.documentId;
+});
+
+/** Strict request schema for listing one dataset's documents. */
+export const ___MemoryGatewayDocumentListRequestSchema: z.ZodType<MemoryGatewayDocumentListRequest> = z.object({
+	datasetId: z.string().uuid(),
+}).strict();
+
+/** Strict response schema for bounded, unique document metadata. */
+export const ___MemoryGatewayDocumentListResponseSchema: z.ZodType<MemoryGatewayDocumentListResponse> = z.object({
+	datasetId: z.string().uuid(),
+	documents: z.array(___MemoryGatewayDocumentSchema)
+		.max(MEMORY_GATEWAY_LIMITS.DocumentResultsMaximum)
+		.refine(function _HasUniqueDocumentIds(documents): boolean
+		{
+			return _HasUniqueStrings(documents.map(document => document.documentId));
+		}),
+}).strict().refine(function _UsesSeparateListedDocumentIdentities(response): boolean
+{
+	return response.documents.every(document => document.documentId !== response.datasetId);
+});
+
+/** Strict request schema for hashing one exact raw document. */
+export const ___MemoryGatewayDocumentRawDigestRequestSchema: z.ZodType<MemoryGatewayDocumentRawDigestRequest> = z.object({
+	datasetId: z.string().uuid(),
+	documentId: z.string().uuid(),
+}).strict().refine(function _UsesSeparateRawDocumentIdentity(request): boolean
+{
+	return request.datasetId !== request.documentId;
+});
+
+/** Strict metadata-only response schema for a raw document digest. */
+export const ___MemoryGatewayDocumentRawDigestResponseSchema: z.ZodType<MemoryGatewayDocumentRawDigestResponse> = z.object({
+	datasetId: z.string().uuid(),
+	documentId: z.string().uuid(),
+	contentDigest: _ContentDigestSchema,
+	byteLength: z.number().int().min(0).max(MEMORY_GATEWAY_LIMITS.TextMaximumBytes),
+}).strict().refine(function _UsesSeparateRawDigestIdentity(response): boolean
+{
+	return response.datasetId !== response.documentId;
+});
+
+/** Strict request schema for blocking dataset processing. */
+export const ___MemoryGatewayDatasetCognifyRequestSchema: z.ZodType<MemoryGatewayDatasetCognifyRequest> = z.object({
+	datasetId: z.string().uuid(),
+}).strict();
+
+/** Strict response schema for an immediately completed cognify call. */
+export const ___MemoryGatewayDatasetCognifyResponseSchema: z.ZodType<MemoryGatewayDatasetCognifyResponse> = z.object({
+	datasetId: z.string().uuid(),
+}).strict();
+
+/** Strict request schema for one bounded dataset search. */
+export const ___MemoryGatewaySearchRequestSchema: z.ZodType<MemoryGatewaySearchRequest> = z.object({
+	datasetId: z.string().uuid(),
+	query: _QuerySchema,
+	topK: z.number().int().min(1).max(MEMORY_GATEWAY_LIMITS.SearchResultsMaximum),
+}).strict();
+
+/** Strict wire schema for one ranked passage and its separate document coordinate. */
+export const ___MemoryGatewaySearchFactSchema: z.ZodType<MemoryGatewaySearchFact> = z.object({
+	documentId: z.string().uuid(),
+	chunkId: z.string().uuid(),
+	content: _FactContentSchema,
+}).strict().refine(function _UsesSeparateChunkIdentity(fact): boolean
+{
+	return fact.chunkId !== fact.documentId;
+});
+
+/** Strict response schema for ranked facts from one exact dataset. */
+export const ___MemoryGatewaySearchResponseSchema: z.ZodType<MemoryGatewaySearchResponse> = z.object({
+	datasetId: z.string().uuid(),
+	facts: z.array(___MemoryGatewaySearchFactSchema)
+		.max(MEMORY_GATEWAY_LIMITS.SearchResultsMaximum)
+		.refine(function _HasUniqueChunkIds(facts): boolean
+		{
+			return _HasUniqueStrings(facts.map(fact => fact.chunkId));
+		}),
+}).strict().refine(function _UsesSeparateSearchIdentities(response): boolean
+{
+	return response.facts.every(function _IsSeparateFactIdentity(fact): boolean
+	{
+		return response.datasetId !== fact.documentId && response.datasetId !== fact.chunkId;
+	});
+});
+
+/** Strict path-coordinate schema for deleting one exact document. */
+export const ___MemoryGatewayDocumentDeleteRequestSchema: z.ZodType<MemoryGatewayDocumentDeleteRequest> = z.object({
+	datasetId: z.string().uuid(),
+	documentId: z.string().uuid(),
+}).strict().refine(function _UsesSeparateDeletedDocumentIdentity(request): boolean
+{
+	return request.datasetId !== request.documentId;
+});
+
+/** Strict read-error schema that rejects mutation delivery evidence. */
+export const ___MemoryGatewayReadErrorSchema: z.ZodType<MemoryGatewayReadError> = z.object({
+	error: z.nativeEnum(MemoryGatewayErrorCodes),
+}).strict();
+
+/** Strict mutation-error schema that requires provider delivery evidence. */
+export const ___MemoryGatewayMutationErrorSchema: z.ZodType<MemoryGatewayMutationError> = z.object({
+	error: z.nativeEnum(MemoryGatewayErrorCodes),
+	deliveryState: z.nativeEnum(MemoryMutationDeliveryStates),
+}).strict().refine(function _MatchesGatewayRefusalDelivery(error): boolean
+{
+	if (error.error === MemoryGatewayErrorCodes.InvalidRequest || error.error === MemoryGatewayErrorCodes.Unauthorized)
+		return error.deliveryState === MemoryMutationDeliveryStates.ProvenNotSent;
+	return true;
+});

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,56 @@
 # OpenCrane — Active Plan
 
+## Personal memory journey — implementation started
+
+This M1 wave starts from draft #872 at `c35f6de574cd3282574d897ac428a6dd71eac3bc`
+on `feat/0.12-personal-memory-journey`. The accepted first outcome is an explicit Remember
+from an already encrypted user message, followed by separately consented recall in another
+conversation. Correct and Forget must also pass before M1 is complete.
+
+The memory adoption preflight passes for implementation. Production activation remains blocked
+until the repaired Cognee candidate passes its exact-image suite. Earlier run `34703714519`,
+candidate job `103579931845`, passed image build, non-root runtime and source attestation, then
+failed in a test adapter before deletion qualification finished. The correction is reviewed and
+pushed in #872, with all 53 local tests passing. Successor run `34705105949` passes dataset recovery,
+scoped search, document identity, Add recovery and final-reference deletion, then fails in synthetic
+process startup. The separate reviewed startup-handshake correction is now pushed at the base above.
+Source review and local tests do not substitute for completed provider qualification.
+
+The detailed protocol handoff found two further recovery boundaries. Cognee currently commits a
+dataset before its separate access grants, and an existing-name retry does not restore unfinished
+grants. Dataset activation must wait for candidate repair and interruption tests. A lost synchronous
+cognify response also lacks correlated completion evidence; it must remain RecoveryRequired until
+controlled replay or a provider status receipt is proven. Shared DTOs and provider authentication
+can be implemented independently, but neither enables memory writes.
+
+The shared gateway contract and provider authentication foundation are implemented locally. Thirteen
+contract tests and sixteen authentication/HTTP tests pass, along with both package type checks,
+dependency lint and workload ownership checks. Provider credentials and responses stay within the
+new gateway library; it has no app consumer or enabled route yet. Independent source reviews and
+architecture post-review pass with no remaining findings. The workload boundary's negative tests
+also pass, and all four module-growth candidates have been reviewed for responsibility and cohesion.
+Dataset/document adapters, the server client replacement, consent, personal workflow/catalog
+adoption and production composition remain the next implementation work.
+
+Implementation owners and dependency order:
+
+1. Settle stable gateway request/response contracts and keep provider authentication and protocol
+   handling in a dedicated library composed by `apps/memory-gateway`.
+2. Implement gateway-only provider credentials and authenticated dataset/document operations in
+   parallel with the server client. Both consume the shared contract; neither saves workflow state.
+3. Add personal dataset provisioning, metadata-only fact adoption, and active-document recall
+   filtering under the personal-memory domain. The existing Absurd engine owns operation keys,
+   retries and saved progress. PostgreSQL receives source coordinates and digests, never fact text.
+4. Bind Remember to explicit operation consent and an authorized encrypted source. Compose the
+   workflow and recall delivery through the existing conversation owners.
+5. Adopt the qualified image/authentication/storage profile, then prove Remember, restart and
+   cross-conversation recall before extending the same saved document coordinates to Correct and
+   Forget. This source wave does not authorize deployment or testv5 changes.
+
+The server keeps its audience-bound gateway token. Cognee credentials remain in the gateway, and
+the frozen personal dataset determines every recall. The gateway performs protocol translation;
+it does not gain a database, outbox, scheduler or authority to choose a person's dataset.
+
 ## Recover interrupted memory deletion — source reviewed, local checks passed
 
 This independent M1 slice starts directly from draft #871 at

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -337,6 +337,9 @@
       ],
       "@opencrane/backend/server/infra/agent-sandbox": [
         "./libs/backend/server/infra/agent-sandbox/src/index.ts"
+      ],
+      "@opencrane/backend/memory-gateway": [
+        "./libs/backend/memory-gateway/main/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
The memory gateway currently forwards unauthenticated, provider-shaped search requests. A usable personal-memory journey needs a stable server contract and a gateway-owned provider session before it can adopt Cognee's authenticated profile.

This foundation adds strict dataset/document/search and mutation-delivery contracts, plus a dedicated gateway library with bounded HTTP exchange and an in-memory Cognee 1.5.4 session. Concurrent authentication failures share one refresh; a late 401 cannot discard a newer session. Only one 401 replay is allowed, and timeouts or network failures never replay a mutation. Provider credentials, tokens and error bodies stay private to the gateway implementation.

The package is not composed into an app yet. It has no enabled route or published runtime factory. Provider adapters, the server-client replacement, credential mounts, consent, personal dataset/catalog workflows and the Remember/recall journey remain unfinished. Dataset ACL recovery and uncertain cognify completion remain required provider work; these DTOs and tests do not enable memory writes or qualify a provider image.

Stack order: PR #872, then this PR. Base: `feat/0.12-memory-delete-recovery` at `c35f6de574cd3282574d897ac428a6dd71eac3bc`.

## Validation

- Focused Nx contracts tests: 13 passed; `contracts:lint` passed after the barrel and review correction.
- Nx `backend-memory-gateway:test`: 16 passed; `backend-memory-gateway:lint` passed.
- `npm run lint:boundaries` passed.
- `npm run check:workload-ownership-app-composition` and its negative tests passed: three Helm profiles and 18 workload owners remained valid.
- Style and Prisma ownership checks passed. Module growth reported zero errors; all four candidates received a responsibility/cohesion review.
- Architecture preflight/post-review and independent contract/authentication reviews passed. Review corrected the delivery invariant for pre-dispatch gateway refusals while preserving ambiguous delivery for provider NotFound evidence.
- `git diff --check` passed. Parent source changes after review were limited to the candidate fixture and plan; reviewed foundation source hashes remained unchanged.

Application builds, exact-image provider qualification and the complete personal-memory journey remain later integration gates. Testv5/live qualification remains a separate gate. No deployment, live provider/model/tool call, credential inspection or testv5 data change was performed.

## Review order

#831 → #843 → #849 → #850 → #851 → #852 → #853 → #854 → #855 → #856 → #857 → #858 → #862 → #863 → #867 → #868 → #869 → #870 → #871 → #872 → #873.
