### PR TITLE
Recover interrupted memory indexing without redispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,10 @@ The 0.11 baseline remains under review; this is not a release or a completed MVP
 - **Operators can evaluate a proposed Cognee replacement independently of the deployed image.** The
   separate 1.5.4 qualification uses fresh disposable storage and retains evidence for image identity,
   isolation, recovery and deletion. Dataset checks retain the saved name, owner and identifier across
-  concurrent creation, a lost creation response and provider restart. Explicit candidate repairs preserve the official source hashes
+  concurrent creation, a lost creation response and provider restart. Indexing recovery checks that a
+  lost response returns the exact saved operation receipt, including after restart, while unfinished
+  work refuses repeat dispatch. The receipt binds the document content and processing inputs saved
+  before the first request. Explicit candidate repairs preserve the official source hashes
   and separately verify their patch artifacts, base image and running source. It cannot publish a
   candidate or replace the existing production provider gate. The candidate and personal memory
   journeys remain under qualification.

--- a/apps/_infra/cognee/README.md
+++ b/apps/_infra/cognee/README.md
@@ -162,12 +162,25 @@ saved coordinates again.
 
 The candidate dataset route always passes an authenticated create or same-name retry through the
 authorised-dataset owner. That owner holds Cognee's existing per-dataset lock while it ensures the
-owner's `read`, `write`, `delete` and `share` grants. A restart retry can therefore complete grants
+owner’s `read`, `write`, `delete` and `share` grants. A restart retry can therefore complete grants
 that stopped after the dataset row or any one grant. This lock is process-local: the qualification
 is limited to the candidate's one-worker, one-replica SQLite profile and does not establish safety
 for a multi-worker or shared provider. The exact candidate image must still pass the five fault
 boundaries, foreign-owner isolation, concurrent uniqueness and public list/add/search/delete proof
 before personal dataset provisioning can be activated.
+
+The candidate Cognify recovery path extends the existing dataset-data and Cognify routes. An owner
+first reads one locked, bounded input snapshot. Its digest covers the complete raw bytes and private
+routing metadata for at most 1,000 documents of at most 65,536 bytes each. The caller then supplies
+that saved digest with one operation UUID. Under the same dataset lock, a new run compares the
+current snapshot before it records Started; an exact terminal history returns its saved run receipt
+without starting another task. A Started-only or contradictory history returns a fixed recovery
+failure and remains ambiguous. The evidence contains only dataset, document, operation and run
+coordinates plus digests and byte counts; it contains no document text, file paths or credentials.
+
+This recovery authority has the same one-worker, one-replica SQLite limit as the candidate dataset
+lock. Exact-image qualification must still prove response-loss replay, concurrent replay and
+restart refusal of a Started-only run before any candidate image can be selected for production.
 
 ## See also
 

--- a/apps/_infra/cognee/tests/candidates/1.5.4/Dockerfile
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/Dockerfile
@@ -60,15 +60,6 @@ RUN package_root="$(python -c 'import cognee, pathlib; print(pathlib.Path(cognee
     --patch-sha256 7eb15e93fa0986d225ce0a3c89001f1c1b671db72c4254a690141edd4c4be312 \
     --postimage-sha256 df8872f1f864b50640f7a083e62c33d29a1c704a8f9df9918702d0b712dedc7b && \
   python /tmp/apply-cognee-source-patch.py \
-    --source "$package_root/api/v1/datasets/routers/get_datasets_router.py" \
-    --patch /opt/opencrane/cognee-repair/dataset-route-acl-recovery.patch \
-    --receipt /opt/opencrane/cognee-repair/dataset-route-acl-recovery.json \
-    --module cognee.api.v1.datasets.routers.get_datasets_router \
-    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
-    --preimage-sha256 87b3ff9da756bbf730237197cdedcd26278f27e0c17f19ae887b77c9c0ccc241 \
-    --patch-sha256 ab4abb197a4e7fa3c7d04288ca56f16dab7c4d8a42d51a0ab89c929db63ddad7 \
-    --postimage-sha256 0f6226908897c14c97c17a449f715e461201e801a8bab5832b7fd0f8766a551e && \
-  python /tmp/apply-cognee-source-patch.py \
     --source "$package_root/modules/data/methods/create_authorized_dataset.py" \
     --patch /opt/opencrane/cognee-repair/create-authorized-dataset-acl-recovery.patch \
     --receipt /opt/opencrane/cognee-repair/create-authorized-dataset-acl-recovery.json \
@@ -77,7 +68,125 @@ RUN package_root="$(python -c 'import cognee, pathlib; print(pathlib.Path(cognee
     --preimage-sha256 cbdf60978470b0cba30fdb53aae00f4b4657390ae37294bcc9d31460150a91c9 \
     --patch-sha256 0831738dec01b161c78f5198b1c9bc6307efa56eeb3fd82f8941be2d4de48690 \
     --postimage-sha256 a3e261dbf13831b044cbf190fb9ac204150c88afc771b761a259c2430fbdb26b && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/modules/pipelines/operations/cognify_input_evidence.py" \
+    --patch /opt/opencrane/cognee-repair/cognify-input-evidence.patch \
+    --receipt /opt/opencrane/cognee-repair/cognify-input-evidence.json \
+    --module cognee.modules.pipelines.operations.cognify_input_evidence \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-absent \
+    --patch-sha256 0ebf313e96d2337db333817eaef1347beea99f170a9e7ae31ed9fc0118ee0f25 \
+    --postimage-sha256 5b7df0e5db3f0c785b257b4ab88a6e13576287cb78f4da0072c41efeb81c6632 && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/modules/pipelines/operations/cognify_run_recovery.py" \
+    --patch /opt/opencrane/cognee-repair/cognify-run-recovery.patch \
+    --receipt /opt/opencrane/cognee-repair/cognify-run-recovery.json \
+    --module cognee.modules.pipelines.operations.cognify_run_recovery \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-absent \
+    --patch-sha256 5b7fe3e33ff82ee67a3872ea5faec8d2424ad69cd42d656611523f7ba13bb46f \
+    --postimage-sha256 2e1d1f6c54f668960f291fb77c8f35111b795b0144dfbc24d0388eff1c0a26c0 && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/modules/pipelines/models/PipelineRunInfo.py" \
+    --patch /opt/opencrane/cognee-repair/pipeline-run-info-recovery.patch \
+    --receipt /opt/opencrane/cognee-repair/pipeline-run-info-recovery.json \
+    --module cognee.modules.pipelines.models.PipelineRunInfo \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 bb1ff28d87db42ee084bca375f0dec64042bf66ff36834a9bd3ebc64dfec63a9 \
+    --patch-sha256 586ba9af1ff107a98f673414411ea1063681b65f744683da85049f5cbbe30826 \
+    --postimage-sha256 562793af28ef6b18ffd191c91ef2018e960f2b373f1c0f021e78ecc880fd8859 && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/modules/pipelines/utils/generate_pipeline_run_id.py" \
+    --patch /opt/opencrane/cognee-repair/generate-pipeline-run-id-recovery.patch \
+    --receipt /opt/opencrane/cognee-repair/generate-pipeline-run-id-recovery.json \
+    --module cognee.modules.pipelines.utils.generate_pipeline_run_id \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 45761dedbee9955aa20f0a247ba65a2b0c84d34a5c0c0f5db8b465c9982cfd38 \
+    --patch-sha256 fa98f93a3a001316655b4da607457e046e853f1a2e4be10af6977672911ef7ef \
+    --postimage-sha256 2b491a3895198f18797496bcff29b185431a3194ac91c62a8208632053971508 && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/modules/pipelines/operations/log_pipeline_run_start.py" \
+    --patch /opt/opencrane/cognee-repair/log_pipeline_run_start-recovery.patch \
+    --receipt /opt/opencrane/cognee-repair/log_pipeline_run_start-recovery.json \
+    --module cognee.modules.pipelines.operations.log_pipeline_run_start \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 befdec2bd7e6bc7c0f7102f05def09845529430bd98f9d24ea2da21bc5b96a8d \
+    --patch-sha256 dbad948fe5a2b47fa7c004aa426e1eb806090549d2a918725288b65e2723aa0f \
+    --postimage-sha256 848ff4b9d87d679b707c0b45967a85798914f75f3cb5bdba991a6215508556d1 && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/modules/pipelines/operations/log_pipeline_run_complete.py" \
+    --patch /opt/opencrane/cognee-repair/log_pipeline_run_complete-recovery.patch \
+    --receipt /opt/opencrane/cognee-repair/log_pipeline_run_complete-recovery.json \
+    --module cognee.modules.pipelines.operations.log_pipeline_run_complete \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 e8368f9f86569d0e0d79102846dd777f5678302a41357c0d9a81a74827f24892 \
+    --patch-sha256 355d0fe9083bdd416d51bfe7e978f247bcc91dd56a97d4e9a7eea315cde42e0f \
+    --postimage-sha256 02d8fcd96565192fd545d9004e35c86d5eb9f4dd2d64943f6c991dd1b183cc42 && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/modules/pipelines/operations/log_pipeline_run_error.py" \
+    --patch /opt/opencrane/cognee-repair/log_pipeline_run_error-recovery.patch \
+    --receipt /opt/opencrane/cognee-repair/log_pipeline_run_error-recovery.json \
+    --module cognee.modules.pipelines.operations.log_pipeline_run_error \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 352d8ffdbab00b81768dcf5f4b0155d59be925816a921d7e1ea5cb93c5816210 \
+    --patch-sha256 0efefeca72028ec862c8af5b2f99202f0eaf56e4f688ba179297ee3efd63059d \
+    --postimage-sha256 490ffd6c0bd1b39f4a0dc75b31ed00493f6a503daa1d0888be72d179f26025cf && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/modules/pipelines/operations/pipeline.py" \
+    --patch /opt/opencrane/cognee-repair/pipeline-recovery.patch \
+    --receipt /opt/opencrane/cognee-repair/pipeline-recovery.json \
+    --module cognee.modules.pipelines.operations.pipeline \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 60851f717ecd0b4c14fa6a7b1caac2cb4a98a52ca9c76e395601bbeeed69d667 \
+    --patch-sha256 182d580032e9853b4db302380cdf7b7e4ef877fbbce910f33da9fa24bf9c1756 \
+    --postimage-sha256 60008785c69f72471469843c7dc5da3c2df7573a55a7a68724e6748cc33dfe4c && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/modules/pipelines/operations/run_tasks.py" \
+    --patch /opt/opencrane/cognee-repair/run_tasks-recovery.patch \
+    --receipt /opt/opencrane/cognee-repair/run_tasks-recovery.json \
+    --module cognee.modules.pipelines.operations.run_tasks \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 adcc62df702d4c8163e43cd7f824b63e0889bcc4c90ee4779013dcddf33a1370 \
+    --patch-sha256 10f8123c0799b7e961b300dfbb7cab0255c82f40dbf2a977540b8406ba8897c1 \
+    --postimage-sha256 1df56f0ffbaeff6e9a2a0aeaa2474cc662b8f6d735a8695bc0427fb3e2aea2b7 && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/api/v1/cognify/cognify.py" \
+    --patch /opt/opencrane/cognee-repair/cognify-operation-flow.patch \
+    --receipt /opt/opencrane/cognee-repair/cognify-operation-flow.json \
+    --module cognee.api.v1.cognify.cognify \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 9305160366736380639f9781c917c501bfb45f766fac79a0c0865c699ba01d00 \
+    --patch-sha256 4ba59030198e0f5794d14a43a05b9e5f50cbb72b263923e99afe41e5fb30d248 \
+    --postimage-sha256 c65b713d425db4b1b4d55e739499b5489bf44e1cc9a99fa609c43db28d4fadd6 && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/api/v1/cognify/routers/get_cognify_router.py" \
+    --patch /opt/opencrane/cognee-repair/cognify-router-recovery.patch \
+    --receipt /opt/opencrane/cognee-repair/cognify-router-recovery.json \
+    --module cognee.api.v1.cognify.routers.get_cognify_router \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 3632b88864dc39ef1c719b8fe7914f897939e7d3622756f0d0ba9a922b322b63 \
+    --patch-sha256 8cbe53f5030173700154caf8f63c7929ef15acef79db09c0a0653220fea36266 \
+    --postimage-sha256 c7e7cbe1d0faaa20bb26dc2a763016db32644d5b7e590cd1ccaa4941e328858b && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/api/v1/datasets/dto.py" \
+    --patch /opt/opencrane/cognee-repair/dataset-evidence-dto.patch \
+    --receipt /opt/opencrane/cognee-repair/dataset-evidence-dto.json \
+    --module cognee.api.v1.datasets.dto \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 9864c4d4cffd5e5c45ef6b9b18daa8e861a5c73f25b88caf16468d1d4b7cd68c \
+    --patch-sha256 19eb21e204a485c2068325205d81228ce3a1f8d23752529789382c0906fcc860 \
+    --postimage-sha256 3348738cdadd0372e6063fc62fd609c89a99ec1489dc79f387394c12ba0d0fb2 && \
+  python /tmp/apply-cognee-source-patch.py \
+    --source "$package_root/api/v1/datasets/routers/get_datasets_router.py" \
+    --patch /opt/opencrane/cognee-repair/dataset-route-acl-recovery.patch \
+    --receipt /opt/opencrane/cognee-repair/dataset-route-acl-recovery.json \
+    --module cognee.api.v1.datasets.routers.get_datasets_router \
+    --base-image-digest sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10 \
+    --preimage-sha256 87b3ff9da756bbf730237197cdedcd26278f27e0c17f19ae887b77c9c0ccc241 \
+    --patch-sha256 b4ce55d9d619c0be85417956f85bdc82a729359acfddee130675d8a695fee35c \
+    --postimage-sha256 677afc0b7bb6c2633cf2c01d59a18f72dee0a2131ea6f49b16a42c72420baafb && \
   rm /tmp/apply-cognee-source-patch.py
+
 
 USER cognee
 

--- a/apps/_infra/cognee/tests/candidates/1.5.4/expected-source-hashes.json
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/expected-source-hashes.json
@@ -58,7 +58,14 @@
     "cognee.tasks.ingestion.data_item_to_text_file": "00bafc34a5a8ebab3b4f7c30dd10dccc539ae6de349047134a88d24d50f89bde",
     "cognee.tasks.ingestion.ingest_data": "6493bd63bb7f860684695458c3755c3531a9722612da41a2deb5f5307b52d674",
     "cognee.tasks.ingestion.save_data_item_to_storage": "3979e866334ff639648441adf4afea4e3cbda7a323ce4c792f2f1208558ba6c5",
-    "cognee.version": "8ac37d817a40c24611f36726871fb66a78bc2b2968b81caa33a8942ebf391f29"
+    "cognee.version": "8ac37d817a40c24611f36726871fb66a78bc2b2968b81caa33a8942ebf391f29",
+    "cognee.modules.pipelines.models.PipelineRunInfo": "bb1ff28d87db42ee084bca375f0dec64042bf66ff36834a9bd3ebc64dfec63a9",
+    "cognee.modules.pipelines.utils.generate_pipeline_run_id": "45761dedbee9955aa20f0a247ba65a2b0c84d34a5c0c0f5db8b465c9982cfd38",
+    "cognee.modules.pipelines.operations.log_pipeline_run_start": "befdec2bd7e6bc7c0f7102f05def09845529430bd98f9d24ea2da21bc5b96a8d",
+    "cognee.modules.pipelines.operations.log_pipeline_run_complete": "e8368f9f86569d0e0d79102846dd777f5678302a41357c0d9a81a74827f24892",
+    "cognee.modules.pipelines.operations.log_pipeline_run_error": "352d8ffdbab00b81768dcf5f4b0155d59be925816a921d7e1ea5cb93c5816210",
+    "cognee.modules.pipelines.operations.pipeline": "60851f717ecd0b4c14fa6a7b1caac2cb4a98a52ca9c76e395601bbeeed69d667",
+    "cognee.modules.pipelines.operations.run_tasks": "adcc62df702d4c8163e43cd7f824b63e0889bcc4c90ee4779013dcddf33a1370"
   },
   "repairs": {
     "cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter": {
@@ -96,8 +103,8 @@
     "cognee.api.v1.datasets.routers.get_datasets_router": {
       "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
       "preimageSha256": "87b3ff9da756bbf730237197cdedcd26278f27e0c17f19ae887b77c9c0ccc241",
-      "patchSha256": "ab4abb197a4e7fa3c7d04288ca56f16dab7c4d8a42d51a0ab89c929db63ddad7",
-      "postimageSha256": "0f6226908897c14c97c17a449f715e461201e801a8bab5832b7fd0f8766a551e",
+      "patchSha256": "b4ce55d9d619c0be85417956f85bdc82a729359acfddee130675d8a695fee35c",
+      "postimageSha256": "677afc0b7bb6c2633cf2c01d59a18f72dee0a2131ea6f49b16a42c72420baafb",
       "patchPath": "/opt/opencrane/cognee-repair/dataset-route-acl-recovery.patch",
       "receiptPath": "/opt/opencrane/cognee-repair/dataset-route-acl-recovery.json"
     },
@@ -108,6 +115,102 @@
       "postimageSha256": "a3e261dbf13831b044cbf190fb9ac204150c88afc771b761a259c2430fbdb26b",
       "patchPath": "/opt/opencrane/cognee-repair/create-authorized-dataset-acl-recovery.patch",
       "receiptPath": "/opt/opencrane/cognee-repair/create-authorized-dataset-acl-recovery.json"
+    },
+    "cognee.modules.pipelines.operations.cognify_input_evidence": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": null,
+      "patchSha256": "0ebf313e96d2337db333817eaef1347beea99f170a9e7ae31ed9fc0118ee0f25",
+      "postimageSha256": "5b7df0e5db3f0c785b257b4ab88a6e13576287cb78f4da0072c41efeb81c6632",
+      "patchPath": "/opt/opencrane/cognee-repair/cognify-input-evidence.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/cognify-input-evidence.json"
+    },
+    "cognee.modules.pipelines.operations.cognify_run_recovery": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": null,
+      "patchSha256": "5b7fe3e33ff82ee67a3872ea5faec8d2424ad69cd42d656611523f7ba13bb46f",
+      "postimageSha256": "2e1d1f6c54f668960f291fb77c8f35111b795b0144dfbc24d0388eff1c0a26c0",
+      "patchPath": "/opt/opencrane/cognee-repair/cognify-run-recovery.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/cognify-run-recovery.json"
+    },
+    "cognee.modules.pipelines.models.PipelineRunInfo": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "bb1ff28d87db42ee084bca375f0dec64042bf66ff36834a9bd3ebc64dfec63a9",
+      "patchSha256": "586ba9af1ff107a98f673414411ea1063681b65f744683da85049f5cbbe30826",
+      "postimageSha256": "562793af28ef6b18ffd191c91ef2018e960f2b373f1c0f021e78ecc880fd8859",
+      "patchPath": "/opt/opencrane/cognee-repair/pipeline-run-info-recovery.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/pipeline-run-info-recovery.json"
+    },
+    "cognee.modules.pipelines.utils.generate_pipeline_run_id": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "45761dedbee9955aa20f0a247ba65a2b0c84d34a5c0c0f5db8b465c9982cfd38",
+      "patchSha256": "fa98f93a3a001316655b4da607457e046e853f1a2e4be10af6977672911ef7ef",
+      "postimageSha256": "2b491a3895198f18797496bcff29b185431a3194ac91c62a8208632053971508",
+      "patchPath": "/opt/opencrane/cognee-repair/generate-pipeline-run-id-recovery.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/generate-pipeline-run-id-recovery.json"
+    },
+    "cognee.modules.pipelines.operations.log_pipeline_run_start": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "befdec2bd7e6bc7c0f7102f05def09845529430bd98f9d24ea2da21bc5b96a8d",
+      "patchSha256": "dbad948fe5a2b47fa7c004aa426e1eb806090549d2a918725288b65e2723aa0f",
+      "postimageSha256": "848ff4b9d87d679b707c0b45967a85798914f75f3cb5bdba991a6215508556d1",
+      "patchPath": "/opt/opencrane/cognee-repair/log_pipeline_run_start-recovery.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/log_pipeline_run_start-recovery.json"
+    },
+    "cognee.modules.pipelines.operations.log_pipeline_run_complete": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "e8368f9f86569d0e0d79102846dd777f5678302a41357c0d9a81a74827f24892",
+      "patchSha256": "355d0fe9083bdd416d51bfe7e978f247bcc91dd56a97d4e9a7eea315cde42e0f",
+      "postimageSha256": "02d8fcd96565192fd545d9004e35c86d5eb9f4dd2d64943f6c991dd1b183cc42",
+      "patchPath": "/opt/opencrane/cognee-repair/log_pipeline_run_complete-recovery.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/log_pipeline_run_complete-recovery.json"
+    },
+    "cognee.modules.pipelines.operations.log_pipeline_run_error": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "352d8ffdbab00b81768dcf5f4b0155d59be925816a921d7e1ea5cb93c5816210",
+      "patchSha256": "0efefeca72028ec862c8af5b2f99202f0eaf56e4f688ba179297ee3efd63059d",
+      "postimageSha256": "490ffd6c0bd1b39f4a0dc75b31ed00493f6a503daa1d0888be72d179f26025cf",
+      "patchPath": "/opt/opencrane/cognee-repair/log_pipeline_run_error-recovery.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/log_pipeline_run_error-recovery.json"
+    },
+    "cognee.modules.pipelines.operations.pipeline": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "60851f717ecd0b4c14fa6a7b1caac2cb4a98a52ca9c76e395601bbeeed69d667",
+      "patchSha256": "182d580032e9853b4db302380cdf7b7e4ef877fbbce910f33da9fa24bf9c1756",
+      "postimageSha256": "60008785c69f72471469843c7dc5da3c2df7573a55a7a68724e6748cc33dfe4c",
+      "patchPath": "/opt/opencrane/cognee-repair/pipeline-recovery.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/pipeline-recovery.json"
+    },
+    "cognee.modules.pipelines.operations.run_tasks": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "adcc62df702d4c8163e43cd7f824b63e0889bcc4c90ee4779013dcddf33a1370",
+      "patchSha256": "10f8123c0799b7e961b300dfbb7cab0255c82f40dbf2a977540b8406ba8897c1",
+      "postimageSha256": "1df56f0ffbaeff6e9a2a0aeaa2474cc662b8f6d735a8695bc0427fb3e2aea2b7",
+      "patchPath": "/opt/opencrane/cognee-repair/run_tasks-recovery.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/run_tasks-recovery.json"
+    },
+    "cognee.api.v1.cognify.cognify": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "9305160366736380639f9781c917c501bfb45f766fac79a0c0865c699ba01d00",
+      "patchSha256": "4ba59030198e0f5794d14a43a05b9e5f50cbb72b263923e99afe41e5fb30d248",
+      "postimageSha256": "c65b713d425db4b1b4d55e739499b5489bf44e1cc9a99fa609c43db28d4fadd6",
+      "patchPath": "/opt/opencrane/cognee-repair/cognify-operation-flow.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/cognify-operation-flow.json"
+    },
+    "cognee.api.v1.cognify.routers.get_cognify_router": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "3632b88864dc39ef1c719b8fe7914f897939e7d3622756f0d0ba9a922b322b63",
+      "patchSha256": "8cbe53f5030173700154caf8f63c7929ef15acef79db09c0a0653220fea36266",
+      "postimageSha256": "c7e7cbe1d0faaa20bb26dc2a763016db32644d5b7e590cd1ccaa4941e328858b",
+      "patchPath": "/opt/opencrane/cognee-repair/cognify-router-recovery.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/cognify-router-recovery.json"
+    },
+    "cognee.api.v1.datasets.dto": {
+      "baseImageDigest": "sha256:a52b0c2669e28932b53d677a6adf6d6487b03886732a5db07b58f3b869647b10",
+      "preimageSha256": "9864c4d4cffd5e5c45ef6b9b18daa8e861a5c73f25b88caf16468d1d4b7cd68c",
+      "patchSha256": "19eb21e204a485c2068325205d81228ce3a1f8d23752529789382c0906fcc860",
+      "postimageSha256": "3348738cdadd0372e6063fc62fd609c89a99ec1489dc79f387394c12ba0d0fb2",
+      "patchPath": "/opt/opencrane/cognee-repair/dataset-evidence-dto.patch",
+      "receiptPath": "/opt/opencrane/cognee-repair/dataset-evidence-dto.json"
     }
   }
 }

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/cognify-input-evidence.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/cognify-input-evidence.patch
@@ -1,0 +1,135 @@
+--- /dev/null
++++ b/cognee/modules/pipelines/operations/cognify_input_evidence.py
+@@ -0,0 +1,132 @@
++"""Bound the exact provider input admitted by an OpenCrane Cognify command."""
++
++import hashlib
++import json
++from enum import Enum
++from typing import Any, Awaitable, Callable
++from uuid import UUID
++
++from cognee.infrastructure.files.utils.open_data_file import open_data_file
++
++
++MAXIMUM_DOCUMENTS = 1000
++MAXIMUM_DOCUMENT_BYTES = 65536
++MAXIMUM_DATASET_BYTES = MAXIMUM_DOCUMENTS * MAXIMUM_DOCUMENT_BYTES
++EVIDENCE_VERSION = "opencrane-cognify-input-v1"
++
++
++def _json_value(value: Any) -> Any:
++    """Normalize JSON-backed provider values without stringifying unknown objects."""
++    if value is None or isinstance(value, (str, bool, int)):
++        return value
++    if isinstance(value, UUID):
++        return str(value)
++    if isinstance(value, Enum):
++        return _json_value(value.value)
++    if isinstance(value, list):
++        return [_json_value(item) for item in value]
++    if isinstance(value, dict):
++        if not all(isinstance(key, str) for key in value):
++            raise ValueError("Cognify input metadata contains a non-string key")
++        return {key: _json_value(value[key]) for key in sorted(value)}
++    if isinstance(value, float) and value == value and abs(value) != float("inf"):
++        return value
++    raise ValueError("Cognify input metadata contains an unsupported value")
++
++
++def _digest(value: Any) -> str:
++    """Hash one versioned canonical JSON value."""
++    encoded = json.dumps(
++        _json_value(value), ensure_ascii=False, allow_nan=False, sort_keys=True, separators=(",", ":")
++    ).encode("utf-8")
++    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
++
++
++async def _read_complete_raw(location: str) -> bytes:
++    """Read one bounded complete provider-managed source file."""
++    async with open_data_file(location, mode="rb") as stream:
++        content = stream.read(MAXIMUM_DOCUMENT_BYTES + 1)
++    if len(content) > MAXIMUM_DOCUMENT_BYTES:
++        raise ValueError("Cognify evidence source exceeds the admitted byte limit")
++    return content
++
++
++async def build_cognify_input_evidence(
++    dataset: Any,
++    user: Any,
++    data: list[Any],
++    raw_reader: Callable[[str], Awaitable[bytes]] = _read_complete_raw,
++) -> tuple[str, list[dict[str, Any]]]:
++    """Return the opaque dataset digest and safe per-document byte evidence."""
++    if len(data) > MAXIMUM_DOCUMENTS:
++        raise ValueError("Cognify evidence contains too many documents")
++    if str(dataset.owner_id) != str(user.id):
++        raise PermissionError("Cognify recovery requires the dataset owner")
++
++    documents = []
++    projected = []
++    seen = set()
++    total_bytes = 0
++    expected_tenant = getattr(user, "tenant_id", None)
++    for row in sorted(data, key=lambda item: str(item.id)):
++        document_id = str(row.id)
++        if (
++            document_id in seen
++            or str(row.dataset_id) != str(dataset.id)
++            or str(row.owner_id) != str(user.id)
++            or row.tenant_id != expected_tenant
++        ):
++            raise ValueError("Cognify evidence contains duplicate or foreign data")
++        seen.add(document_id)
++        content = await raw_reader(row.raw_data_location)
++        if len(content) > MAXIMUM_DOCUMENT_BYTES:
++            raise ValueError("Cognify evidence source exceeds the admitted byte limit")
++        total_bytes += len(content)
++        if total_bytes > MAXIMUM_DATASET_BYTES:
++            raise ValueError("Cognify evidence dataset exceeds the admitted byte limit")
++        content_digest = f"sha256:{hashlib.sha256(content).hexdigest()}"
++        documents.append(
++            {
++                "documentId": document_id,
++                "ownerId": str(row.owner_id),
++                "tenantId": str(row.tenant_id) if row.tenant_id is not None else None,
++                "name": row.name,
++                "label": row.label,
++                "extension": row.extension,
++                "originalExtension": row.original_extension,
++                "mimeType": row.mime_type,
++                "originalMimeType": row.original_mime_type,
++                "loaderEngine": row.loader_engine,
++                "contentDigest": content_digest,
++                "byteLength": len(content),
++                "contentHash": row.content_hash,
++                "rawContentHash": row.raw_content_hash,
++                "externalMetadata": row.external_metadata,
++                "systemMetadata": row.system_metadata,
++                "nodeSet": row.node_set,
++                "importanceWeight": row.importance_weight,
++                "cognifyStatus": (row.pipeline_status or {}).get("cognify_pipeline"),
++            }
++        )
++        projected.append(
++            {
++                "document_id": document_id,
++                "content_digest": content_digest,
++                "byte_length": len(content),
++            }
++        )
++
++    evidence = {
++        "version": EVIDENCE_VERSION,
++        "userId": str(user.id),
++        "tenantId": str(getattr(user, "tenant_id", None)) if getattr(user, "tenant_id", None) is not None else None,
++        "datasetId": str(dataset.id),
++        "datasetOwnerId": str(dataset.owner_id),
++        "documents": documents,
++    }
++    return _digest(evidence), projected
++
++
++def build_cognify_request_digest(profile: dict[str, Any]) -> str:
++    """Bind the fixed effect-shaping profile independently of dataset contents."""
++    return _digest({"version": EVIDENCE_VERSION, "profile": profile})

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/cognify-operation-flow.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/cognify-operation-flow.patch
@@ -1,0 +1,62 @@
+--- a/cognee/api/v1/cognify/cognify.py
++++ b/cognee/api/v1/cognify/cognify.py
+@@ -16,0 +16,3 @@
++from cognee.modules.pipelines.operations.cognify_input_evidence import (
++    build_cognify_request_digest,
++)
+@@ -128,0 +131,2 @@
++    operation_id: Optional[UUID] = None,
++    expected_input_evidence_digest: Optional[str] = None,
+@@ -294,0 +299,44 @@
++    request_digest = None
++    if operation_id is None and expected_input_evidence_digest is not None:
++        raise ValueError("Cognify input evidence requires an operation id")
++    if operation_id is not None:
++        canonical = (
++            isinstance(datasets, list)
++            and len(datasets) == 1
++            and isinstance(datasets[0], UUID)
++            and user is not None
++            and graph_model is KnowledgeGraph
++            and chunker is TextChunker
++            and chunk_size == 128
++            and chunks_per_batch is None
++            and config is None
++            and vector_db_config is None
++            and graph_db_config is None
++            and run_in_background is False
++            and incremental_loading is True
++            and custom_prompt in (None, "")
++            and temporal_cognify is False
++            and functional_relationships is None
++            and data_per_batch == 20
++            and llm_config is None
++            and embedding_config is None
++            and data_cache is True
++            and dry_run is False
++            and raise_on_error is False
++            and chunk_attachment is None
++            and not kwargs
++            and expected_input_evidence_digest is not None
++        )
++        if not canonical:
++            raise ValueError("Operation-identified Cognify requires the fixed OpenCrane profile")
++        request_digest = build_cognify_request_digest(
++            {
++                "pipeline": "cognify_pipeline",
++                "chunkSize": 128,
++                "dataPerBatch": 20,
++                "incrementalLoading": True,
++                "dataCache": True,
++                "graphModel": "KnowledgeGraph",
++            }
++        )
++
+@@ -437,0 +486,7 @@
++                # Operation-identified calls use the actual admitted tasks as
++                # their provider check. Startup probes would run again after a
++                # process restart before exact history replay was decided.
++                skip_connection_test=operation_id is not None,
++                operation_id=operation_id,
++                expected_input_evidence_digest=expected_input_evidence_digest,
++                request_digest=request_digest,

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/cognify-router-recovery.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/cognify-router-recovery.patch
@@ -1,0 +1,30 @@
+--- a/cognee/api/v1/cognify/routers/get_cognify_router.py
++++ b/cognee/api/v1/cognify/routers/get_cognify_router.py
+@@ -39,0 +39,4 @@
++from cognee.modules.pipelines.operations.cognify_run_recovery import (
++    CognifyOperationConflictError,
++    CognifyRecoveryRequiredError,
++)
+@@ -118,0 +122,8 @@
++    )
++    operation_id: Optional[UUID] = Field(
++        default=None,
++        description="Caller-saved UUID used only for exact blocking-run recovery.",
++    )
++    expected_input_evidence_digest: Optional[str] = Field(
++        default=None,
++        description="Opaque dataset evidence saved before the first recovered call.",
+@@ -255,0 +267,2 @@
++                operation_id=payload.operation_id,
++                expected_input_evidence_digest=payload.expected_input_evidence_digest,
+@@ -286,0 +300,10 @@
++            )
++        except CognifyRecoveryRequiredError:
++            return JSONResponse(
++                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
++                content=ErrorResponse(error="Cognify recovery required").model_dump(),
++            )
++        except CognifyOperationConflictError:
++            return JSONResponse(
++                status_code=status.HTTP_409_CONFLICT,
++                content=ErrorResponse(error="Cognify operation conflicts").model_dump(),

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/cognify-run-recovery.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/cognify-run-recovery.patch
@@ -1,0 +1,196 @@
+--- /dev/null
++++ b/cognee/modules/pipelines/operations/cognify_run_recovery.py
+@@ -0,0 +1,193 @@
++"""Admit or replay one caller-identified Cognify pipeline run."""
++
++import re
++from dataclasses import dataclass
++from typing import Any
++from uuid import UUID
++
++from sqlalchemy import select
++
++from cognee.infrastructure.databases.relational import get_relational_engine
++from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus
++from cognee.modules.pipelines.models.PipelineRunInfo import PipelineRunCompleted, PipelineRunErrored
++from cognee.modules.pipelines.utils import generate_pipeline_run_id
++
++from .cognify_input_evidence import build_cognify_input_evidence
++
++
++_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
++_EVIDENCE_KEY = "opencrane_cognify"
++
++
++class CognifyOperationConflictError(RuntimeError):
++    """The saved command does not match the requested Cognify operation."""
++
++
++class CognifyRecoveryRequiredError(RuntimeError):
++    """The exact run may have effects but has no coherent terminal receipt."""
++
++
++@dataclass(frozen=True)
++class CognifyRunAdmission:
++    """Coordinates saved before a first provider task may start."""
++
++    pipeline_run_id: UUID
++    evidence: dict[str, str]
++
++
++@dataclass(frozen=True)
++class CognifyRunReplay:
++    """One exact terminal provider result reconstructed without dispatch."""
++
++    run_info: PipelineRunCompleted | PipelineRunErrored
++
++
++def _saved_evidence(row: PipelineRun) -> dict[str, str]:
++    value = (row.run_info or {}).get(_EVIDENCE_KEY)
++    required = {"operation_id", "request_digest", "input_evidence_digest"}
++    if not isinstance(value, dict) or set(value) != required:
++        raise CognifyRecoveryRequiredError("Cognify run evidence is incomplete")
++    if not all(isinstance(value[key], str) for key in required):
++        raise CognifyRecoveryRequiredError("Cognify run evidence is malformed")
++    if _DIGEST.fullmatch(value["request_digest"]) is None or _DIGEST.fullmatch(value["input_evidence_digest"]) is None:
++        raise CognifyRecoveryRequiredError("Cognify run digest evidence is malformed")
++    return value
++
++
++def _validate_row(
++    row: PipelineRun,
++    pipeline_id: UUID,
++    pipeline_name: str,
++    dataset: Any,
++    user: Any,
++    operation_id: UUID,
++    request_digest: str,
++    expected_input_evidence_digest: str,
++) -> dict[str, str]:
++    expected_tenant = getattr(user, "tenant_id", None)
++    if (
++        row.pipeline_id != pipeline_id
++        or row.pipeline_name != pipeline_name
++        or row.operation_name != pipeline_name
++        or row.dataset_id != dataset.id
++        or row.user_id != user.id
++        or row.tenant_id != expected_tenant
++    ):
++        raise CognifyRecoveryRequiredError("Cognify run coordinates conflict")
++    evidence = _saved_evidence(row)
++    if evidence != {
++        "operation_id": str(operation_id),
++        "request_digest": request_digest,
++        "input_evidence_digest": expected_input_evidence_digest,
++    }:
++        raise CognifyRecoveryRequiredError("Cognify operation evidence conflicts")
++    return evidence
++
++
++def _plan_saved_history(
++    rows: list[PipelineRun],
++    pipeline_id: UUID,
++    pipeline_name: str,
++    dataset: Any,
++    user: Any,
++    operation_id: UUID,
++    request_digest: str,
++    expected_input_evidence_digest: str,
++    run_id: UUID,
++) -> CognifyRunReplay | None:
++    """Validate an ordered saved history and reconstruct its terminal receipt."""
++    if not rows:
++        return None
++    for row in rows:
++        _validate_row(
++            row,
++            pipeline_id,
++            pipeline_name,
++            dataset,
++            user,
++            operation_id,
++            request_digest,
++            expected_input_evidence_digest,
++        )
++    started = [row for row in rows if row.status == PipelineRunStatus.DATASET_PROCESSING_STARTED]
++    completed = [row for row in rows if row.status == PipelineRunStatus.DATASET_PROCESSING_COMPLETED]
++    errored = [row for row in rows if row.status == PipelineRunStatus.DATASET_PROCESSING_ERRORED]
++    if (
++        len(started) != 1
++        or len(completed) + len(errored) > 1
++        or len(rows) != len(started) + len(completed) + len(errored)
++        or rows[0] is not started[0]
++        or (len(rows) == 2 and rows[1] not in completed + errored)
++    ):
++        raise CognifyRecoveryRequiredError("Cognify run history is contradictory")
++    common = {
++        "pipeline_run_id": run_id,
++        "dataset_id": dataset.id,
++        "dataset_name": dataset.name,
++        "operation_id": operation_id,
++        "input_evidence_digest": expected_input_evidence_digest,
++    }
++    if len(completed) == 1:
++        return CognifyRunReplay(PipelineRunCompleted(**common))
++    if len(errored) == 1:
++        terminal = errored[0]
++        return CognifyRunReplay(
++            PipelineRunErrored(
++                **common,
++                payload="Saved Cognify run errored",
++                error_class=terminal.error_class,
++                error_message=terminal.error_message,
++            )
++        )
++    raise CognifyRecoveryRequiredError("Cognify run has no terminal receipt")
++
++
++async def plan_cognify_run(
++    pipeline_id: UUID,
++    pipeline_name: str,
++    dataset: Any,
++    data: list[Any],
++    user: Any,
++    operation_id: UUID,
++    expected_input_evidence_digest: str,
++    request_digest: str,
++) -> CognifyRunAdmission | CognifyRunReplay:
++    """Plan one run while the caller holds the dataset lock."""
++    if _DIGEST.fullmatch(expected_input_evidence_digest) is None or _DIGEST.fullmatch(request_digest) is None:
++        raise CognifyOperationConflictError("Cognify operation digest is invalid")
++    run_id = generate_pipeline_run_id(pipeline_id, dataset.id, operation_id=operation_id)
++    engine = get_relational_engine()
++    async with engine.get_async_session() as session:
++        rows = list(
++            (
++                await session.scalars(
++                    select(PipelineRun)
++                    .where(PipelineRun.pipeline_run_id == run_id)
++                    .order_by(PipelineRun.created_at.asc(), PipelineRun.id.asc())
++                )
++            ).all()
++        )
++
++    replay = _plan_saved_history(
++        rows,
++        pipeline_id,
++        pipeline_name,
++        dataset,
++        user,
++        operation_id,
++        request_digest,
++        expected_input_evidence_digest,
++        run_id,
++    )
++    if replay is not None:
++        return replay
++
++    actual_digest, _documents = await build_cognify_input_evidence(dataset, user, data)
++    if actual_digest != expected_input_evidence_digest:
++        raise CognifyOperationConflictError("Cognify input evidence changed before admission")
++    evidence = {
++        "operation_id": str(operation_id),
++        "request_digest": request_digest,
++        "input_evidence_digest": actual_digest,
++    }
++    return CognifyRunAdmission(run_id, evidence)

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/dataset-evidence-dto.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/dataset-evidence-dto.patch
@@ -1,0 +1,21 @@
+--- a/cognee/api/v1/datasets/dto.py
++++ b/cognee/api/v1/datasets/dto.py
+@@ -10 +10 @@
+-from typing import Optional
++from typing import List, Optional
+@@ -27,0 +27,15 @@
++
++
++class CognifyEvidenceDataDTO(DataDTO):
++    """Safe document coordinates returned with one locked Cognify snapshot."""
++
++    content_digest: str
++    byte_length: int
++
++
++class CognifyInputEvidenceDTO(OutDTO):
++    """Opaque input evidence plus the documents observed in the same lock."""
++
++    dataset_id: UUID
++    input_evidence_digest: str
++    data: List[CognifyEvidenceDataDTO]

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/dataset-route-acl-recovery.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/dataset-route-acl-recovery.patch
@@ -1,22 +1,64 @@
 --- a/cognee/api/v1/datasets/routers/get_datasets_router.py
 +++ b/cognee/api/v1/datasets/routers/get_datasets_router.py
-@@ -17,7 +17,6 @@
- from cognee.api.v1.datasets.dto import DataDTO
- from cognee.infrastructure.databases.relational import get_relational_engine
- from cognee.modules.data.methods import get_authorized_existing_datasets
+@@ -17 +17 @@
+-from cognee.api.v1.datasets.dto import DataDTO
++from cognee.api.v1.datasets.dto import CognifyInputEvidenceDTO, DataDTO
+@@ -20 +19,0 @@
 -from cognee.modules.data.methods import get_datasets_by_name
- from cognee.modules.data.methods import get_datasets_graph_counts
- from cognee.modules.data.methods.create_authorized_dataset import create_authorized_dataset
- from cognee.shared.logging_utils import get_logger
-@@ -209,11 +208,6 @@
-         )
- 
-         try:
+@@ -212,5 +210,0 @@
 -            datasets = await get_datasets_by_name([dataset_data.name], user.id)
 -
 -            if datasets:
 -                return datasets[0]
 -
-             dataset = await create_authorized_dataset(dataset_data.name, user)
- 
-             return dataset
+@@ -364 +358 @@
+-        response_model=list[DataDTO],
++        response_model=Union[list[DataDTO], CognifyInputEvidenceDTO],
+@@ -373,0 +367,4 @@
++        include_cognify_evidence: bool = Query(
++            default=False,
++            description="Return one locked, opaque Cognify input snapshot.",
++        ),
+@@ -414,2 +412,2 @@
+-        # Verify user has permission to read dataset
+-        dataset = await get_authorized_existing_datasets([dataset_id], "read", user)
++        permission = "write" if include_cognify_evidence else "read"
++        dataset = await get_authorized_existing_datasets([dataset_id], permission, user)
+@@ -425 +423,36 @@
+-        dataset_id = dataset[0].id
++        dataset = dataset[0]
++        dataset_id = dataset.id
++
++        if include_cognify_evidence:
++            from cognee.infrastructure.locks import get_dataset_lock
++            from cognee.modules.pipelines.operations.cognify_input_evidence import (
++                build_cognify_input_evidence,
++            )
++
++            async with await get_dataset_lock(dataset_id):
++                authorized = await get_authorized_existing_datasets(
++                    [dataset_id], "write", user
++                )
++                if len(authorized) != 1:
++                    return JSONResponse(
++                        status_code=404,
++                        content=ErrorResponseDTO(message="Dataset is unavailable.").model_dump(),
++                    )
++                dataset_data = await get_dataset_data(dataset_id=dataset_id)
++                evidence_digest, evidence_rows = await build_cognify_input_evidence(
++                    authorized[0], user, dataset_data
++                )
++                evidence_by_id = {row["document_id"]: row for row in evidence_rows}
++                return {
++                    "dataset_id": dataset_id,
++                    "input_evidence_digest": evidence_digest,
++                    "data": [
++                        {
++                            **jsonable_encoder(data),
++                            "dataset_id": dataset_id,
++                            "content_digest": evidence_by_id[str(data.id)]["content_digest"],
++                            "byte_length": evidence_by_id[str(data.id)]["byte_length"],
++                        }
++                        for data in dataset_data
++                    ],
++                }

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/generate-pipeline-run-id-recovery.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/generate-pipeline-run-id-recovery.patch
@@ -1,0 +1,15 @@
+--- a/cognee/modules/pipelines/utils/generate_pipeline_run_id.py
++++ b/cognee/modules/pipelines/utils/generate_pipeline_run_id.py
+@@ -1 +1 @@
+-from uuid import UUID, uuid4
++from uuid import UUID, uuid4, uuid5
+@@ -4,2 +4,7 @@
+-def generate_pipeline_run_id(pipeline_id: UUID, dataset_id: UUID):
+-    # pipeline_run_id must be unique per execution; keep args for API compatibility.
++def generate_pipeline_run_id(
++    pipeline_id: UUID, dataset_id: UUID, *, operation_id: UUID | None = None
++):
++    """Return a caller-stable run id only when an operation identity is supplied."""
++    if operation_id is not None:
++        return uuid5(pipeline_id, str(operation_id))
++    # Legacy callers still receive one unique id for every execution.

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/log_pipeline_run_complete-recovery.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/log_pipeline_run_complete-recovery.patch
@@ -1,0 +1,14 @@
+--- a/cognee/modules/pipelines/operations/log_pipeline_run_complete.py
++++ b/cognee/modules/pipelines/operations/log_pipeline_run_complete.py
+@@ -24,0 +24 @@
++    run_evidence: Optional[dict[str, str]] = None,
+@@ -26,0 +27,4 @@
++
++    run_info = {"data": data_info}
++    if run_evidence is not None:
++        run_info["opencrane_cognify"] = dict(run_evidence)
+@@ -33,3 +38 @@
+-        run_info={
+-            "data": data_info,
+-        },
++        run_info=run_info,

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/log_pipeline_run_error-recovery.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/log_pipeline_run_error-recovery.patch
@@ -1,0 +1,21 @@
+--- a/cognee/modules/pipelines/operations/log_pipeline_run_error.py
++++ b/cognee/modules/pipelines/operations/log_pipeline_run_error.py
+@@ -25,0 +25 @@
++    run_evidence: Optional[dict[str, str]] = None,
+@@ -27,0 +28,8 @@
++
++    # Persist only the existing scrubbed summary; raw provider/model errors never enter evidence.
++    run_info = {
++        "data": data_info,
++        "error": scrub_error_message(e),
++    }
++    if run_evidence is not None:
++        run_info["opencrane_cognify"] = dict(run_evidence)
+@@ -34,6 +43 @@
+-        run_info={
+-            "data": data_info,
+-            # Scrubbed like error_message — persisting the raw text here would
+-            # defeat the redaction (and run_info growth is capped, COG-5359).
+-            "error": scrub_error_message(e),
+-        },
++        run_info=run_info,

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/log_pipeline_run_start-recovery.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/log_pipeline_run_start-recovery.patch
@@ -1,0 +1,16 @@
+--- a/cognee/modules/pipelines/operations/log_pipeline_run_start.py
++++ b/cognee/modules/pipelines/operations/log_pipeline_run_start.py
+@@ -18,0 +18,2 @@
++    pipeline_run_id: Optional[UUID] = None,
++    run_evidence: Optional[dict[str, str]] = None,
+@@ -21 +23,4 @@
+-    pipeline_run_id = generate_pipeline_run_id(pipeline_id, dataset_id)
++    pipeline_run_id = pipeline_run_id or generate_pipeline_run_id(pipeline_id, dataset_id)
++    run_info = {"data": data_info}
++    if run_evidence is not None:
++        run_info["opencrane_cognify"] = dict(run_evidence)
+@@ -29,3 +34 @@
+-        run_info={
+-            "data": data_info,
+-        },
++        run_info=run_info,

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/pipeline-recovery.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/pipeline-recovery.patch
@@ -1,0 +1,18 @@
+--- a/cognee/modules/pipelines/operations/pipeline.py
++++ b/cognee/modules/pipelines/operations/pipeline.py
+@@ -77,0 +77,3 @@
++    operation_id: Optional[UUID] = None,
++    expected_input_evidence_digest: Optional[str] = None,
++    request_digest: Optional[str] = None,
+@@ -109,0 +112,3 @@
++            operation_id=operation_id,
++            expected_input_evidence_digest=expected_input_evidence_digest,
++            request_digest=request_digest,
+@@ -126,0 +132,3 @@
++    operation_id: Optional[UUID] = None,
++    expected_input_evidence_digest: Optional[str] = None,
++    request_digest: Optional[str] = None,
+@@ -156,0 +165,3 @@
++            operation_id=operation_id,
++            expected_input_evidence_digest=expected_input_evidence_digest,
++            request_digest=request_digest,

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/pipeline-run-info-recovery.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/pipeline-run-info-recovery.patch
@@ -1,0 +1,5 @@
+--- a/cognee/modules/pipelines/models/PipelineRunInfo.py
++++ b/cognee/modules/pipelines/models/PipelineRunInfo.py
+@@ -15,0 +15,2 @@
++    operation_id: Optional[UUID] = None
++    input_evidence_digest: Optional[str] = None

--- a/apps/_infra/cognee/tests/candidates/1.5.4/patches/run_tasks-recovery.patch
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/patches/run_tasks-recovery.patch
@@ -1,0 +1,56 @@
+--- a/cognee/modules/pipelines/operations/run_tasks.py
++++ b/cognee/modules/pipelines/operations/run_tasks.py
+@@ -34,0 +34,5 @@
++from .cognify_run_recovery import (
++    CognifyRunAdmission,
++    CognifyRunReplay,
++    plan_cognify_run,
++)
+@@ -52,0 +57,3 @@
++    operation_id: Optional[UUID] = None,
++    expected_input_evidence_digest: Optional[str] = None,
++    request_digest: Optional[str] = None,
+@@ -72,0 +80,21 @@
++    admission = None
++    if operation_id is not None:
++        if expected_input_evidence_digest is None or request_digest is None:
++            raise ValueError("Cognify recovery coordinates are incomplete")
++        planned = await plan_cognify_run(
++            pipeline_id,
++            pipeline_name,
++            dataset,
++            data,
++            user,
++            operation_id,
++            expected_input_evidence_digest,
++            request_digest,
++        )
++        if isinstance(planned, CognifyRunReplay):
++            yield planned.run_info
++            return
++        if not isinstance(planned, CognifyRunAdmission):
++            raise RuntimeError("Cognify recovery returned an unknown decision")
++        admission = planned
++
+@@ -73 +102,7 @@
+-        pipeline_id, pipeline_name, dataset.id, data, user=user
++        pipeline_id,
++        pipeline_name,
++        dataset.id,
++        data,
++        user=user,
++        pipeline_run_id=admission.pipeline_run_id if admission else None,
++        run_evidence=admission.evidence if admission else None,
+@@ -85,0 +120,2 @@
++        operation_id=operation_id,
++        input_evidence_digest=expected_input_evidence_digest,
+@@ -284,0 +321 @@
++                    run_evidence=admission.evidence if admission else None,
+@@ -291,0 +329,2 @@
++                    operation_id=operation_id,
++                    input_evidence_digest=expected_input_evidence_digest,
+@@ -335,0 +375 @@
++                    run_evidence=admission.evidence if admission else None,
+@@ -347,0 +388,2 @@
++                    operation_id=operation_id,
++                    input_evidence_digest=expected_input_evidence_digest,

--- a/apps/_infra/cognee/tests/candidates/1.5.4/profile.json
+++ b/apps/_infra/cognee/tests/candidates/1.5.4/profile.json
@@ -32,8 +32,8 @@
         "receiptPath": "/opt/opencrane/cognee-repair/run-tasks-data-item.json"
       },
       "cognee.api.v1.datasets.routers.get_datasets_router": {
-        "patchSha256": "ab4abb197a4e7fa3c7d04288ca56f16dab7c4d8a42d51a0ab89c929db63ddad7",
-        "postimageSha256": "0f6226908897c14c97c17a449f715e461201e801a8bab5832b7fd0f8766a551e",
+        "patchSha256": "b4ce55d9d619c0be85417956f85bdc82a729359acfddee130675d8a695fee35c",
+        "postimageSha256": "677afc0b7bb6c2633cf2c01d59a18f72dee0a2131ea6f49b16a42c72420baafb",
         "patchPath": "/opt/opencrane/cognee-repair/dataset-route-acl-recovery.patch",
         "receiptPath": "/opt/opencrane/cognee-repair/dataset-route-acl-recovery.json"
       },
@@ -42,6 +42,78 @@
         "postimageSha256": "a3e261dbf13831b044cbf190fb9ac204150c88afc771b761a259c2430fbdb26b",
         "patchPath": "/opt/opencrane/cognee-repair/create-authorized-dataset-acl-recovery.patch",
         "receiptPath": "/opt/opencrane/cognee-repair/create-authorized-dataset-acl-recovery.json"
+      },
+      "cognee.modules.pipelines.operations.cognify_input_evidence": {
+        "patchSha256": "0ebf313e96d2337db333817eaef1347beea99f170a9e7ae31ed9fc0118ee0f25",
+        "postimageSha256": "5b7df0e5db3f0c785b257b4ab88a6e13576287cb78f4da0072c41efeb81c6632",
+        "patchPath": "/opt/opencrane/cognee-repair/cognify-input-evidence.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/cognify-input-evidence.json"
+      },
+      "cognee.modules.pipelines.operations.cognify_run_recovery": {
+        "patchSha256": "5b7fe3e33ff82ee67a3872ea5faec8d2424ad69cd42d656611523f7ba13bb46f",
+        "postimageSha256": "2e1d1f6c54f668960f291fb77c8f35111b795b0144dfbc24d0388eff1c0a26c0",
+        "patchPath": "/opt/opencrane/cognee-repair/cognify-run-recovery.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/cognify-run-recovery.json"
+      },
+      "cognee.modules.pipelines.models.PipelineRunInfo": {
+        "patchSha256": "586ba9af1ff107a98f673414411ea1063681b65f744683da85049f5cbbe30826",
+        "postimageSha256": "562793af28ef6b18ffd191c91ef2018e960f2b373f1c0f021e78ecc880fd8859",
+        "patchPath": "/opt/opencrane/cognee-repair/pipeline-run-info-recovery.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/pipeline-run-info-recovery.json"
+      },
+      "cognee.modules.pipelines.utils.generate_pipeline_run_id": {
+        "patchSha256": "fa98f93a3a001316655b4da607457e046e853f1a2e4be10af6977672911ef7ef",
+        "postimageSha256": "2b491a3895198f18797496bcff29b185431a3194ac91c62a8208632053971508",
+        "patchPath": "/opt/opencrane/cognee-repair/generate-pipeline-run-id-recovery.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/generate-pipeline-run-id-recovery.json"
+      },
+      "cognee.modules.pipelines.operations.log_pipeline_run_start": {
+        "patchSha256": "dbad948fe5a2b47fa7c004aa426e1eb806090549d2a918725288b65e2723aa0f",
+        "postimageSha256": "848ff4b9d87d679b707c0b45967a85798914f75f3cb5bdba991a6215508556d1",
+        "patchPath": "/opt/opencrane/cognee-repair/log_pipeline_run_start-recovery.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/log_pipeline_run_start-recovery.json"
+      },
+      "cognee.modules.pipelines.operations.log_pipeline_run_complete": {
+        "patchSha256": "355d0fe9083bdd416d51bfe7e978f247bcc91dd56a97d4e9a7eea315cde42e0f",
+        "postimageSha256": "02d8fcd96565192fd545d9004e35c86d5eb9f4dd2d64943f6c991dd1b183cc42",
+        "patchPath": "/opt/opencrane/cognee-repair/log_pipeline_run_complete-recovery.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/log_pipeline_run_complete-recovery.json"
+      },
+      "cognee.modules.pipelines.operations.log_pipeline_run_error": {
+        "patchSha256": "0efefeca72028ec862c8af5b2f99202f0eaf56e4f688ba179297ee3efd63059d",
+        "postimageSha256": "490ffd6c0bd1b39f4a0dc75b31ed00493f6a503daa1d0888be72d179f26025cf",
+        "patchPath": "/opt/opencrane/cognee-repair/log_pipeline_run_error-recovery.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/log_pipeline_run_error-recovery.json"
+      },
+      "cognee.modules.pipelines.operations.pipeline": {
+        "patchSha256": "182d580032e9853b4db302380cdf7b7e4ef877fbbce910f33da9fa24bf9c1756",
+        "postimageSha256": "60008785c69f72471469843c7dc5da3c2df7573a55a7a68724e6748cc33dfe4c",
+        "patchPath": "/opt/opencrane/cognee-repair/pipeline-recovery.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/pipeline-recovery.json"
+      },
+      "cognee.modules.pipelines.operations.run_tasks": {
+        "patchSha256": "10f8123c0799b7e961b300dfbb7cab0255c82f40dbf2a977540b8406ba8897c1",
+        "postimageSha256": "1df56f0ffbaeff6e9a2a0aeaa2474cc662b8f6d735a8695bc0427fb3e2aea2b7",
+        "patchPath": "/opt/opencrane/cognee-repair/run_tasks-recovery.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/run_tasks-recovery.json"
+      },
+      "cognee.api.v1.cognify.cognify": {
+        "patchSha256": "4ba59030198e0f5794d14a43a05b9e5f50cbb72b263923e99afe41e5fb30d248",
+        "postimageSha256": "c65b713d425db4b1b4d55e739499b5489bf44e1cc9a99fa609c43db28d4fadd6",
+        "patchPath": "/opt/opencrane/cognee-repair/cognify-operation-flow.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/cognify-operation-flow.json"
+      },
+      "cognee.api.v1.cognify.routers.get_cognify_router": {
+        "patchSha256": "8cbe53f5030173700154caf8f63c7929ef15acef79db09c0a0653220fea36266",
+        "postimageSha256": "c7e7cbe1d0faaa20bb26dc2a763016db32644d5b7e590cd1ccaa4941e328858b",
+        "patchPath": "/opt/opencrane/cognee-repair/cognify-router-recovery.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/cognify-router-recovery.json"
+      },
+      "cognee.api.v1.datasets.dto": {
+        "patchSha256": "19eb21e204a485c2068325205d81228ce3a1f8d23752529789382c0906fcc860",
+        "postimageSha256": "3348738cdadd0372e6063fc62fd609c89a99ec1489dc79f387394c12ba0d0fb2",
+        "patchPath": "/opt/opencrane/cognee-repair/dataset-evidence-dto.patch",
+        "receiptPath": "/opt/opencrane/cognee-repair/dataset-evidence-dto.json"
       }
     }
   },

--- a/apps/_infra/cognee/tests/fixtures/commit_then_drop_proxy.py
+++ b/apps/_infra/cognee/tests/fixtures/commit_then_drop_proxy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Forward one add request, consume its successful response, and drop the caller connection."""
+"""Forward one admitted provider mutation, then drop its successful response."""
 
 import http.client
 import json
@@ -28,7 +28,7 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_error(404)
 
     def do_POST(self) -> None:
-        if self.path != "/api/v1/add":
+        if self.path not in ("/api/v1/add", "/api/v1/cognify"):
             self.send_error(404)
             return
         length = int(self.headers.get("content-length", "0"))
@@ -36,7 +36,7 @@ class _Handler(BaseHTTPRequestHandler):
         connection = http.client.HTTPConnection(
             os.environ.get("UPSTREAM_HOST", "cognee"),
             int(os.environ.get("UPSTREAM_PORT", "8000")),
-            timeout=300,
+            timeout=600 if self.path == "/api/v1/cognify" else 300,
         )
         forwarded_headers = {
             "accept": "application/json",

--- a/apps/_infra/cognee/tests/fixtures/evidence_summary.py
+++ b/apps/_infra/cognee/tests/fixtures/evidence_summary.py
@@ -16,6 +16,7 @@ def _arguments() -> argparse.Namespace:
     parser.add_argument("--positive", required=True)
     parser.add_argument("--stub-log", required=True)
     parser.add_argument("--drop-log", required=True)
+    parser.add_argument("--expected-drop-path", action="append", required=True)
     parser.add_argument("--output", required=True)
     parser.add_argument("--failure-status", type=int)
     parser.add_argument("--failed-case")
@@ -49,6 +50,28 @@ def _optional_json(path: str):
         return _read_json(path)
     except json.JSONDecodeError:
         return {"outcome": "invalid-json"}
+
+
+def _validate_commit_then_drop(records: list[dict], expected_paths: list[str]) -> None:
+    if not expected_paths or len(set(expected_paths)) != len(expected_paths):
+        raise AssertionError("Commit-then-drop expectation must name unique recovery boundaries")
+    if len(records) != len(expected_paths):
+        raise AssertionError("Commit-then-drop proxy did not record both recovery boundaries")
+    actual_paths = []
+    for record in records:
+        if set(record) != {"method", "path", "upstreamStatus", "responseDropped"}:
+            raise AssertionError("Commit-then-drop evidence contains an unsafe or incomplete field set")
+        if (
+            record["method"] != "POST"
+            or record["responseDropped"] is not True
+            or not isinstance(record["upstreamStatus"], int)
+            or not 200 <= record["upstreamStatus"] < 300
+            or not isinstance(record["path"], str)
+        ):
+            raise AssertionError("Commit-then-drop evidence did not prove a completed dropped response")
+        actual_paths.append(record["path"])
+    if sorted(actual_paths) != sorted(expected_paths):
+        raise AssertionError("Commit-then-drop evidence did not identify every expected recovery boundary")
 
 
 def main() -> None:
@@ -92,8 +115,7 @@ def main() -> None:
         "stubRequests": _read_json_lines(args.stub_log),
         "commitThenDrop": _read_json_lines(args.drop_log),
     }
-    if len(receipt["commitThenDrop"]) != 1:
-        raise AssertionError("Commit-then-drop proxy did not record exactly one committed add")
+    _validate_commit_then_drop(receipt["commitThenDrop"], args.expected_drop_path)
     Path(args.output).write_text(
         json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )

--- a/apps/_infra/cognee/tests/fixtures/test_provider_auth.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_auth.py
@@ -10,6 +10,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 from commit_then_drop_proxy import _Handler as DropProxyHandler
+from evidence_summary import _validate_commit_then_drop
 from provider_api import ProviderApi
 
 
@@ -138,6 +139,25 @@ class ProviderAuthenticationTest(unittest.TestCase):
             )
             self.assertNotIn("test-bearer", metadata.read_text(encoding="utf-8"))
         self.assertEqual(_ProviderHandler.requests[-1][2], "Bearer test-bearer")
+
+    def test_evidence_summary_requires_the_runner_owned_recovery_boundaries(self) -> None:
+        records = [
+            {"method": "POST", "path": "/api/v1/add", "upstreamStatus": 200, "responseDropped": True},
+            {"method": "POST", "path": "/api/v1/cognify", "upstreamStatus": 200, "responseDropped": True},
+        ]
+        _validate_commit_then_drop(records[:1], ["/api/v1/add"])
+        _validate_commit_then_drop(records, ["/api/v1/add", "/api/v1/cognify"])
+        invalid = [
+            (records, ["/api/v1/add"]),
+            (records[:1], ["/api/v1/add", "/api/v1/cognify"]),
+            ([records[0], records[0]], ["/api/v1/add", "/api/v1/cognify"]),
+            ([records[0], {**records[1], "responseDropped": False}], ["/api/v1/add", "/api/v1/cognify"]),
+            ([records[0], {**records[1], "authorization": "secret"}], ["/api/v1/add", "/api/v1/cognify"]),
+        ]
+        for value, expected in invalid:
+            with self.subTest(value=value, expected=expected):
+                with self.assertRaises(AssertionError):
+                    _validate_commit_then_drop(value, expected)
 
 
 if __name__ == "__main__":

--- a/apps/_infra/cognee/tests/fixtures/test_provider_candidate_patch_1_5_4.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_candidate_patch_1_5_4.py
@@ -50,6 +50,18 @@ def _load_managed_lock() -> types.ModuleType:
 
 
 class CandidatePatch154Test(unittest.TestCase):
+    def test_candidate_runner_keeps_connection_test_and_tokenizer_offline(self) -> None:
+        runner = (
+            REPOSITORY_ROOT / "apps/_infra/cognee/tests/memory-contract-1.5.4.sh"
+        ).read_text(encoding="utf-8")
+        start = runner.index("_start_cognee()")
+        end = runner.index('current_case="acl_disabled_negative_control"', start)
+        start_cognee = runner[start:end]
+
+        self.assertIn("--env HF_HUB_OFFLINE=1", start_cognee)
+        self.assertIn("--env TRANSFORMERS_OFFLINE=1", start_cognee)
+        self.assertNotIn("COGNEE_SKIP_CONNECTION_TEST", start_cognee)
+
     def test_patch_applier_rejects_context_drift(self) -> None:
         patch = "--- a/example.py\n+++ b/example.py\n@@ -1 +1 @@\n-old\n+new\n"
         self.assertEqual(APPLIER._apply_unified_patch("old\n", patch), "new\n")

--- a/apps/_infra/cognee/tests/fixtures/test_provider_cognify_recovery_1_5_4.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_cognify_recovery_1_5_4.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Verify the candidate Cognify evidence and exact-run recovery helpers."""
+
+import asyncio
+import hashlib
+import importlib.util
+import sys
+import types
+import unittest
+from enum import Enum
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID, uuid4, uuid5
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[5]
+PATCH_DIRECTORY = REPOSITORY_ROOT / "apps/_infra/cognee/tests/candidates/1.5.4/patches"
+APPLIER_PATH = PATCH_DIRECTORY / "apply-source-patch.py"
+APPLIER_SPEC = importlib.util.spec_from_file_location("candidate_source_patch", APPLIER_PATH)
+if APPLIER_SPEC is None or APPLIER_SPEC.loader is None:
+    raise RuntimeError("Unable to load the candidate source patch helper")
+APPLIER = importlib.util.module_from_spec(APPLIER_SPEC)
+APPLIER_SPEC.loader.exec_module(APPLIER)
+
+
+def _new_module_source(patch_name: str) -> str:
+    patch = (PATCH_DIRECTORY / patch_name).read_text(encoding="utf-8")
+    return APPLIER._apply_unified_patch("", patch)
+
+
+def _load_evidence_module() -> types.ModuleType:
+    source = _new_module_source("cognify-input-evidence.patch").replace(
+        "from cognee.infrastructure.files.utils.open_data_file import open_data_file",
+        "open_data_file = None",
+    )
+    module = types.ModuleType("candidate_cognify_input_evidence")
+    exec(compile(source, "cognify_input_evidence.py", "exec"), module.__dict__)
+    return module
+
+
+class _Status(Enum):
+    DATASET_PROCESSING_STARTED = "started"
+    DATASET_PROCESSING_COMPLETED = "completed"
+    DATASET_PROCESSING_ERRORED = "errored"
+    UNKNOWN = "unknown"
+
+
+class _RunInfo:
+    def __init__(self, **values):
+        self.__dict__.update(values)
+
+
+class _PipelineRun:
+    pass
+
+
+def _load_recovery_module(evidence_module: types.ModuleType) -> types.ModuleType:
+    source = _new_module_source("cognify-run-recovery.patch")
+    source = source.replace("from sqlalchemy import select", "select = None")
+    source = source.replace(
+        "from cognee.infrastructure.databases.relational import get_relational_engine",
+        "get_relational_engine = None",
+    )
+    source = source.replace(
+        "from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus",
+        "PipelineRun = _PipelineRun\nPipelineRunStatus = _Status",
+    )
+    source = source.replace(
+        "from cognee.modules.pipelines.models.PipelineRunInfo import "
+        "PipelineRunCompleted, PipelineRunErrored",
+        "PipelineRunCompleted = _RunInfo\nPipelineRunErrored = _RunInfo",
+    )
+    source = source.replace(
+        "from cognee.modules.pipelines.utils import generate_pipeline_run_id",
+        "generate_pipeline_run_id = _generate_pipeline_run_id",
+    )
+    source = source.replace(
+        "from .cognify_input_evidence import build_cognify_input_evidence",
+        "build_cognify_input_evidence = _build_cognify_input_evidence",
+    )
+    name = "candidate_cognify_run_recovery"
+    module = types.ModuleType(name)
+    module.__dict__.update(
+        {
+            "_PipelineRun": _PipelineRun,
+            "_Status": _Status,
+            "_RunInfo": _RunInfo,
+            "_generate_pipeline_run_id": lambda pipeline_id, dataset_id, operation_id: uuid5(
+                pipeline_id, str(operation_id)
+            ),
+            "_build_cognify_input_evidence": evidence_module.build_cognify_input_evidence,
+        }
+    )
+    sys.modules[name] = module
+    exec(compile(source, "cognify_run_recovery.py", "exec"), module.__dict__)
+    return module
+
+
+def _row(dataset_id: UUID, owner_id: UUID, *, content: bytes = b"fact") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(),
+        dataset_id=dataset_id,
+        owner_id=owner_id,
+        tenant_id=None,
+        raw_data_location="ignored",
+        name="fact.txt",
+        label=None,
+        extension=".txt",
+        original_extension=".txt",
+        mime_type="text/plain",
+        original_mime_type="text/plain",
+        loader_engine="text",
+        content_hash=hashlib.sha256(content).hexdigest(),
+        raw_content_hash=hashlib.sha256(content).hexdigest(),
+        external_metadata={"source": "test"},
+        system_metadata={"route": "standard"},
+        node_set=["memory"],
+        importance_weight=1.0,
+        pipeline_status={"cognify_pipeline": "DATASET_PROCESSING_INITIATED"},
+        content=content,
+    )
+
+
+async def _raw(row_by_location: dict[str, bytes], location: str) -> bytes:
+    return row_by_location[location]
+
+
+class CandidateCognifyRecovery154Test(unittest.TestCase):
+    def setUp(self) -> None:
+        self.evidence = _load_evidence_module()
+        self.recovery = _load_recovery_module(self.evidence)
+        self.user = SimpleNamespace(id=uuid4(), tenant_id=None)
+        self.dataset = SimpleNamespace(id=uuid4(), owner_id=self.user.id, name="opaque")
+
+    def _evidence(self, rows: list[SimpleNamespace]):
+        locations = {}
+        for index, row in enumerate(rows):
+            row.raw_data_location = f"raw-{index}"
+            locations[row.raw_data_location] = row.content
+
+        async def read(location: str) -> bytes:
+            return await _raw(locations, location)
+
+        return asyncio.run(
+            self.evidence.build_cognify_input_evidence(self.dataset, self.user, rows, read)
+        )
+
+    def test_snapshot_is_order_independent_and_changes_with_effect_input(self) -> None:
+        first = _row(self.dataset.id, self.user.id, content=b"alpha")
+        second = _row(self.dataset.id, self.user.id, content=b"beta")
+        digest, projected = self._evidence([first, second])
+        reverse, reverse_projected = self._evidence([second, first])
+        self.assertEqual(reverse, digest)
+        self.assertEqual(reverse_projected, projected)
+        second.pipeline_status["cognify_pipeline"] = "DATASET_PROCESSING_COMPLETED"
+        changed, _ = self._evidence([first, second])
+        self.assertNotEqual(changed, digest)
+        second.content = b"changed"
+        changed_bytes, _ = self._evidence([first, second])
+        self.assertNotEqual(changed_bytes, changed)
+
+    def test_snapshot_rejects_foreign_duplicate_and_oversized_data(self) -> None:
+        row = _row(self.dataset.id, self.user.id)
+        foreign = _row(uuid4(), self.user.id)
+        with self.assertRaisesRegex(ValueError, "foreign"):
+            self._evidence([foreign])
+        duplicate = _row(self.dataset.id, self.user.id)
+        duplicate.id = row.id
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            self._evidence([row, duplicate])
+        row.content = b"x" * (self.evidence.MAXIMUM_DOCUMENT_BYTES + 1)
+        with self.assertRaisesRegex(ValueError, "byte limit"):
+            self._evidence([row])
+        self.dataset.owner_id = uuid4()
+        with self.assertRaises(PermissionError):
+            self._evidence([])
+
+    def _history_row(self, status: _Status, operation_id: UUID, request: str, evidence: str):
+        return SimpleNamespace(
+            pipeline_id=self.pipeline_id,
+            pipeline_name="cognify_pipeline",
+            operation_name="cognify_pipeline",
+            dataset_id=self.dataset.id,
+            user_id=self.user.id,
+            tenant_id=None,
+            status=status,
+            run_info={
+                "opencrane_cognify": {
+                    "operation_id": str(operation_id),
+                    "request_digest": request,
+                    "input_evidence_digest": evidence,
+                }
+            },
+            error_class="SyntheticError",
+            error_message="Synthetic failure",
+        )
+
+    def test_terminal_history_replays_exact_receipt(self) -> None:
+        self.pipeline_id = uuid4()
+        operation = uuid4()
+        request = "sha256:" + "1" * 64
+        evidence = "sha256:" + "2" * 64
+        run_id = uuid5(self.pipeline_id, str(operation))
+        started = self._history_row(_Status.DATASET_PROCESSING_STARTED, operation, request, evidence)
+        completed = self._history_row(_Status.DATASET_PROCESSING_COMPLETED, operation, request, evidence)
+        replay = self.recovery._plan_saved_history(
+            [started, completed], self.pipeline_id, "cognify_pipeline", self.dataset,
+            self.user, operation, request, evidence, run_id,
+        )
+        self.assertEqual(replay.run_info.pipeline_run_id, run_id)
+        self.assertEqual(replay.run_info.operation_id, operation)
+        self.assertEqual(replay.run_info.input_evidence_digest, evidence)
+        errored = self._history_row(
+            _Status.DATASET_PROCESSING_ERRORED, operation, request, evidence
+        )
+        failed = self.recovery._plan_saved_history(
+            [started, errored], self.pipeline_id, "cognify_pipeline", self.dataset,
+            self.user, operation, request, evidence, run_id,
+        )
+        self.assertEqual(failed.run_info.error_class, "SyntheticError")
+        self.assertEqual(failed.run_info.payload, "Saved Cognify run errored")
+
+    def test_started_and_contradictory_history_require_recovery(self) -> None:
+        self.pipeline_id = uuid4()
+        operation = uuid4()
+        request = "sha256:" + "3" * 64
+        evidence = "sha256:" + "4" * 64
+        run_id = uuid5(self.pipeline_id, str(operation))
+        started = self._history_row(_Status.DATASET_PROCESSING_STARTED, operation, request, evidence)
+        with self.assertRaises(self.recovery.CognifyRecoveryRequiredError):
+            self.recovery._plan_saved_history(
+                [started], self.pipeline_id, "cognify_pipeline", self.dataset,
+                self.user, operation, request, evidence, run_id,
+            )
+        terminal = self._history_row(_Status.DATASET_PROCESSING_COMPLETED, operation, request, evidence)
+        with self.assertRaises(self.recovery.CognifyRecoveryRequiredError):
+            self.recovery._plan_saved_history(
+                [started, terminal, terminal], self.pipeline_id, "cognify_pipeline", self.dataset,
+                self.user, operation, request, evidence, run_id,
+            )
+        with self.assertRaises(self.recovery.CognifyRecoveryRequiredError):
+            self.recovery._plan_saved_history(
+                [terminal, started], self.pipeline_id, "cognify_pipeline", self.dataset,
+                self.user, operation, request, evidence, run_id,
+            )
+
+    def test_saved_coordinate_or_digest_mismatch_fails_closed(self) -> None:
+        self.pipeline_id = uuid4()
+        operation = uuid4()
+        request = "sha256:" + "5" * 64
+        evidence = "sha256:" + "6" * 64
+        run_id = uuid5(self.pipeline_id, str(operation))
+        started = self._history_row(_Status.DATASET_PROCESSING_STARTED, operation, request, evidence)
+        started.dataset_id = uuid4()
+        with self.assertRaises(self.recovery.CognifyRecoveryRequiredError):
+            self.recovery._plan_saved_history(
+                [started], self.pipeline_id, "cognify_pipeline", self.dataset,
+                self.user, operation, request, evidence, run_id,
+            )
+        started.dataset_id = self.dataset.id
+        with self.assertRaises(self.recovery.CognifyRecoveryRequiredError):
+            self.recovery._plan_saved_history(
+                [started], self.pipeline_id, "cognify_pipeline", self.dataset,
+                self.user, operation, request, "sha256:" + "7" * 64, run_id,
+            )
+        terminal = self._history_row(
+            _Status.DATASET_PROCESSING_COMPLETED,
+            operation,
+            "sha256:" + "8" * 64,
+            evidence,
+        )
+        with self.assertRaises(self.recovery.CognifyRecoveryRequiredError):
+            self.recovery._plan_saved_history(
+                [started, terminal], self.pipeline_id, "cognify_pipeline", self.dataset,
+                self.user, operation, request, evidence, run_id,
+            )
+        coherent_terminal = self._history_row(
+            _Status.DATASET_PROCESSING_COMPLETED, operation, request, evidence
+        )
+        with self.assertRaises(self.recovery.CognifyRecoveryRequiredError):
+            self.recovery._plan_saved_history(
+                [started, coherent_terminal], self.pipeline_id, "cognify_pipeline", self.dataset,
+                self.user, operation, request, "sha256:" + "9" * 64, run_id,
+            )
+        started.run_info = {}
+        with self.assertRaises(self.recovery.CognifyRecoveryRequiredError):
+            self.recovery._plan_saved_history(
+                [started], self.pipeline_id, "cognify_pipeline", self.dataset,
+                self.user, operation, request, evidence, run_id,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/_infra/cognee/tests/fixtures/test_provider_contract_1_5_4.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_contract_1_5_4.py
@@ -267,6 +267,11 @@ class CandidateDatasetIdentityTest(unittest.TestCase):
                     "verify_dataset_acl_recovery_after_restart",
                     _verify_acl,
                 ),
+                patch.object(
+                    provider_contract,
+                    "verify_cognify_recovery_after_restart",
+                    return_value={},
+                ),
                 patch.object(provider_contract, "recover_identity", _fail_recovery),
                 self.assertRaisesRegex(AssertionError, "distinct chunks"),
             ):

--- a/apps/_infra/cognee/tests/fixtures/test_provider_dataset_acl_recovery_1_5_4.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_dataset_acl_recovery_1_5_4.py
@@ -86,7 +86,7 @@ class ProviderDatasetAclRecovery154Test(unittest.TestCase):
                 "cognee.api.v1.datasets.routers.get_datasets_router",
                 "dataset-route-acl-recovery.patch",
                 "87b3ff9da756bbf730237197cdedcd26278f27e0c17f19ae887b77c9c0ccc241",
-                "0f6226908897c14c97c17a449f715e461201e801a8bab5832b7fd0f8766a551e",
+                "677afc0b7bb6c2633cf2c01d59a18f72dee0a2131ea6f49b16a42c72420baafb",
             ),
             (
                 "cognee.modules.data.methods.create_authorized_dataset",
@@ -114,7 +114,7 @@ class ProviderDatasetAclRecovery154Test(unittest.TestCase):
         )
         self.assertIn("-from cognee.modules.data.methods import get_datasets_by_name", source_patch)
         self.assertIn("-            datasets = await get_datasets_by_name", source_patch)
-        self.assertIn("             dataset = await create_authorized_dataset", source_patch)
+        self.assertNotIn("-            dataset = await create_authorized_dataset", source_patch)
 
     def test_authorized_dataset_patch_holds_one_lock_through_all_grants(self) -> None:
         source_patch = (PATCHES / "create-authorized-dataset-acl-recovery.patch").read_text(
@@ -311,6 +311,7 @@ class ProviderDatasetAclRecovery154Test(unittest.TestCase):
                     {
                         "datasetProvisioning": provisioned,
                         "datasetAclRecovery": acl_before,
+                        "cognifyRecovery": {"operationId": str(uuid.uuid4())},
                     }
                 ),
                 encoding="utf-8",
@@ -336,6 +337,11 @@ class ProviderDatasetAclRecovery154Test(unittest.TestCase):
                     provider_contract,
                     "verify_dataset_acl_recovery_after_restart",
                     side_effect=verify_acl,
+                ),
+                patch.object(
+                    provider_contract,
+                    "verify_cognify_recovery_after_restart",
+                    side_effect=lambda _api, evidence: evidence,
                 ),
                 patch.object(
                     provider_contract,

--- a/apps/_infra/cognee/tests/fixtures/test_provider_dataset_provisioning_1_5_4.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_dataset_provisioning_1_5_4.py
@@ -121,6 +121,11 @@ class ProviderDatasetProvisioning154Test(unittest.TestCase):
                     "prepare_identity",
                     side_effect=lambda _api, evidence, _proxy: evidence,
                 ),
+                patch.object(
+                    provider_contract,
+                    "prepare_cognify_recovery",
+                    return_value={"operationId": str(uuid.uuid4())},
+                ),
             ):
                 provider_contract.main()
 

--- a/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_cognify_recovery_contract.py
+++ b/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_cognify_recovery_contract.py
@@ -1,0 +1,439 @@
+"""Qualify exact Cognify recovery against the installed 1.5.4 candidate."""
+
+import asyncio
+import hashlib
+import http.client
+import json
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Protocol
+
+
+class CognifyRecoveryApi(Protocol):
+    """Expose only provider calls needed by the Cognify recovery contract."""
+
+    _access_token: str | None
+
+    def add(self, dataset_id: str, filename: str, content: bytes) -> Any: ...
+
+    def create_dataset(self, name: str) -> dict[str, Any]: ...
+
+    def delete(self, dataset_id: str, document_id: str) -> None: ...
+
+    def json(
+        self,
+        method: str,
+        path: str,
+        value: Any | None = None,
+        timeout: int = 300,
+        accepted: tuple[int, ...] = (200,),
+    ) -> Any: ...
+
+
+def _opaque_name(namespace: str) -> str:
+    digest = hashlib.sha256(f"{namespace}:cognify-recovery".encode()).hexdigest()
+    return f"ocm-{digest}"
+
+
+def _evidence(api: CognifyRecoveryApi, dataset_id: str) -> dict[str, Any]:
+    value = api.json(
+        "GET",
+        f"/api/v1/datasets/{dataset_id}/data?include_cognify_evidence=true",
+    )
+    if not isinstance(value, dict) or set(value) != {
+        "datasetId",
+        "inputEvidenceDigest",
+        "data",
+    }:
+        raise AssertionError("Cognify evidence response has an invalid envelope")
+    if value["datasetId"] != dataset_id:
+        raise AssertionError("Cognify evidence identifies another dataset")
+    digest = value["inputEvidenceDigest"]
+    rows = value["data"]
+    if (
+        not isinstance(digest, str)
+        or len(digest) != 71
+        or not digest.startswith("sha256:")
+        or not isinstance(rows, list)
+        or not rows
+    ):
+        raise AssertionError("Cognify evidence is missing its bounded document snapshot")
+    document_ids = [row.get("id") for row in rows if isinstance(row, dict)]
+    if len(document_ids) != len(rows) or len(set(document_ids)) != len(rows):
+        raise AssertionError("Cognify evidence contains malformed or duplicate documents")
+    for row in rows:
+        if not isinstance(row.get("contentDigest"), str) or not isinstance(
+            row.get("byteLength"), int
+        ):
+            raise AssertionError("Cognify evidence omits safe raw-byte coordinates")
+    return value
+
+
+def _cognify_body(dataset_id: str, operation_id: str, evidence_digest: str) -> dict[str, Any]:
+    return {
+        "dataset_ids": [dataset_id],
+        "run_in_background": False,
+        "chunk_size": 128,
+        "operation_id": operation_id,
+        "expected_input_evidence_digest": evidence_digest,
+    }
+
+
+def _stub_request_count() -> int:
+    """Count request metadata; the shared stub log never stores input content."""
+    path = Path("/contract-output/stub-requests.jsonl")
+    if not path.is_file():
+        raise AssertionError("Cognify recovery fixture cannot read the provider request log")
+    return sum(1 for line in path.read_text(encoding="utf-8").splitlines() if line)
+
+
+def _run_id(dataset_id: str, owner_id: str, operation_id: str) -> str:
+    from cognee.modules.pipelines.utils import generate_pipeline_id, generate_pipeline_run_id
+
+    dataset_uuid = uuid.UUID(dataset_id)
+    pipeline_id = generate_pipeline_id(
+        uuid.UUID(owner_id), dataset_uuid, "cognify_pipeline"
+    )
+    return str(
+        generate_pipeline_run_id(
+            pipeline_id,
+            dataset_uuid,
+            operation_id=uuid.UUID(operation_id),
+        )
+    )
+
+
+def _require_conflict(api: CognifyRecoveryApi, body: dict[str, Any]) -> None:
+    try:
+        api.json("POST", "/api/v1/cognify", body, timeout=30)
+    except Exception as failure:
+        if getattr(failure, "status", None) == 409:
+            return
+        raise
+    raise AssertionError("Stale Cognify input evidence did not conflict")
+
+
+def _require_recovery(api: CognifyRecoveryApi, body: dict[str, Any]) -> None:
+    try:
+        api.json("POST", "/api/v1/cognify", body, timeout=30)
+    except Exception as failure:
+        if getattr(failure, "status", None) == 503:
+            return
+        raise
+    raise AssertionError("Saved Cognify history did not require recovery")
+
+
+def _terminal(value: Any, dataset_id: str, operation_id: str, evidence_digest: str) -> dict[str, str]:
+    if not isinstance(value, dict) or set(value) != {dataset_id}:
+        raise AssertionError("Recovered Cognify response does not identify the exact dataset")
+    run = value[dataset_id]
+    if not isinstance(run, dict) or run.get("status") != "PipelineRunCompleted":
+        raise AssertionError("Recovered Cognify response is not a completed run")
+    coordinates = {
+        "datasetId": str(run.get("dataset_id")),
+        "operationId": str(run.get("operation_id")),
+        "pipelineRunId": str(run.get("pipeline_run_id")),
+        "inputEvidenceDigest": str(run.get("input_evidence_digest")),
+    }
+    if coordinates["datasetId"] != dataset_id or coordinates["operationId"] != operation_id:
+        raise AssertionError("Recovered Cognify response changed command coordinates")
+    if coordinates["inputEvidenceDigest"] != evidence_digest:
+        raise AssertionError("Recovered Cognify response changed input evidence")
+    uuid.UUID(coordinates["pipelineRunId"])
+    return coordinates
+
+
+def _drop_completed_response(
+    api: CognifyRecoveryApi,
+    drop_proxy: str,
+    body: dict[str, Any],
+) -> None:
+    token = api._access_token
+    if not isinstance(token, str) or not token:
+        raise AssertionError("Dropped Cognify response requires authentication")
+    host, port = drop_proxy.rsplit(":", 1)
+    payload = json.dumps(body, separators=(",", ":")).encode()
+    connection = http.client.HTTPConnection(host, int(port), timeout=610)
+    try:
+        connection.request(
+            "POST",
+            "/api/v1/cognify",
+            body=payload,
+            headers={
+                "accept": "application/json",
+                "authorization": f"Bearer {token}",
+                "content-length": str(len(payload)),
+                "content-type": "application/json",
+            },
+        )
+        response = connection.getresponse()
+        response.read()
+    except (http.client.RemoteDisconnected, ConnectionResetError):
+        return
+    finally:
+        connection.close()
+    raise AssertionError("Commit-then-drop proxy returned the Cognify response")
+
+
+async def _history_count(pipeline_run_id: str) -> int:
+    from sqlalchemy import func, select
+
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.modules.pipelines.models import PipelineRun
+
+    async with get_relational_engine().get_async_session() as session:
+        return int(
+            await session.scalar(
+                select(func.count()).select_from(PipelineRun).where(
+                    PipelineRun.pipeline_run_id == uuid.UUID(pipeline_run_id)
+                )
+            )
+        )
+
+
+async def _insert_started(
+    dataset_id: str,
+    owner_id: str,
+    operation_id: str,
+    evidence_digest: str,
+) -> str:
+    from cognee.infrastructure.databases.relational import get_relational_engine
+    from cognee.modules.pipelines.models import PipelineRun, PipelineRunStatus
+    from cognee.modules.pipelines.operations.cognify_input_evidence import (
+        build_cognify_request_digest,
+    )
+    from cognee.modules.pipelines.utils import generate_pipeline_id, generate_pipeline_run_id
+    from cognee.modules.users.models import User
+
+    dataset_uuid = uuid.UUID(dataset_id)
+    owner_uuid = uuid.UUID(owner_id)
+    operation_uuid = uuid.UUID(operation_id)
+    pipeline_id = generate_pipeline_id(owner_uuid, dataset_uuid, "cognify_pipeline")
+    pipeline_run_id = generate_pipeline_run_id(
+        pipeline_id,
+        dataset_uuid,
+        operation_id=operation_uuid,
+    )
+    request_digest = build_cognify_request_digest(
+        {
+            "pipeline": "cognify_pipeline",
+            "chunkSize": 128,
+            "dataPerBatch": 20,
+            "incrementalLoading": True,
+            "dataCache": True,
+            "graphModel": "KnowledgeGraph",
+        }
+    )
+    async with get_relational_engine().get_async_session() as session:
+        user = await session.get(User, owner_uuid)
+        if user is None:
+            raise AssertionError("Cognify recovery fixture cannot resolve its owner")
+        row = PipelineRun(
+            pipeline_run_id=pipeline_run_id,
+            pipeline_name="cognify_pipeline",
+            pipeline_id=pipeline_id,
+            status=PipelineRunStatus.DATASET_PROCESSING_STARTED,
+            dataset_id=dataset_uuid,
+            user_id=owner_uuid,
+            tenant_id=getattr(user, "tenant_id", None),
+            operation_name="cognify_pipeline",
+            run_info={
+                "data": [],
+                "opencrane_cognify": {
+                    "operation_id": operation_id,
+                    "request_digest": request_digest,
+                    "input_evidence_digest": evidence_digest,
+                },
+            },
+        )
+        session.add(row)
+        await session.commit()
+    return str(pipeline_run_id)
+
+
+def prepare_cognify_recovery(
+    api: CognifyRecoveryApi,
+    namespace: str,
+    drop_proxy: str,
+) -> dict[str, Any]:
+    """Create terminal and interrupted histories for restart qualification."""
+    dataset = api.create_dataset(_opaque_name(namespace))
+    dataset_id = str(dataset.get("id"))
+    owner_id = str(dataset.get("ownerId"))
+    uuid.UUID(dataset_id)
+    uuid.UUID(owner_id)
+    api.add(dataset_id, "memory.txt", b"Synthetic Cognify recovery evidence.\n")
+    snapshot = _evidence(api, dataset_id)
+    operation_id = str(uuid.uuid4())
+    body = _cognify_body(dataset_id, operation_id, snapshot["inputEvidenceDigest"])
+    _drop_completed_response(api, drop_proxy, body)
+    completed_request_count = _stub_request_count()
+    terminal = _terminal(
+        api.json("POST", "/api/v1/cognify", body, timeout=600),
+        dataset_id,
+        operation_id,
+        snapshot["inputEvidenceDigest"],
+    )
+    if asyncio.run(_history_count(terminal["pipelineRunId"])) != 2:
+        raise AssertionError("Cognify terminal replay appended another run event")
+    if _stub_request_count() != completed_request_count:
+        raise AssertionError("Cognify terminal replay dispatched provider work")
+    changed_evidence_body = _cognify_body(
+        dataset_id,
+        operation_id,
+        "sha256:" + "f" * 64,
+    )
+    _require_recovery(api, changed_evidence_body)
+    if asyncio.run(_history_count(terminal["pipelineRunId"])) != 2:
+        raise AssertionError("Mismatched saved Cognify evidence changed run history")
+    if _stub_request_count() != completed_request_count:
+        raise AssertionError("Mismatched saved Cognify evidence dispatched provider work")
+
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        replays = list(
+            pool.map(
+                lambda _index: _terminal(
+                    api.json("POST", "/api/v1/cognify", body, timeout=600),
+                    dataset_id,
+                    operation_id,
+                    snapshot["inputEvidenceDigest"],
+                ),
+                range(3),
+            )
+        )
+    if any(replay != terminal for replay in replays):
+        raise AssertionError("Concurrent Cognify replay changed its terminal receipt")
+    if asyncio.run(_history_count(terminal["pipelineRunId"])) != 2:
+        raise AssertionError("Concurrent Cognify replay appended another run event")
+    if _stub_request_count() != completed_request_count:
+        raise AssertionError("Concurrent Cognify replay dispatched provider work")
+    print("CASE dropped_and_concurrent_cognify_replay_returns_exact_terminal PASS")
+
+    before_add = _evidence(api, dataset_id)
+    added_content = b"Cognify evidence changed after the locked snapshot.\n"
+    api.add(dataset_id, "later.txt", added_content)
+    after_add = _evidence(api, dataset_id)
+    added_digest = f"sha256:{hashlib.sha256(added_content).hexdigest()}"
+    added = [
+        row
+        for row in after_add["data"]
+        if isinstance(row, dict) and row.get("contentDigest") == added_digest
+    ]
+    if len(added) != 1 or not isinstance(added[0].get("id"), str):
+        raise AssertionError("Added document is absent from the locked Cognify snapshot")
+    add_operation_id = str(uuid.uuid4())
+    before_stale_add = _stub_request_count()
+    _require_conflict(
+        api,
+        _cognify_body(dataset_id, add_operation_id, before_add["inputEvidenceDigest"]),
+    )
+    if asyncio.run(_history_count(_run_id(dataset_id, owner_id, add_operation_id))) != 0:
+        raise AssertionError("Stale add snapshot wrote a Cognify run")
+    if _stub_request_count() != before_stale_add:
+        raise AssertionError("Stale add snapshot dispatched provider work")
+
+    api.delete(dataset_id, added[0]["id"])
+    delete_operation_id = str(uuid.uuid4())
+    before_stale_delete = _stub_request_count()
+    _require_conflict(
+        api,
+        _cognify_body(
+            dataset_id,
+            delete_operation_id,
+            after_add["inputEvidenceDigest"],
+        ),
+    )
+    if asyncio.run(_history_count(_run_id(dataset_id, owner_id, delete_operation_id))) != 0:
+        raise AssertionError("Stale delete snapshot wrote a Cognify run")
+    if _stub_request_count() != before_stale_delete:
+        raise AssertionError("Stale delete snapshot dispatched provider work")
+    print("CASE stale_add_and_delete_snapshots_refuse_cognify_dispatch PASS")
+
+    interrupted_operation_id = str(uuid.uuid4())
+    interrupted_run_id = asyncio.run(
+        _insert_started(
+            dataset_id,
+            owner_id,
+            interrupted_operation_id,
+            snapshot["inputEvidenceDigest"],
+        )
+    )
+    return {
+        "datasetId": dataset_id,
+        "ownerId": owner_id,
+        "operationId": operation_id,
+        "pipelineRunId": terminal["pipelineRunId"],
+        "inputEvidenceDigest": terminal["inputEvidenceDigest"],
+        "interruptedOperationId": interrupted_operation_id,
+        "interruptedPipelineRunId": interrupted_run_id,
+    }
+
+
+def verify_cognify_recovery_after_restart(
+    api: CognifyRecoveryApi,
+    evidence: Any,
+) -> dict[str, Any]:
+    """Reauthenticate after restart and require terminal replay plus Started refusal."""
+    required = {
+        "datasetId",
+        "ownerId",
+        "operationId",
+        "pipelineRunId",
+        "inputEvidenceDigest",
+        "interruptedOperationId",
+        "interruptedPipelineRunId",
+    }
+    if not isinstance(evidence, dict) or set(evidence) != required:
+        raise AssertionError("Saved Cognify recovery evidence has an invalid shape")
+    for key in (
+        "datasetId",
+        "ownerId",
+        "operationId",
+        "pipelineRunId",
+        "interruptedOperationId",
+        "interruptedPipelineRunId",
+    ):
+        uuid.UUID(evidence[key])
+    request_count = _stub_request_count()
+    terminal = _terminal(
+        api.json(
+            "POST",
+            "/api/v1/cognify",
+            _cognify_body(
+                evidence["datasetId"],
+                evidence["operationId"],
+                evidence["inputEvidenceDigest"],
+            ),
+            timeout=600,
+        ),
+        evidence["datasetId"],
+        evidence["operationId"],
+        evidence["inputEvidenceDigest"],
+    )
+    if terminal["pipelineRunId"] != evidence["pipelineRunId"]:
+        raise AssertionError("Restart replay changed the completed pipeline run")
+    if _stub_request_count() != request_count:
+        raise AssertionError("Restart terminal replay dispatched provider work")
+    try:
+        api.json(
+            "POST",
+            "/api/v1/cognify",
+            _cognify_body(
+                evidence["datasetId"],
+                evidence["interruptedOperationId"],
+                evidence["inputEvidenceDigest"],
+            ),
+            timeout=30,
+        )
+    except Exception as failure:
+        if getattr(failure, "status", None) != 503:
+            raise
+    else:
+        raise AssertionError("Interrupted Cognify history did not require recovery")
+    if asyncio.run(_history_count(evidence["interruptedPipelineRunId"])) != 1:
+        raise AssertionError("Interrupted Cognify retry dispatched or appended another event")
+    if _stub_request_count() != request_count:
+        raise AssertionError("Interrupted Cognify retry dispatched provider work")
+    print("CASE cognify_terminal_and_started_histories_survive_restart PASS")
+    return evidence

--- a/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_contract.py
+++ b/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_contract.py
@@ -20,6 +20,10 @@ from v1_5_4.provider_dataset_provisioning_contract import (  # noqa: E402
     qualify_dataset_provisioning,
     verify_dataset_provisioning_after_restart,
 )
+from v1_5_4.provider_cognify_recovery_contract import (  # noqa: E402
+    prepare_cognify_recovery,
+    verify_cognify_recovery_after_restart,
+)
 from v1_5_4.provider_identity_contract import prepare_identity, recover_identity  # noqa: E402
 from v1_5_4.provider_isolation_contract import prepare_isolation  # noqa: E402
 
@@ -102,6 +106,9 @@ def main() -> None:
                 evidence["datasetProvisioning"] = dataset_provisioning
                 evidence["datasetAclRecovery"] = dataset_acl_recovery
                 evidence = prepare_identity(api, evidence, args.drop_proxy)
+                evidence["cognifyRecovery"] = prepare_cognify_recovery(
+                    api, args.namespace, args.drop_proxy
+                )
             state_path.write_text(
                 json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
             )
@@ -124,6 +131,11 @@ def main() -> None:
                     validated_evidence.get("datasetAclRecovery"),
                     args.namespace,
                     foreign_api,
+                )
+            )
+            validated_evidence["cognifyRecovery"] = (
+                verify_cognify_recovery_after_restart(
+                    api, validated_evidence.get("cognifyRecovery")
                 )
             )
             evidence = recover_identity(api, validated_evidence)

--- a/apps/_infra/cognee/tests/memory-contract-1.5.4.sh
+++ b/apps/_infra/cognee/tests/memory-contract-1.5.4.sh
@@ -226,6 +226,8 @@ _start_cognee()
     --env "ENABLE_BACKEND_ACCESS_CONTROL=$access_control" \
     --env "REQUIRE_AUTHENTICATION=$require_authentication" \
     --env AUTO_FEEDBACK=false \
+    --env HF_HUB_OFFLINE=1 \
+    --env TRANSFORMERS_OFFLINE=1 \
     --env DATA_ROOT_DIRECTORY=/cognee-storage/data \
     --env SYSTEM_ROOT_DIRECTORY=/cognee-storage/system \
     --env LLM_PROVIDER=openai \

--- a/apps/_infra/cognee/tests/memory-contract-1.5.4.sh
+++ b/apps/_infra/cognee/tests/memory-contract-1.5.4.sh
@@ -83,6 +83,8 @@ _write_failure_receipt()
     --positive "$positive_receipt" \
     --stub-log "$output_dir/stub-requests.jsonl" \
     --drop-log "$output_dir/commit-then-drop.jsonl" \
+    --expected-drop-path /api/v1/add \
+    --expected-drop-path /api/v1/cognify \
     --output "$output_dir/evidence.json" \
     --failure-status "$status" \
     --failed-case "$current_case" \
@@ -307,6 +309,8 @@ python3 "$fixture_dir/evidence_summary.py" \
   --positive "$output_dir/positive-deletion-restart.json" \
   --stub-log "$output_dir/stub-requests.jsonl" \
   --drop-log "$output_dir/commit-then-drop.jsonl" \
+  --expected-drop-path /api/v1/add \
+  --expected-drop-path /api/v1/cognify \
   --output "$output_dir/evidence.json" \
   | tee "$output_dir/evidence-summary.log"
 

--- a/apps/_infra/cognee/tests/memory-contract.sh
+++ b/apps/_infra/cognee/tests/memory-contract.sh
@@ -60,6 +60,7 @@ _cleanup()
       --positive "$output_dir/positive-recovery.json" \
       --stub-log "$output_dir/stub-requests.jsonl" \
       --drop-log "$output_dir/commit-then-drop.jsonl" \
+      --expected-drop-path /api/v1/add \
       --output "$output_dir/evidence.json" \
       --failure-status "$status" \
       --failed-case "$current_case" \
@@ -217,6 +218,7 @@ python3 "$fixture_dir/evidence_summary.py" \
   --positive "$output_dir/positive-recovery.json" \
   --stub-log "$output_dir/stub-requests.jsonl" \
   --drop-log "$output_dir/commit-then-drop.jsonl" \
+  --expected-drop-path /api/v1/add \
   --output "$output_dir/evidence.json" \
   | tee "$output_dir/evidence-summary.log"
 

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,30 @@
 # OpenCrane — Active Plan
 
+## Recover interrupted memory indexing — source implementation
+
+This slice starts directly above #874 at `b7acc1f94e24a41d0c151da252592c36dc613582`.
+It extends the disposable Cognee candidate's existing dataset-data and Cognify boundaries so an
+indexing operation is identified before dispatch. A bounded document-list receipt binds the exact
+raw content and processing metadata. Under the existing dataset lock, first admission compares
+that snapshot before saving Started; recovery reads the complete ordered history for the exact
+operation. Completed work replays its original receipt. Started, missing or contradictory history
+remains recovery-required and cannot start another indexing run.
+
+The repair adds no queue, workflow engine, persistence model or provider activation. It preserves
+the candidate's one-worker, one-replica and local-store restriction. Absurd and the OpenCrane
+operation owner will save the command; the gateway remains the provider and credential boundary.
+Gateway protocol/client integration and the complete Remember, Recall, Correct and Forget journey
+remain separate source work.
+
+All 68 local Cognee tests, including the 43 focused candidate tests, and Cognee lint pass. The patch
+applier reproduces the declared postimages from the pinned upstream source. Architecture post-review
+and independent correctness review pass. Production and candidate qualification each require
+their own exact dropped-response evidence; neither accepts the other profile.
+Installed-image tests count actual model and embedding requests across lost-response, concurrent and
+restarted replay, and reject a changed snapshot before first dispatch. Their runtime execution remains
+pending in exact-image CI on the pushed commit; source checks do not promote the candidate image or
+establish testv5 readiness.
+
 ## Recover interrupted memory dataset permissions — implementation and validation
 
 The deletion-repair candidate now passes its complete exact-image qualification in #872 at
@@ -30,7 +55,11 @@ preimage hashes as declarations of new modules. The correction adds their verifi
 1.5.4 hashes to that map. A regression loads the actual candidate declaration and image profile;
 it reproduces the failure before the correction. All 16 source-evidence tests and Cognee lint pass
 after the correction. The verifier and provider patches are unchanged.
-Candidate runtime qualification remains pending on the corrected commit.
+The manifest correction is pushed at `b7acc1f94e24a41d0c151da252592c36dc613582`.
+Successor run `34719384285`, candidate job `103622387219`, passes the complete exact-image
+qualification, including interrupted permission recovery, deletion recovery, isolation and restart.
+The separate production-provider job `103622387188` still fails; the candidate result does not
+promote the production image or qualify the product memory journey.
 
 Gateway HTTP handlers, provider operations and the server client are being prepared in parallel.
 Automatic approval review rejected deletion of the old client and tests, citing integration risk.

--- a/plan.md
+++ b/plan.md
@@ -21,9 +21,16 @@ applier reproduces the declared postimages from the pinned upstream source. Arch
 and independent correctness review pass. Production and candidate qualification each require
 their own exact dropped-response evidence; neither accepts the other profile.
 Installed-image tests count actual model and embedding requests across lost-response, concurrent and
-restarted replay, and reject a changed snapshot before first dispatch. Their runtime execution remains
-pending in exact-image CI on the pushed commit; source checks do not promote the candidate image or
-establish testv5 readiness.
+restarted replay, and reject a changed snapshot before first dispatch.
+
+The first exact-image run on draft #875 (`331f80a2500d8d5e1eac113e5bc33d4ced42a2de`)
+passed affected build/test/lint, database authority, KurrentDB and review topology. Both provider jobs
+failed. The candidate stopped on its first Add before any indexing-recovery request: external
+tokenizer discovery exhausted the connection-test deadline before reaching the synthetic provider.
+The reviewed harness repair disables that external discovery while retaining the actual synthetic
+model and embedding connection tests. All eight focused harness tests and Cognee lint pass.
+Exact-image indexing recovery remains unqualified until the repaired commit passes CI; source
+checks do not promote the candidate image or establish testv5 readiness.
 
 ## Recover interrupted memory dataset permissions — implementation and validation
 


### PR DESCRIPTION
## Problem and behavior

A lost Cognee indexing response currently leaves the caller without the randomly generated run ID.
Retrying can start more model or embedding work. This candidate repair gives the caller a saved
operation identity and binds the first dispatch to an exact input snapshot. The existing pipeline
history returns the completed receipt for that operation; an unfinished or contradictory history
remains recovery-required without another dispatch.

The existing dataset-data route can return bounded content digests and a digest of the full
processing input. Cognify compares that snapshot under the existing dataset lock before admitting
work. Completed replays retain their original evidence even when the dataset later changes.

## Ownership and stack

- Base: PR #874, `feat/0.12-memory-gateway-operations`, at
  `b7acc1f94e24a41d0c151da252592c36dc613582`.
- Reviewed head: `320a16caff0fa6511825c396c91c4ce4371fb517`.
- This changes only the disposable Cognee 1.5.4 candidate, its source attestations, qualification
  fixtures and owning documentation. It does not select or publish a production provider image.
- Absurd remains the server workflow owner. The gateway remains the private provider boundary.
  The provider reuses its existing dataset lock and pipeline history; no queue, scheduler, outbox
  or new persistence model is introduced.
- The candidate remains restricted to one worker and replica with its existing local store.
- Gateway protocol/client changes and Remember, Recall, Correct and Forget integration follow
  separately.

## Validation

- The original recovery source at `331f80a25` passed all 68 local Cognee tests.
- The tokenizer harness follow-up at `320a16caf` passed its eight focused tests and uncached Cognee lint.
  Independent review of the exact two-file follow-up passed; unrelated source checks are unchanged.
- Evidence-summary regressions: all four tests pass for the distinct production and candidate
  expectations, including missing, duplicate and invalid records.
- Focused candidate fixture suite through `nx exec -p cognee`: 43 tests pass (a subset of the full
  suite).
- `NX_DAEMON=false NX_NO_CLOUD=true npm exec -- nx run cognee:lint`: passes shell syntax and Python
  compilation checks.
- The patch applier reproduces every declared postimage from the pinned official upstream sources;
  all 28 files match the frozen review manifest.
- Module-growth check: zero errors; the review also inventories the narrowly patched upstream
  modules and the two new evidence/recovery helpers.
- Independent correctness review: PASS with no findings on the final 28-file manifest. Architecture
  preflight and post-review: PASS; the final follow-up changes only qualification fixtures.

Installed-image tests now count actual stub model/embedding requests across dropped-response,
concurrent and restarted replay, and test stale input snapshots before first admission. Their
first execution at `331f80a25` stopped before recovery: external tokenizer DNS retries exhausted
the actual LLM connection-test deadline before any synthetic request. The candidate harness now
uses Hugging Face offline mode while retaining the model and embedding checks. Exact-image candidate qualification
passed on `320a16caff0fa6511825c396c91c4ce4371fb517`: [run 34724401692, candidate job 103635957933](https://github.com/elewa-git/opencrane/actions/runs/34724401692/job/103635957933).
The separate existing production-provider job failed, so the overall workflow is not green.

Testv5/live qualification remains a separate gate. No live provider, model, credentials, deployment
or testv5 data were used or changed by this source work.

## Review order

#831 → #843 → #849 → #850 → #851 → #852 → #853 → #854 → #855 → #856 → #857 → #858 → #862 → #863 → #867 → #868 → #869 → #870 → #871 → #872 → #873 → #874 → #875.
