### PR TITLE
Preserve personal memory operations across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ The 0.11 baseline remains under review; this is not a release or a completed MVP
 
 ### Added
 
+- **Memory command integrations can preserve one operation across retries and restarts.** The
+  personal-memory repository retains the original source, command and provider receipts, adopts a
+  new dataset atomically, and hides a fact when Forget is admitted. Concurrent retries return the
+  saved operation; rejected transactions leave neither partial adoption nor a partial command.
+  Authenticated product commands, Absurd task admission and the complete memory journey remain
+  unfinished.
+
 - **Conversation participants can open ready uploaded files from the Files panel.** Supported
   previews and downloads use the current authorized content read, show loading and safe retry
   feedback, and discard pending results when the selected conversation or access changes.

--- a/apps/opencrane/package.json
+++ b/apps/opencrane/package.json
@@ -115,7 +115,7 @@
         "options": {
           "cwd": "apps/opencrane",
           "commands": [
-            "sh ../../scripts/run-postgres-authority-tests.sh prisma/tests/authorization-active-grant-uniqueness.sql prisma/tests/phase-d-authority-integration.sql prisma/tests/skill-authoring-validation-authority.sql",
+            "sh ../../scripts/run-postgres-authority-tests.sh prisma/tests/authorization-active-grant-uniqueness.sql prisma/tests/phase-d-authority-integration.sql prisma/tests/skill-authoring-validation-authority.sql prisma/tests/personal-memory-operations.sql",
             "vitest run src/bootstrap/conversations/__tests__/conversation-tool-proposal.sql.test.ts",
             "vitest run src/bootstrap/conversations/__tests__/conversation-tool-approval.sql.test.ts",
             "vitest run src/bootstrap/conversations/__tests__/conversation-tool-result.sql.test.ts",

--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -149,13 +149,25 @@ CREATE TYPE "McpApprovalStatus" AS ENUM ('pending-review', 'approved', 'publishe
 CREATE TYPE "McpConnectionStatus" AS ENUM ('needs-credential', 'credentialless');
 
 -- CreateEnum
-CREATE TYPE "MemoryDatasetState" AS ENUM ('active', 'retired');
+CREATE TYPE "MemoryDatasetState" AS ENUM ('provisioning', 'active', 'retired');
 
 -- CreateEnum
 CREATE TYPE "MemoryFactState" AS ENUM ('active', 'corrected', 'forget_pending', 'forgotten');
 
 -- CreateEnum
 CREATE TYPE "MemoryConsentState" AS ENUM ('explicit', 'confirmed');
+
+-- CreateEnum
+CREATE TYPE "PersonalMemoryOperationKind" AS ENUM ('remember', 'correct', 'forget');
+
+-- CreateEnum
+CREATE TYPE "PersonalMemoryOperationPhase" AS ENUM ('dataset_ensure_pending', 'document_add_pending', 'cognify_pending', 'catalog_commit_pending', 'prior_document_delete_pending', 'document_delete_pending', 'catalog_finalize_pending', 'recovery_required', 'completed');
+
+-- CreateEnum
+CREATE TYPE "PersonalMemoryOperationFailureCode" AS ENUM ('authority_ended', 'dataset_unavailable', 'source_unavailable', 'document_conflict', 'index_input_changed', 'indexing_unavailable', 'catalog_conflict', 'deletion_unavailable');
+
+-- CreateEnum
+CREATE TYPE "PersonalMemoryOperationDeliveryState" AS ENUM ('proven_not_sent', 'ambiguous');
 
 -- CreateEnum
 CREATE TYPE "OrgRole" AS ENUM ('owner', 'admin', 'member');
@@ -1168,7 +1180,7 @@ CREATE TABLE "memory_datasets" (
     "boundary_kind" "AuthorizationBoundaryKind" NOT NULL,
     "boundary_group_id" TEXT,
     "boundary_principal_id" TEXT,
-    "cognee_dataset_id" TEXT NOT NULL,
+    "cognee_dataset_id" TEXT,
     "state" "MemoryDatasetState" NOT NULL DEFAULT 'active',
     "created_by" TEXT NOT NULL,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1183,6 +1195,7 @@ CREATE TABLE "memory_fact_catalog" (
     "dataset_id" TEXT NOT NULL,
     "cognee_external_id" TEXT NOT NULL,
     "content_digest" TEXT NOT NULL,
+    "revision" INTEGER NOT NULL DEFAULT 1,
     "state" "MemoryFactState" NOT NULL DEFAULT 'active',
     "consent_state" "MemoryConsentState" NOT NULL,
     "sensitivity" TEXT NOT NULL,
@@ -1197,6 +1210,46 @@ CREATE TABLE "memory_fact_catalog" (
     "forgotten_at" TIMESTAMP(3),
 
     CONSTRAINT "memory_fact_catalog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "personal_memory_operations" (
+    "id" TEXT NOT NULL,
+    "silo_id" TEXT NOT NULL,
+    "dataset_id" TEXT NOT NULL,
+    "actor_principal_id" TEXT NOT NULL,
+    "idempotency_key_digest" TEXT NOT NULL,
+    "command_digest" TEXT NOT NULL,
+    "kind" "PersonalMemoryOperationKind" NOT NULL,
+    "phase" "PersonalMemoryOperationPhase" NOT NULL,
+    "recovery_phase" "PersonalMemoryOperationPhase",
+    "revision" INTEGER NOT NULL DEFAULT 1,
+    "source_conversation_id" TEXT,
+    "source_message_id" TEXT,
+    "source_message_position" BIGINT,
+    "source_payload_ref" TEXT,
+    "source_ciphertext_digest" TEXT,
+    "source_author_principal_id" TEXT,
+    "content_digest" TEXT,
+    "target_fact_id" TEXT,
+    "target_document_id" TEXT,
+    "expected_fact_revision" INTEGER,
+    "admitted_provider_dataset_id" TEXT,
+    "provider_dataset_id" TEXT,
+    "provider_document_id" TEXT,
+    "indexing_operation_id" TEXT,
+    "expected_input_evidence_digest" TEXT,
+    "pipeline_run_id" TEXT,
+    "failure_code" "PersonalMemoryOperationFailureCode",
+    "delivery_state" "PersonalMemoryOperationDeliveryState",
+    "workflow_task_id" TEXT NOT NULL,
+    "workflow_task_name" TEXT NOT NULL,
+    "workflow_task_key" TEXT NOT NULL,
+    "admitted_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "recovery_recorded_at" TIMESTAMP(3),
+    "completed_at" TIMESTAMP(3),
+
+    CONSTRAINT "personal_memory_operations_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -2467,6 +2520,21 @@ CREATE UNIQUE INDEX "memory_fact_catalog_dataset_id_cognee_external_id_key" ON "
 CREATE UNIQUE INDEX "memory_fact_catalog_id_dataset_id_key" ON "memory_fact_catalog"("id", "dataset_id");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "personal_memory_operations_workflow_task_id_key" ON "personal_memory_operations"("workflow_task_id");
+
+-- CreateIndex
+CREATE INDEX "personal_memory_operations_dataset_id_phase_idx" ON "personal_memory_operations"("dataset_id", "phase");
+
+-- CreateIndex
+CREATE INDEX "personal_memory_operations_target_fact_id_dataset_id_idx" ON "personal_memory_operations"("target_fact_id", "dataset_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "personal_memory_operations_replay_key" ON "personal_memory_operations"("silo_id", "idempotency_key_digest");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "personal_memory_operations_workflow_task_key" ON "personal_memory_operations"("workflow_task_name", "workflow_task_key");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "model_routing_defaults_id_silo_id_key" ON "model_routing_defaults"("id", "silo_id");
 
 -- CreateIndex
@@ -3046,6 +3114,12 @@ ALTER TABLE "memory_fact_catalog" ADD CONSTRAINT "memory_fact_catalog_dataset_id
 
 -- AddForeignKey
 ALTER TABLE "memory_fact_catalog" ADD CONSTRAINT "memory_fact_catalog_supersedes_fact_id_fkey" FOREIGN KEY ("supersedes_fact_id") REFERENCES "memory_fact_catalog"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "personal_memory_operations" ADD CONSTRAINT "personal_memory_operations_dataset_id_fkey" FOREIGN KEY ("dataset_id") REFERENCES "memory_datasets"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "personal_memory_operations" ADD CONSTRAINT "personal_memory_operations_target_fact_id_dataset_id_fkey" FOREIGN KEY ("target_fact_id", "dataset_id") REFERENCES "memory_fact_catalog"("id", "dataset_id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "persona_questions" ADD CONSTRAINT "persona_questions_question_set_id_question_set_version_fkey" FOREIGN KEY ("question_set_id", "question_set_version") REFERENCES "persona_question_sets"("question_set_id", "version") ON DELETE RESTRICT ON UPDATE CASCADE;
@@ -5860,9 +5934,51 @@ END;
 $$;
 CREATE FUNCTION "enforce_memory_dataset_lifecycle"() RETURNS trigger LANGUAGE plpgsql AS $$
 BEGIN
-    IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'MemoryDataset catalog rows cannot be deleted'; END IF;
-    IF TG_OP = 'UPDATE' AND (NEW."silo_id" IS DISTINCT FROM OLD."silo_id" OR NEW."boundary_kind" IS DISTINCT FROM OLD."boundary_kind" OR NEW."boundary_group_id" IS DISTINCT FROM OLD."boundary_group_id" OR NEW."boundary_principal_id" IS DISTINCT FROM OLD."boundary_principal_id" OR NEW."cognee_dataset_id" IS DISTINCT FROM OLD."cognee_dataset_id" OR NEW."created_by" IS DISTINCT FROM OLD."created_by" OR NEW."created_at" IS DISTINCT FROM OLD."created_at") THEN RAISE EXCEPTION 'MemoryDataset authority is immutable'; END IF;
-    IF TG_OP = 'UPDATE' AND OLD."state" = 'retired' THEN RAISE EXCEPTION 'retired MemoryDataset is closed'; END IF;
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'MemoryDataset catalog rows cannot be deleted';
+    END IF;
+    IF TG_OP = 'INSERT' THEN
+        IF NEW."state" = 'provisioning' AND (
+            NEW."boundary_kind" IS DISTINCT FROM 'personal'::"AuthorizationBoundaryKind"
+            OR NEW."boundary_group_id" IS NOT NULL
+            OR NEW."boundary_principal_id" IS NULL
+            OR NEW."created_by" IS DISTINCT FROM NEW."boundary_principal_id") THEN
+            RAISE EXCEPTION 'MemoryDataset must bind its creating personal principal';
+        END IF;
+        RETURN NEW;
+    END IF;
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+        RETURN NEW;
+    END IF;
+    IF NEW."id" IS DISTINCT FROM OLD."id"
+        OR NEW."silo_id" IS DISTINCT FROM OLD."silo_id"
+        OR NEW."boundary_kind" IS DISTINCT FROM OLD."boundary_kind"
+        OR NEW."boundary_group_id" IS DISTINCT FROM OLD."boundary_group_id"
+        OR NEW."boundary_principal_id" IS DISTINCT FROM OLD."boundary_principal_id"
+        OR NEW."created_by" IS DISTINCT FROM OLD."created_by"
+        OR NEW."created_at" IS DISTINCT FROM OLD."created_at" THEN
+        RAISE EXCEPTION 'MemoryDataset authority is immutable';
+    END IF;
+    IF OLD."state" = 'retired' THEN
+        RAISE EXCEPTION 'retired MemoryDataset is closed';
+    END IF;
+    IF OLD."state" = 'provisioning' THEN
+        IF NEW."state" IS DISTINCT FROM 'active'::"MemoryDatasetState"
+            OR OLD."cognee_dataset_id" IS NOT NULL
+            OR NEW."cognee_dataset_id" IS NULL
+            OR NEW."retired_at" IS NOT NULL THEN
+            RAISE EXCEPTION 'Provisioning MemoryDataset may only adopt one provider UUID';
+        END IF;
+    ELSIF OLD."state" = 'active' THEN
+        IF NEW."state" IS DISTINCT FROM 'retired'::"MemoryDatasetState"
+            OR NEW."cognee_dataset_id" IS DISTINCT FROM OLD."cognee_dataset_id"
+            OR NEW."retired_at" IS NULL
+            OR NEW."retired_at" < OLD."created_at" THEN
+            RAISE EXCEPTION 'Active MemoryDataset may only retire with immutable provider identity';
+        END IF;
+    ELSE
+        RAISE EXCEPTION 'invalid MemoryDataset lifecycle state';
+    END IF;
     RETURN NEW;
 END;
 $$;
@@ -5870,7 +5986,7 @@ CREATE FUNCTION "enforce_memory_fact_lifecycle"() RETURNS trigger LANGUAGE plpgs
 DECLARE prior_dataset TEXT; prior_state "MemoryFactState"; dataset_silo_id TEXT; source_silo_id TEXT;
 BEGIN
     IF TG_OP = 'INSERT' THEN
-        IF NEW."state" <> 'active' THEN RAISE EXCEPTION 'MemoryFact catalog entry must begin Active'; END IF;
+        IF NEW."state" <> 'active' OR NEW."revision" <> 1 THEN RAISE EXCEPTION 'MemoryFact catalog entry must begin Active at revision 1'; END IF;
         SELECT "silo_id" INTO dataset_silo_id FROM "memory_datasets" WHERE "id" = NEW."dataset_id" AND "state" = 'active' FOR UPDATE;
         IF dataset_silo_id IS NULL THEN RAISE EXCEPTION 'MemoryFact requires an active MemoryDataset'; END IF;
         IF NEW."source_artifact_revision_id" IS NOT NULL THEN
@@ -5889,6 +6005,8 @@ BEGIN
         RETURN NEW;
     END IF;
     IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'MemoryFact catalog rows use explicit forget lifecycle'; END IF;
+    IF NEW IS NOT DISTINCT FROM OLD THEN RETURN NEW; END IF;
+    IF NEW."revision" IS DISTINCT FROM OLD."revision" THEN RAISE EXCEPTION 'MemoryFact revision is database-owned'; END IF;
     IF NEW."id" IS DISTINCT FROM OLD."id" OR NEW."dataset_id" IS DISTINCT FROM OLD."dataset_id" OR NEW."cognee_external_id" IS DISTINCT FROM OLD."cognee_external_id" OR NEW."content_digest" IS DISTINCT FROM OLD."content_digest" OR NEW."consent_state" IS DISTINCT FROM OLD."consent_state" OR NEW."sensitivity" IS DISTINCT FROM OLD."sensitivity" OR NEW."provenance" IS DISTINCT FROM OLD."provenance" OR NEW."source_artifact_revision_id" IS DISTINCT FROM OLD."source_artifact_revision_id" OR NEW."source_message_id" IS DISTINCT FROM OLD."source_message_id" OR NEW."supersedes_fact_id" IS DISTINCT FROM OLD."supersedes_fact_id" OR NEW."recorded_by" IS DISTINCT FROM OLD."recorded_by" OR NEW."recorded_at" IS DISTINCT FROM OLD."recorded_at" THEN RAISE EXCEPTION 'MemoryFact content and provenance are immutable'; END IF;
     IF OLD."corrected_at" IS NOT NULL AND NEW."corrected_at" IS DISTINCT FROM OLD."corrected_at" THEN RAISE EXCEPTION 'MemoryFact correction evidence is immutable'; END IF;
     IF OLD."forget_requested_at" IS NOT NULL AND NEW."forget_requested_at" IS DISTINCT FROM OLD."forget_requested_at" THEN RAISE EXCEPTION 'MemoryFact forget request evidence is immutable'; END IF;
@@ -5898,6 +6016,169 @@ BEGIN
         OR (OLD."state" = 'corrected' AND NEW."state" IN ('corrected', 'forget_pending'))
         OR (OLD."state" = 'forget_pending' AND NEW."state" IN ('forget_pending', 'forgotten'))
         OR (OLD."state" = 'forgotten' AND NEW."state" = 'forgotten')) THEN RAISE EXCEPTION 'invalid MemoryFact forget lifecycle'; END IF;
+    NEW."revision" := OLD."revision" + 1;
+    RETURN NEW;
+END;
+$$;
+CREATE FUNCTION "enforce_personal_memory_operation_lifecycle"() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    dataset_row "memory_datasets"%ROWTYPE;
+    target_row "memory_fact_catalog"%ROWTYPE;
+    target_changed_in_transaction BOOLEAN := FALSE;
+    active_phase "PersonalMemoryOperationPhase";
+    prior_active_phase "PersonalMemoryOperationPhase";
+    valid_transition BOOLEAN := FALSE;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'PersonalMemoryOperation rows cannot be deleted';
+    END IF;
+    SELECT * INTO dataset_row FROM "memory_datasets" WHERE "id" = NEW."dataset_id" FOR UPDATE;
+    IF dataset_row."id" IS NULL
+        OR dataset_row."silo_id" IS DISTINCT FROM NEW."silo_id"
+        OR dataset_row."boundary_kind" IS DISTINCT FROM 'personal'::"AuthorizationBoundaryKind"
+        OR dataset_row."boundary_group_id" IS NOT NULL
+        OR dataset_row."boundary_principal_id" IS DISTINCT FROM NEW."actor_principal_id" THEN
+        RAISE EXCEPTION 'PersonalMemoryOperation requires its actor-owned personal dataset';
+    END IF;
+    IF TG_OP = 'INSERT' THEN
+        IF NEW."revision" <> 1
+            OR NEW."phase" IS DISTINCT FROM (CASE NEW."kind"
+                WHEN 'remember' THEN 'dataset_ensure_pending'::"PersonalMemoryOperationPhase"
+                WHEN 'correct' THEN 'document_add_pending'::"PersonalMemoryOperationPhase"
+                WHEN 'forget' THEN 'document_delete_pending'::"PersonalMemoryOperationPhase"
+            END) THEN
+            RAISE EXCEPTION 'PersonalMemoryOperation must begin at revision 1 in its exact initial phase';
+        END IF;
+        IF NEW."source_author_principal_id" IS NOT NULL
+            AND NEW."source_author_principal_id" IS DISTINCT FROM NEW."actor_principal_id" THEN
+            RAISE EXCEPTION 'PersonalMemoryOperation source author must be its actor';
+        END IF;
+        IF NEW."kind" = 'remember' THEN
+            IF dataset_row."state" NOT IN ('provisioning', 'active')
+                OR NEW."admitted_provider_dataset_id" IS DISTINCT FROM dataset_row."cognee_dataset_id"
+                OR NEW."provider_dataset_id" IS DISTINCT FROM dataset_row."cognee_dataset_id" THEN
+                RAISE EXCEPTION 'Remember admission requires the current personal dataset identity';
+            END IF;
+        ELSE
+            SELECT * INTO target_row FROM "memory_fact_catalog" fact
+            WHERE fact."id" = NEW."target_fact_id" AND fact."dataset_id" = NEW."dataset_id" FOR UPDATE;
+            SELECT fact.xmin = pg_current_xact_id()::xid INTO target_changed_in_transaction FROM "memory_fact_catalog" fact
+            WHERE fact."id" = NEW."target_fact_id" AND fact."dataset_id" = NEW."dataset_id";
+            IF dataset_row."state" IS DISTINCT FROM 'active'::"MemoryDatasetState"
+                OR NEW."admitted_provider_dataset_id" IS DISTINCT FROM dataset_row."cognee_dataset_id"
+                OR NEW."provider_dataset_id" IS DISTINCT FROM dataset_row."cognee_dataset_id"
+                OR target_row."id" IS NULL
+                OR target_row."cognee_external_id" IS DISTINCT FROM NEW."target_document_id"
+                OR (NEW."kind" = 'correct' AND (target_row."state" IS DISTINCT FROM 'active'::"MemoryFactState" OR target_row."revision" IS DISTINCT FROM NEW."expected_fact_revision"))
+                OR (NEW."kind" = 'forget' AND (target_row."state" IS DISTINCT FROM 'forget_pending'::"MemoryFactState" OR target_row."revision" IS DISTINCT FROM NEW."expected_fact_revision" + 1 OR target_changed_in_transaction IS DISTINCT FROM TRUE)) THEN
+                RAISE EXCEPTION 'existing-fact admission requires its exact current target and provider dataset';
+            END IF;
+        END IF;
+    ELSE
+        IF NEW IS NOT DISTINCT FROM OLD THEN RETURN NEW; END IF;
+        IF NEW."id" IS DISTINCT FROM OLD."id"
+            OR NEW."silo_id" IS DISTINCT FROM OLD."silo_id"
+            OR NEW."dataset_id" IS DISTINCT FROM OLD."dataset_id"
+            OR NEW."actor_principal_id" IS DISTINCT FROM OLD."actor_principal_id"
+            OR NEW."idempotency_key_digest" IS DISTINCT FROM OLD."idempotency_key_digest"
+            OR NEW."command_digest" IS DISTINCT FROM OLD."command_digest"
+            OR NEW."kind" IS DISTINCT FROM OLD."kind"
+            OR NEW."source_conversation_id" IS DISTINCT FROM OLD."source_conversation_id"
+            OR NEW."source_message_id" IS DISTINCT FROM OLD."source_message_id"
+            OR NEW."source_message_position" IS DISTINCT FROM OLD."source_message_position"
+            OR NEW."source_payload_ref" IS DISTINCT FROM OLD."source_payload_ref"
+            OR NEW."source_ciphertext_digest" IS DISTINCT FROM OLD."source_ciphertext_digest"
+            OR NEW."source_author_principal_id" IS DISTINCT FROM OLD."source_author_principal_id"
+            OR NEW."content_digest" IS DISTINCT FROM OLD."content_digest"
+            OR NEW."target_fact_id" IS DISTINCT FROM OLD."target_fact_id"
+            OR NEW."target_document_id" IS DISTINCT FROM OLD."target_document_id"
+            OR NEW."expected_fact_revision" IS DISTINCT FROM OLD."expected_fact_revision"
+            OR NEW."admitted_provider_dataset_id" IS DISTINCT FROM OLD."admitted_provider_dataset_id"
+            OR NEW."workflow_task_id" IS DISTINCT FROM OLD."workflow_task_id"
+            OR NEW."workflow_task_name" IS DISTINCT FROM OLD."workflow_task_name"
+            OR NEW."workflow_task_key" IS DISTINCT FROM OLD."workflow_task_key"
+            OR NEW."admitted_at" IS DISTINCT FROM OLD."admitted_at" THEN
+            RAISE EXCEPTION 'PersonalMemoryOperation admission, source, target, and task evidence are immutable';
+        END IF;
+        IF OLD."phase" = 'completed' THEN RAISE EXCEPTION 'completed PersonalMemoryOperation is closed'; END IF;
+        IF NEW."revision" IS DISTINCT FROM OLD."revision" + 1 THEN RAISE EXCEPTION 'PersonalMemoryOperation must advance exactly one revision'; END IF;
+        prior_active_phase := CASE WHEN OLD."phase" = 'recovery_required' THEN OLD."recovery_phase" ELSE OLD."phase" END;
+        valid_transition := NEW."phase" = 'recovery_required' AND NEW."recovery_phase" = prior_active_phase;
+        IF NOT valid_transition THEN
+            valid_transition := CASE NEW."kind"
+                WHEN 'remember' THEN
+                    (prior_active_phase = 'dataset_ensure_pending' AND NEW."phase" = 'document_add_pending') OR
+                    (prior_active_phase = 'document_add_pending' AND NEW."phase" = 'cognify_pending') OR
+                    (prior_active_phase = 'cognify_pending' AND NEW."phase" IN ('cognify_pending', 'catalog_commit_pending')) OR
+                    (prior_active_phase = 'catalog_commit_pending' AND NEW."phase" = 'completed')
+                WHEN 'correct' THEN
+                    (prior_active_phase = 'document_add_pending' AND NEW."phase" = 'cognify_pending') OR
+                    (prior_active_phase = 'cognify_pending' AND NEW."phase" IN ('cognify_pending', 'catalog_commit_pending')) OR
+                    (prior_active_phase = 'catalog_commit_pending' AND NEW."phase" = 'prior_document_delete_pending') OR
+                    (prior_active_phase = 'prior_document_delete_pending' AND NEW."phase" = 'completed')
+                WHEN 'forget' THEN
+                    (prior_active_phase = 'document_delete_pending' AND NEW."phase" = 'catalog_finalize_pending') OR
+                    (prior_active_phase = 'catalog_finalize_pending' AND NEW."phase" = 'completed')
+            END;
+        END IF;
+        IF NOT COALESCE(valid_transition, FALSE) THEN RAISE EXCEPTION 'invalid PersonalMemoryOperation phase progression'; END IF;
+        IF OLD."provider_dataset_id" IS NOT NULL AND NEW."provider_dataset_id" IS DISTINCT FROM OLD."provider_dataset_id" THEN RAISE EXCEPTION 'PersonalMemoryOperation provider dataset receipt is immutable'; END IF;
+        IF OLD."provider_document_id" IS NOT NULL AND NEW."provider_document_id" IS DISTINCT FROM OLD."provider_document_id" THEN RAISE EXCEPTION 'PersonalMemoryOperation document receipt is immutable'; END IF;
+        IF OLD."indexing_operation_id" IS NOT NULL AND NEW."indexing_operation_id" IS DISTINCT FROM OLD."indexing_operation_id" THEN RAISE EXCEPTION 'PersonalMemoryOperation indexing identity is immutable'; END IF;
+        IF OLD."expected_input_evidence_digest" IS NOT NULL AND NEW."expected_input_evidence_digest" IS DISTINCT FROM OLD."expected_input_evidence_digest" THEN RAISE EXCEPTION 'PersonalMemoryOperation indexing evidence is immutable'; END IF;
+        IF OLD."pipeline_run_id" IS NOT NULL AND NEW."pipeline_run_id" IS DISTINCT FROM OLD."pipeline_run_id" THEN RAISE EXCEPTION 'PersonalMemoryOperation pipeline receipt is immutable'; END IF;
+        IF OLD."provider_dataset_id" IS NULL AND NEW."provider_dataset_id" IS NOT NULL AND prior_active_phase <> 'dataset_ensure_pending' THEN RAISE EXCEPTION 'PersonalMemoryOperation adopted a provider dataset outside ensure'; END IF;
+        IF OLD."provider_document_id" IS NULL AND NEW."provider_document_id" IS NOT NULL AND prior_active_phase <> 'document_add_pending' THEN RAISE EXCEPTION 'PersonalMemoryOperation adopted a document outside add'; END IF;
+        IF OLD."indexing_operation_id" IS NULL AND NEW."indexing_operation_id" IS NOT NULL AND prior_active_phase <> 'cognify_pending' THEN RAISE EXCEPTION 'PersonalMemoryOperation adopted indexing evidence outside Cognify'; END IF;
+        IF OLD."pipeline_run_id" IS NULL AND NEW."pipeline_run_id" IS NOT NULL AND (prior_active_phase <> 'cognify_pending' OR NEW."phase" <> 'catalog_commit_pending') THEN RAISE EXCEPTION 'PersonalMemoryOperation adopted a pipeline receipt outside Cognify completion'; END IF;
+    END IF;
+
+    active_phase := CASE WHEN NEW."phase" = 'recovery_required' THEN NEW."recovery_phase" ELSE NEW."phase" END;
+    IF ((NEW."kind" = 'remember' AND active_phase IN ('dataset_ensure_pending', 'document_add_pending', 'cognify_pending', 'catalog_commit_pending', 'completed'))
+        OR (NEW."kind" = 'correct' AND active_phase IN ('document_add_pending', 'cognify_pending', 'catalog_commit_pending', 'prior_document_delete_pending', 'completed'))
+        OR (NEW."kind" = 'forget' AND active_phase IN ('document_delete_pending', 'catalog_finalize_pending', 'completed'))) IS NOT TRUE THEN
+        RAISE EXCEPTION 'PersonalMemoryOperation phase does not match command kind';
+    END IF;
+    IF (NEW."phase" = 'recovery_required') IS DISTINCT FROM (NEW."recovery_phase" IS NOT NULL AND NEW."failure_code" IS NOT NULL AND NEW."recovery_recorded_at" IS NOT NULL AND NEW."completed_at" IS NULL)
+        OR (NEW."phase" <> 'recovery_required' AND (NEW."recovery_phase" IS NOT NULL OR NEW."failure_code" IS NOT NULL OR NEW."delivery_state" IS NOT NULL OR NEW."recovery_recorded_at" IS NOT NULL))
+        OR (NEW."phase" = 'recovery_required' AND active_phase IN ('recovery_required', 'completed'))
+        OR (NEW."phase" = 'completed') IS DISTINCT FROM (NEW."completed_at" IS NOT NULL) THEN
+        RAISE EXCEPTION 'PersonalMemoryOperation recovery or completion evidence is malformed';
+    END IF;
+    IF NEW."phase" = 'recovery_required' AND (
+        (NEW."delivery_state" = 'ambiguous' AND ((active_phase = 'dataset_ensure_pending' AND NEW."failure_code" = 'dataset_unavailable') OR (active_phase = 'document_add_pending' AND NEW."failure_code" = 'document_conflict') OR (active_phase = 'cognify_pending' AND NEW."failure_code" = 'indexing_unavailable') OR (active_phase IN ('prior_document_delete_pending', 'document_delete_pending') AND NEW."failure_code" = 'deletion_unavailable'))) OR
+        (NEW."delivery_state" IS NULL AND ((active_phase = 'dataset_ensure_pending' AND NEW."failure_code" IN ('authority_ended', 'dataset_unavailable')) OR (active_phase = 'document_add_pending' AND NEW."failure_code" IN ('authority_ended', 'source_unavailable', 'document_conflict')) OR (active_phase = 'cognify_pending' AND NEW."failure_code" IN ('authority_ended', 'dataset_unavailable', 'index_input_changed', 'indexing_unavailable')) OR (active_phase = 'catalog_commit_pending' AND NEW."failure_code" IN ('authority_ended', 'catalog_conflict')) OR (active_phase IN ('prior_document_delete_pending', 'document_delete_pending') AND NEW."failure_code" IN ('authority_ended', 'deletion_unavailable')) OR (active_phase = 'catalog_finalize_pending' AND NEW."failure_code" IN ('authority_ended', 'catalog_conflict'))))
+    ) IS NOT TRUE THEN RAISE EXCEPTION 'PersonalMemoryOperation failure evidence does not match recovery phase'; END IF;
+    IF (NEW."kind" = 'forget') IS DISTINCT FROM (NEW."source_conversation_id" IS NULL AND NEW."source_message_id" IS NULL AND NEW."source_message_position" IS NULL AND NEW."source_payload_ref" IS NULL AND NEW."source_ciphertext_digest" IS NULL AND NEW."source_author_principal_id" IS NULL AND NEW."content_digest" IS NULL)
+        OR (NEW."kind" <> 'forget' AND (NEW."source_conversation_id" IS NULL OR btrim(NEW."source_conversation_id") = '' OR NEW."source_message_id" IS NULL OR btrim(NEW."source_message_id") = '' OR NEW."source_message_position" IS NULL OR NEW."source_message_position" < 0 OR NEW."source_payload_ref" IS NULL OR btrim(NEW."source_payload_ref") = '' OR NEW."source_ciphertext_digest" !~ '^sha256:[0-9a-f]{64}$' OR NEW."source_author_principal_id" IS DISTINCT FROM NEW."actor_principal_id" OR NEW."content_digest" !~ '^sha256:[0-9a-f]{64}$')) THEN
+        RAISE EXCEPTION 'PersonalMemoryOperation source evidence does not match command kind';
+    END IF;
+    IF (NEW."kind" = 'remember') IS DISTINCT FROM (NEW."target_fact_id" IS NULL AND NEW."target_document_id" IS NULL AND NEW."expected_fact_revision" IS NULL)
+        OR (NEW."kind" <> 'remember' AND (NEW."target_fact_id" IS NULL OR btrim(NEW."target_fact_id") = '' OR NEW."target_document_id" IS NULL OR NEW."expected_fact_revision" IS NULL OR NEW."expected_fact_revision" <= 0)) THEN
+        RAISE EXCEPTION 'PersonalMemoryOperation target evidence does not match command kind';
+    END IF;
+    IF NEW."admitted_provider_dataset_id" IS NOT NULL AND NEW."provider_dataset_id" IS DISTINCT FROM NEW."admitted_provider_dataset_id" THEN RAISE EXCEPTION 'PersonalMemoryOperation changed its admitted provider dataset'; END IF;
+    IF NOT (NEW."kind" = 'remember' AND active_phase = 'dataset_ensure_pending') AND NEW."provider_dataset_id" IS NULL THEN RAISE EXCEPTION 'PersonalMemoryOperation phase requires a provider dataset'; END IF;
+    IF NEW."provider_dataset_id" IS NOT NULL AND (dataset_row."state" <> 'active' OR dataset_row."cognee_dataset_id" IS DISTINCT FROM NEW."provider_dataset_id") THEN RAISE EXCEPTION 'PersonalMemoryOperation provider dataset is not current'; END IF;
+    IF NEW."kind" <> 'forget' AND active_phase NOT IN ('dataset_ensure_pending', 'document_add_pending') AND NEW."provider_document_id" IS NULL THEN RAISE EXCEPTION 'PersonalMemoryOperation phase requires a document receipt'; END IF;
+    IF (NEW."kind" = 'forget' OR active_phase IN ('dataset_ensure_pending', 'document_add_pending')) AND NEW."provider_document_id" IS NOT NULL THEN RAISE EXCEPTION 'PersonalMemoryOperation phase cannot retain a new document receipt'; END IF;
+    IF (NEW."indexing_operation_id" IS NULL) IS DISTINCT FROM (NEW."expected_input_evidence_digest" IS NULL) THEN RAISE EXCEPTION 'PersonalMemoryOperation indexing identity and evidence must be paired'; END IF;
+    IF NEW."kind" = 'forget' AND (NEW."indexing_operation_id" IS NOT NULL OR NEW."pipeline_run_id" IS NOT NULL) THEN RAISE EXCEPTION 'Forget cannot retain indexing evidence'; END IF;
+    IF NEW."kind" <> 'forget' AND active_phase IN ('catalog_commit_pending', 'prior_document_delete_pending', 'completed') AND (NEW."indexing_operation_id" IS NULL OR NEW."pipeline_run_id" IS NULL) THEN RAISE EXCEPTION 'PersonalMemoryOperation phase requires exact indexing completion'; END IF;
+    IF NEW."kind" <> 'forget' AND active_phase NOT IN ('catalog_commit_pending', 'prior_document_delete_pending', 'completed') AND NEW."pipeline_run_id" IS NOT NULL THEN RAISE EXCEPTION 'PersonalMemoryOperation phase cannot retain a pipeline receipt'; END IF;
+
+    IF TG_OP = 'UPDATE' AND prior_active_phase = 'catalog_commit_pending' AND NEW."phase" IN ('completed', 'prior_document_delete_pending') THEN
+        IF NEW."kind" = 'remember' THEN
+            PERFORM 1 FROM "memory_fact_catalog" fact WHERE fact."dataset_id" = NEW."dataset_id" AND fact."cognee_external_id" = NEW."provider_document_id" AND fact."content_digest" = NEW."content_digest" AND fact."state" = 'active' AND fact."recorded_by" = NEW."actor_principal_id" AND fact."source_message_id" IS NOT DISTINCT FROM NEW."source_message_id" AND fact.xmin = pg_current_xact_id()::xid;
+        ELSE
+            PERFORM 1 FROM "memory_fact_catalog" fact JOIN "memory_fact_catalog" prior ON prior."id" = NEW."target_fact_id" AND prior."dataset_id" = NEW."dataset_id" WHERE fact."dataset_id" = NEW."dataset_id" AND fact."supersedes_fact_id" = NEW."target_fact_id" AND fact."cognee_external_id" = NEW."provider_document_id" AND fact."content_digest" = NEW."content_digest" AND fact."state" = 'active' AND fact."recorded_by" = NEW."actor_principal_id" AND fact."source_message_id" IS NOT DISTINCT FROM NEW."source_message_id" AND prior."state" = 'corrected' AND prior."revision" = NEW."expected_fact_revision" + 1 AND fact.xmin = pg_current_xact_id()::xid AND prior.xmin = pg_current_xact_id()::xid;
+        END IF;
+        IF NOT FOUND THEN RAISE EXCEPTION 'CatalogCommitted requires its exact same-transaction fact evidence'; END IF;
+    END IF;
+    IF TG_OP = 'UPDATE' AND NEW."kind" = 'forget' AND prior_active_phase = 'catalog_finalize_pending' AND NEW."phase" = 'completed' THEN
+        PERFORM 1 FROM "memory_fact_catalog" fact WHERE fact."id" = NEW."target_fact_id" AND fact."dataset_id" = NEW."dataset_id" AND fact."cognee_external_id" = NEW."target_document_id" AND fact."state" = 'forgotten' AND fact."revision" = NEW."expected_fact_revision" + 2 AND fact.xmin = pg_current_xact_id()::xid;
+        IF NOT FOUND THEN RAISE EXCEPTION 'CatalogFinalized requires its exact same-transaction Forgotten fact'; END IF;
+    END IF;
     RETURN NEW;
 END;
 $$;
@@ -6342,13 +6623,18 @@ ALTER TABLE "skill_revisions" ADD CONSTRAINT "skill_revisions_review_check" CHEC
          AND "signature" IS NOT NULL AND btrim("signature") <> '' AND "signer_key_id" IS NOT NULL AND btrim("signer_key_id") <> '')
     );
 ALTER TABLE "memory_datasets" ADD CONSTRAINT "memory_datasets_identity_check" CHECK (
-		btrim("silo_id") <> '' AND btrim("cognee_dataset_id") <> '' AND btrim("created_by") <> '' AND
-		(("boundary_kind" = 'group' AND "boundary_group_id" IS NOT NULL AND "boundary_principal_id" IS NULL) OR
-		 ("boundary_kind" = 'personal' AND "boundary_group_id" IS NULL AND "boundary_principal_id" IS NOT NULL))
+		(btrim("id") <> '' AND btrim("silo_id") <> '' AND btrim("created_by") <> '' AND
+		 (("boundary_kind" = 'group' AND "boundary_group_id" IS NOT NULL AND btrim("boundary_group_id") <> '' AND "boundary_principal_id" IS NULL) OR
+		  ("boundary_kind" = 'personal' AND "boundary_group_id" IS NULL AND "boundary_principal_id" IS NOT NULL AND btrim("boundary_principal_id") <> ''))) IS TRUE
 	);
-ALTER TABLE "memory_datasets" ADD CONSTRAINT "memory_datasets_retirement_check" CHECK (("state" = 'retired' AND "retired_at" IS NOT NULL) OR ("state" = 'active' AND "retired_at" IS NULL));
+ALTER TABLE "memory_datasets" ADD CONSTRAINT "memory_datasets_retirement_check" CHECK ((
+        ("state" = 'provisioning' AND "boundary_kind" = 'personal' AND "boundary_principal_id" = "created_by" AND "cognee_dataset_id" IS NULL AND "retired_at" IS NULL) OR
+        ("state" = 'active' AND "cognee_dataset_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' AND "retired_at" IS NULL) OR
+        ("state" = 'retired' AND "cognee_dataset_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' AND "retired_at" IS NOT NULL AND "retired_at" >= "created_at")
+    ) IS TRUE);
 ALTER TABLE "memory_fact_catalog" ADD CONSTRAINT "memory_fact_catalog_valid_check" CHECK (
-        btrim("cognee_external_id") <> '' AND "content_digest" ~ '^sha256:[0-9a-f]{64}$'
+        btrim("id") <> '' AND btrim("dataset_id") <> '' AND "revision" > 0
+        AND btrim("cognee_external_id") <> '' AND "content_digest" ~ '^sha256:[0-9a-f]{64}$'
         AND btrim("sensitivity") <> '' AND jsonb_typeof("provenance") = 'object' AND btrim("recorded_by") <> ''
         AND ((CASE WHEN "source_artifact_revision_id" IS NOT NULL THEN 1 ELSE 0 END)
             + (CASE WHEN "source_message_id" IS NOT NULL THEN 1 ELSE 0 END)
@@ -6361,6 +6647,25 @@ ALTER TABLE "memory_fact_catalog" ADD CONSTRAINT "memory_fact_catalog_forget_che
         ("state" = 'forget_pending' AND "forget_requested_at" IS NOT NULL AND "forgotten_at" IS NULL) OR
         ("state" = 'forgotten' AND "forget_requested_at" IS NOT NULL AND "forgotten_at" IS NOT NULL)
     );
+ALTER TABLE "personal_memory_operations" ADD CONSTRAINT "personal_memory_operations_identity_check" CHECK ((
+        "id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+        AND btrim("silo_id") <> '' AND btrim("dataset_id") <> '' AND btrim("actor_principal_id") <> ''
+        AND "idempotency_key_digest" ~ '^sha256:[0-9a-f]{64}$' AND "command_digest" ~ '^sha256:[0-9a-f]{64}$'
+        AND "revision" > 0
+        AND "workflow_task_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+        AND btrim("workflow_task_name") <> '' AND length("workflow_task_name") <= 128
+        AND btrim("workflow_task_key") <> '' AND length("workflow_task_key") <= 256
+        AND "admitted_at" IS NOT NULL
+        AND ("admitted_provider_dataset_id" IS NULL OR "admitted_provider_dataset_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+        AND ("provider_dataset_id" IS NULL OR "provider_dataset_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+        AND ("provider_document_id" IS NULL OR "provider_document_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+        AND ("target_document_id" IS NULL OR "target_document_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+        AND ("indexing_operation_id" IS NULL OR "indexing_operation_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+        AND ("pipeline_run_id" IS NULL OR "pipeline_run_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')
+        AND ("expected_input_evidence_digest" IS NULL OR "expected_input_evidence_digest" ~ '^sha256:[0-9a-f]{64}$')
+        AND ("recovery_recorded_at" IS NULL OR "recovery_recorded_at" >= "admitted_at")
+        AND ("completed_at" IS NULL OR "completed_at" >= "admitted_at")
+    ) IS TRUE);
 ALTER TABLE "artifact_upload_leases" ADD CONSTRAINT "artifact_upload_leases_identity_check" CHECK (btrim("silo_id") <> '' AND btrim("capability_jti") <> '' AND btrim("media_type") <> '' AND strpos("media_type", '/') > 1);
 ALTER TABLE "artifact_upload_leases" ADD CONSTRAINT "artifact_upload_leases_expected_content_check" CHECK ("expected_content_address" IS NULL OR "expected_content_address" ~ '^sha256:[0-9a-f]{64}$');
 ALTER TABLE "artifact_upload_leases" ADD CONSTRAINT "artifact_upload_leases_expected_length_check" CHECK ("expected_byte_length" IS NULL OR "expected_byte_length" >= 0);
@@ -6617,8 +6922,9 @@ CREATE CONSTRAINT TRIGGER "skill_artifact_revisions_remain_published" AFTER UPDA
     DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE FUNCTION "protect_skill_artifact_revision"();
 CREATE TRIGGER "agent_revision_skill_assignments_same_silo" BEFORE INSERT OR UPDATE ON "agent_revision_skill_assignments"
     FOR EACH ROW EXECUTE FUNCTION "enforce_agent_skill_assignment_silo"();
-CREATE TRIGGER "memory_datasets_closed_lifecycle" BEFORE UPDATE OR DELETE ON "memory_datasets" FOR EACH ROW EXECUTE FUNCTION "enforce_memory_dataset_lifecycle"();
+CREATE TRIGGER "memory_datasets_closed_lifecycle" BEFORE INSERT OR UPDATE OR DELETE ON "memory_datasets" FOR EACH ROW EXECUTE FUNCTION "enforce_memory_dataset_lifecycle"();
 CREATE TRIGGER "memory_fact_catalog_closed_lifecycle" BEFORE INSERT OR UPDATE OR DELETE ON "memory_fact_catalog" FOR EACH ROW EXECUTE FUNCTION "enforce_memory_fact_lifecycle"();
+CREATE TRIGGER "personal_memory_operations_closed_lifecycle" BEFORE INSERT OR UPDATE OR DELETE ON "personal_memory_operations" FOR EACH ROW EXECUTE FUNCTION "enforce_personal_memory_operation_lifecycle"();
 CREATE CONSTRAINT TRIGGER "corrected_memory_facts_require_successor" AFTER INSERT OR UPDATE OF "state" ON "memory_fact_catalog"
     DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION "enforce_corrected_memory_successor"();
 CREATE TRIGGER "artifact_upload_leases_silo_and_lifecycle" BEFORE INSERT OR UPDATE OR DELETE ON "artifact_upload_leases" FOR EACH ROW EXECUTE FUNCTION "enforce_artifact_upload_lease_silo_and_lifecycle"();

--- a/apps/opencrane/prisma/bootstrap/verify-authority-baseline.mjs
+++ b/apps/opencrane/prisma/bootstrap/verify-authority-baseline.mjs
@@ -1,9 +1,9 @@
 import { readFileSync } from "node:fs";
 
 const _BASELINE = new URL("./target-baseline.sql", import.meta.url);
-const _MINIMUM_FUNCTIONS = 79;
-const _MINIMUM_TRIGGERS = 89;
-const _MINIMUM_CONSTRAINTS = 227;
+const _MINIMUM_FUNCTIONS = 80;
+const _MINIMUM_TRIGGERS = 90;
+const _MINIMUM_CONSTRAINTS = 228;
 const _REQUIRED_AUTHORITY_MARKERS = [
 	'ADD CONSTRAINT "mcp_servers_credentialless_schema_check"',
 	'ADD CONSTRAINT "mcp_servers_oci_credential_requirement_check"',
@@ -122,7 +122,15 @@ const _REQUIRED_AUTHORITY_MARKERS = [
 	'ALTER TABLE "tool_result_deliveries" ADD CONSTRAINT "tool_result_deliveries_exact_check"',
 	'CREATE TYPE "PersonalMemoryPermissionReceiptState" AS ENUM (\'active\', \'consumed\');',
 	'CREATE UNIQUE INDEX "memory_datasets_exact_boundary_key"',
-	'NEW."boundary_kind" IS DISTINCT FROM OLD."boundary_kind" OR NEW."boundary_group_id" IS DISTINCT FROM OLD."boundary_group_id" OR NEW."boundary_principal_id" IS DISTINCT FROM OLD."boundary_principal_id"',
+	'CREATE FUNCTION "enforce_personal_memory_operation_lifecycle"()',
+	'CREATE TRIGGER "personal_memory_operations_closed_lifecycle"',
+	'ALTER TABLE "personal_memory_operations" ADD CONSTRAINT "personal_memory_operations_identity_check"',
+	'PersonalMemoryOperation requires its actor-owned personal dataset',
+	'CatalogCommitted requires its exact same-transaction fact evidence',
+	'CatalogFinalized requires its exact same-transaction Forgotten fact',
+	'MemoryFact revision is database-owned',
+	'Provisioning MemoryDataset may only adopt one provider UUID',
+	'MemoryDataset authority is immutable',
 	'CREATE FUNCTION "enforce_personal_memory_permission_authority"()',
 	'WHERE "run_id" = NEW."run_id"\n      AND "attempt" = NEW."attempt"\n      AND "input_digest" = NEW."input_snapshot_digest"',
 	'CREATE TRIGGER "personal_memory_permission_receipts_authority"',

--- a/apps/opencrane/prisma/schema/memory.prisma
+++ b/apps/opencrane/prisma/schema/memory.prisma
@@ -1,4 +1,5 @@
 enum MemoryDatasetState {
+  Provisioning @map("provisioning")
   Active  @map("active")
   Retired @map("retired")
 }
@@ -15,18 +16,57 @@ enum MemoryConsentState {
   Confirmed @map("confirmed")
 }
 
+/// Selects the user command retained by a personal-memory operation independently of its phase.
+enum PersonalMemoryOperationKind {
+  Remember @map("remember")
+  Correct  @map("correct")
+  Forget   @map("forget")
+}
+
+/// Names the saved work that may advance after the operation owner verifies its evidence.
+enum PersonalMemoryOperationPhase {
+  DatasetEnsurePending       @map("dataset_ensure_pending")
+  DocumentAddPending         @map("document_add_pending")
+  CognifyPending             @map("cognify_pending")
+  CatalogCommitPending       @map("catalog_commit_pending")
+  PriorDocumentDeletePending @map("prior_document_delete_pending")
+  DocumentDeletePending      @map("document_delete_pending")
+  CatalogFinalizePending     @map("catalog_finalize_pending")
+  RecoveryRequired           @map("recovery_required")
+  Completed                  @map("completed")
+}
+
+/// Records why a personal-memory operation stopped without retaining provider or source details.
+enum PersonalMemoryOperationFailureCode {
+  AuthorityEnded      @map("authority_ended")
+  DatasetUnavailable  @map("dataset_unavailable")
+  SourceUnavailable   @map("source_unavailable")
+  DocumentConflict    @map("document_conflict")
+  IndexInputChanged   @map("index_input_changed")
+  IndexingUnavailable @map("indexing_unavailable")
+  CatalogConflict     @map("catalog_conflict")
+  DeletionUnavailable @map("deletion_unavailable")
+}
+
+/// Distinguishes a mutation that can be retried from one that first needs read-only reconciliation.
+enum PersonalMemoryOperationDeliveryState {
+  ProvenNotSent @map("proven_not_sent")
+  Ambiguous     @map("ambiguous")
+}
+
 model MemoryDataset {
   id                  String                    @id @default(cuid())
   siloId              String                    @map("silo_id")
   boundaryKind        AuthorizationBoundaryKind @map("boundary_kind")
   boundaryGroupId     String?                   @map("boundary_group_id")
   boundaryPrincipalId String?                   @map("boundary_principal_id")
-  cogneeDatasetId     String                    @map("cognee_dataset_id")
+  cogneeDatasetId     String?                   @map("cognee_dataset_id")
   state               MemoryDatasetState        @default(Active)
   createdBy           String                    @map("created_by")
   createdAt           DateTime                  @default(now()) @map("created_at")
   retiredAt           DateTime?                 @map("retired_at")
   facts               MemoryFactCatalog[]
+  operations          PersonalMemoryOperation[]
   boundaryGroup       Group?                    @relation("MemoryDatasetBoundaryGroup", fields: [boundaryGroupId, siloId], references: [id, siloId], onDelete: Restrict)
   boundaryPrincipal   Principal?                @relation("MemoryDatasetBoundaryPrincipal", fields: [boundaryPrincipalId, siloId], references: [id, siloId], onDelete: Restrict)
 
@@ -41,6 +81,7 @@ model MemoryFactCatalog {
   datasetId                String              @map("dataset_id")
   cogneeExternalId         String              @map("cognee_external_id")
   contentDigest            String              @map("content_digest")
+  revision                 Int                 @default(1)
   state                    MemoryFactState     @default(Active)
   consentState             MemoryConsentState  @map("consent_state")
   sensitivity              String
@@ -56,6 +97,7 @@ model MemoryFactCatalog {
   dataset                  MemoryDataset       @relation(fields: [datasetId], references: [id], onDelete: Restrict)
   supersedes               MemoryFactCatalog?  @relation("MemoryFactCorrections", fields: [supersedesFactId], references: [id], onDelete: Restrict)
   corrections              MemoryFactCatalog[] @relation("MemoryFactCorrections")
+  targetedByOperations     PersonalMemoryOperation[] @relation("PersonalMemoryOperationTargetFact")
 
   @@unique([datasetId, cogneeExternalId])
   @@unique([id, datasetId])
@@ -63,4 +105,51 @@ model MemoryFactCatalog {
   @@index([sourceMessageId])
   @@index([datasetId, state])
   @@map("memory_fact_catalog")
+}
+
+/// Saves identifiers, digests, and provider receipts for one admitted personal-memory command.
+/// Remembered text and provider payloads stay outside PostgreSQL.
+model PersonalMemoryOperation {
+  id                          String                               @id
+  siloId                      String                               @map("silo_id")
+  datasetId                   String                               @map("dataset_id")
+  actorPrincipalId            String                               @map("actor_principal_id")
+  idempotencyKeyDigest        String                               @map("idempotency_key_digest")
+  commandDigest               String                               @map("command_digest")
+  kind                        PersonalMemoryOperationKind
+  phase                       PersonalMemoryOperationPhase
+  recoveryPhase               PersonalMemoryOperationPhase?        @map("recovery_phase")
+  revision                    Int                                  @default(1)
+  sourceConversationId        String?                              @map("source_conversation_id")
+  sourceMessageId             String?                              @map("source_message_id")
+  sourceMessagePosition       BigInt?                              @map("source_message_position")
+  sourcePayloadRef            String?                              @map("source_payload_ref")
+  sourceCiphertextDigest      String?                              @map("source_ciphertext_digest")
+  sourceAuthorPrincipalId     String?                              @map("source_author_principal_id")
+  contentDigest               String?                              @map("content_digest")
+  targetFactId                String?                              @map("target_fact_id")
+  targetDocumentId            String?                              @map("target_document_id")
+  expectedFactRevision        Int?                                 @map("expected_fact_revision")
+  admittedProviderDatasetId   String?                              @map("admitted_provider_dataset_id")
+  providerDatasetId           String?                              @map("provider_dataset_id")
+  providerDocumentId          String?                              @map("provider_document_id")
+  indexingOperationId         String?                              @map("indexing_operation_id")
+  expectedInputEvidenceDigest String?                              @map("expected_input_evidence_digest")
+  pipelineRunId               String?                              @map("pipeline_run_id")
+  failureCode                 PersonalMemoryOperationFailureCode?  @map("failure_code")
+  deliveryState               PersonalMemoryOperationDeliveryState? @map("delivery_state")
+  workflowTaskId              String                               @unique @map("workflow_task_id")
+  workflowTaskName            String                               @map("workflow_task_name")
+  workflowTaskKey             String                               @map("workflow_task_key")
+  admittedAt                  DateTime                             @default(now()) @map("admitted_at")
+  recoveryRecordedAt          DateTime?                            @map("recovery_recorded_at")
+  completedAt                 DateTime?                            @map("completed_at")
+  dataset                     MemoryDataset                        @relation(fields: [datasetId], references: [id], onDelete: Restrict)
+  targetFact                  MemoryFactCatalog?                   @relation("PersonalMemoryOperationTargetFact", fields: [targetFactId, datasetId], references: [id, datasetId], onDelete: Restrict)
+
+  @@unique([siloId, idempotencyKeyDigest], map: "personal_memory_operations_replay_key")
+  @@unique([workflowTaskName, workflowTaskKey], map: "personal_memory_operations_workflow_task_key")
+  @@index([datasetId, phase])
+  @@index([targetFactId, datasetId])
+  @@map("personal_memory_operations")
 }

--- a/apps/opencrane/prisma/tests/personal-memory-operations.sql
+++ b/apps/opencrane/prisma/tests/personal-memory-operations.sql
@@ -1,0 +1,342 @@
+BEGIN;
+
+SELECT pg_temp.seed_external_user('memory-silo-1', 'memory-principal-1');
+SELECT pg_temp.seed_external_user('memory-silo-2', 'memory-principal-2');
+
+SELECT pg_temp.expect_failure(
+  'active personal dataset requires a provider UUID',
+  $statement$
+    INSERT INTO "memory_datasets" (
+      "id", "silo_id", "boundary_kind", "boundary_principal_id", "cognee_dataset_id", "state", "created_by"
+    ) VALUES ('dataset-invalid-active', 'memory-silo-1', 'personal', 'memory-principal-1', NULL, 'active', 'memory-principal-1')
+  $statement$,
+  'memory_datasets_retirement_check'
+);
+
+INSERT INTO "memory_datasets" (
+  "id", "silo_id", "boundary_kind", "boundary_principal_id", "cognee_dataset_id", "state", "created_by"
+) VALUES (
+  'dataset-provisioning', 'memory-silo-1', 'personal', 'memory-principal-1', NULL, 'provisioning', 'memory-principal-1'
+);
+
+SELECT pg_temp.expect_failure(
+  'personal dataset rejects a different creator',
+  $statement$
+    INSERT INTO "memory_datasets" (
+      "id", "silo_id", "boundary_kind", "boundary_principal_id", "cognee_dataset_id", "state", "created_by"
+    ) VALUES ('dataset-cross-actor', 'memory-silo-1', 'personal', 'memory-principal-1', NULL, 'provisioning', 'memory-principal-2')
+  $statement$,
+  'MemoryDataset must bind its creating personal principal'
+);
+
+INSERT INTO "personal_memory_operations" (
+  "id", "silo_id", "dataset_id", "actor_principal_id", "idempotency_key_digest", "command_digest",
+  "kind", "phase", "revision", "source_conversation_id", "source_message_id", "source_message_position",
+  "source_payload_ref", "source_ciphertext_digest", "source_author_principal_id", "content_digest",
+  "workflow_task_id", "workflow_task_name", "workflow_task_key"
+) VALUES (
+  '10000000-0000-4000-8000-000000000001', 'memory-silo-1', 'dataset-provisioning', 'memory-principal-1',
+  'sha256:' || repeat('1', 64), 'sha256:' || repeat('2', 64), 'remember', 'dataset_ensure_pending', 1,
+  'conversation-1', 'message-1', 1, 'payload-1', 'sha256:' || repeat('3', 64), 'memory-principal-1',
+  'sha256:' || repeat('4', 64), '20000000-0000-4000-8000-000000000001', 'personal-memory-operation', 'remember-1'
+);
+
+SELECT pg_temp.expect_failure(
+  'operation rejects a cross-principal actor',
+  $statement$
+    INSERT INTO "personal_memory_operations" (
+      "id", "silo_id", "dataset_id", "actor_principal_id", "idempotency_key_digest", "command_digest",
+      "kind", "phase", "source_conversation_id", "source_message_id", "source_message_position", "source_payload_ref",
+      "source_ciphertext_digest", "source_author_principal_id", "content_digest", "workflow_task_id", "workflow_task_name", "workflow_task_key"
+    ) VALUES (
+      '10000000-0000-4000-8000-000000000002', 'memory-silo-1', 'dataset-provisioning', 'memory-principal-2',
+      'sha256:' || repeat('5', 64), 'sha256:' || repeat('6', 64), 'remember', 'dataset_ensure_pending',
+      'conversation-2', 'message-2', 2, 'payload-2', 'sha256:' || repeat('7', 64), 'memory-principal-2',
+      'sha256:' || repeat('8', 64), '20000000-0000-4000-8000-000000000002', 'personal-memory-operation', 'remember-2'
+    )
+  $statement$,
+  'PersonalMemoryOperation requires its actor-owned personal dataset'
+);
+
+SELECT pg_temp.expect_failure(
+  'operation rejects a skipped initial phase',
+  $statement$
+    INSERT INTO "personal_memory_operations" (
+      "id", "silo_id", "dataset_id", "actor_principal_id", "idempotency_key_digest", "command_digest",
+      "kind", "phase", "source_conversation_id", "source_message_id", "source_message_position", "source_payload_ref",
+      "source_ciphertext_digest", "source_author_principal_id", "content_digest", "workflow_task_id", "workflow_task_name", "workflow_task_key"
+    ) VALUES (
+      '10000000-0000-4000-8000-000000000003', 'memory-silo-1', 'dataset-provisioning', 'memory-principal-1',
+      'sha256:' || repeat('9', 64), 'sha256:' || repeat('a', 64), 'remember', 'document_add_pending',
+      'conversation-3', 'message-3', 3, 'payload-3', 'sha256:' || repeat('b', 64), 'memory-principal-1',
+      'sha256:' || repeat('c', 64), '20000000-0000-4000-8000-000000000003', 'personal-memory-operation', 'remember-3'
+    )
+  $statement$,
+  'PersonalMemoryOperation must begin at revision 1 in its exact initial phase'
+);
+
+UPDATE "memory_datasets"
+SET "state" = 'active', "cognee_dataset_id" = '30000000-0000-4000-8000-000000000001'
+WHERE "id" = 'dataset-provisioning';
+UPDATE "personal_memory_operations"
+SET "phase" = 'document_add_pending', "provider_dataset_id" = '30000000-0000-4000-8000-000000000001', "revision" = 2
+WHERE "id" = '10000000-0000-4000-8000-000000000001';
+
+SELECT pg_temp.assert_true(
+  'dataset adoption and DatasetEnsured bind the same provider UUID',
+  (SELECT "state" = 'active' AND "cognee_dataset_id" = '30000000-0000-4000-8000-000000000001' FROM "memory_datasets" WHERE "id" = 'dataset-provisioning')
+  AND (SELECT "phase" = 'document_add_pending' AND "provider_dataset_id" = '30000000-0000-4000-8000-000000000001' AND "revision" = 2 FROM "personal_memory_operations" WHERE "id" = '10000000-0000-4000-8000-000000000001')
+);
+
+INSERT INTO "memory_datasets" (
+  "id", "silo_id", "boundary_kind", "boundary_principal_id", "cognee_dataset_id", "state", "created_by"
+) VALUES (
+  'dataset-other-silo', 'memory-silo-2', 'personal', 'memory-principal-2',
+  '30000000-0000-4000-8000-000000000002', 'active', 'memory-principal-2'
+);
+INSERT INTO "memory_fact_catalog" (
+  "id", "dataset_id", "cognee_external_id", "content_digest", "consent_state", "sensitivity", "provenance",
+  "source_message_id", "recorded_by"
+) VALUES (
+  'fact-other-silo', 'dataset-other-silo', '40000000-0000-4000-8000-000000000099', 'sha256:' || repeat('9', 64),
+  'explicit', 'personal', '{"source":"human-message"}', 'message-other-silo', 'memory-principal-2'
+);
+SELECT pg_temp.expect_failure(
+  'operation cannot target a fact from another dataset and silo',
+  $statement$
+    INSERT INTO "personal_memory_operations" (
+      "id", "silo_id", "dataset_id", "actor_principal_id", "idempotency_key_digest", "command_digest", "kind", "phase",
+      "source_conversation_id", "source_message_id", "source_message_position", "source_payload_ref", "source_ciphertext_digest",
+      "source_author_principal_id", "content_digest", "target_fact_id", "target_document_id", "expected_fact_revision",
+      "admitted_provider_dataset_id", "provider_dataset_id", "workflow_task_id", "workflow_task_name", "workflow_task_key"
+    ) VALUES (
+      '10000000-0000-4000-8000-000000000099', 'memory-silo-1', 'dataset-provisioning', 'memory-principal-1',
+      'sha256:' || repeat('8', 64), 'sha256:' || repeat('7', 64), 'correct', 'document_add_pending',
+      'conversation-99', 'message-99', 99, 'payload-99', 'sha256:' || repeat('6', 64), 'memory-principal-1',
+      'sha256:' || repeat('5', 64), 'fact-other-silo', '40000000-0000-4000-8000-000000000099', 1,
+      '30000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000001',
+      '20000000-0000-4000-8000-000000000099', 'personal-memory-operation', 'correct-99'
+    )
+  $statement$,
+  'existing-fact admission requires its exact current target and provider dataset'
+);
+
+SELECT pg_temp.expect_failure(
+  'operation rejects a skipped phase',
+  $statement$
+    UPDATE "personal_memory_operations" SET "phase" = 'catalog_commit_pending', "revision" = 3
+    WHERE "id" = '10000000-0000-4000-8000-000000000001'
+  $statement$,
+  'invalid PersonalMemoryOperation phase progression'
+);
+
+SELECT pg_temp.expect_failure(
+  'operation rejects changed source evidence',
+  $statement$
+    UPDATE "personal_memory_operations" SET "source_message_id" = 'message-other', "revision" = 3
+    WHERE "id" = '10000000-0000-4000-8000-000000000001'
+  $statement$,
+  'PersonalMemoryOperation admission, source, target, and task evidence are immutable'
+);
+
+SELECT pg_temp.expect_failure(
+  'operation rejects malformed recovery evidence',
+  $statement$
+    UPDATE "personal_memory_operations"
+    SET "phase" = 'recovery_required', "recovery_phase" = 'document_add_pending', "failure_code" = 'document_conflict',
+        "delivery_state" = 'proven_not_sent', "recovery_recorded_at" = clock_timestamp(), "revision" = 3
+    WHERE "id" = '10000000-0000-4000-8000-000000000001'
+  $statement$,
+  'PersonalMemoryOperation failure evidence does not match recovery phase'
+);
+
+UPDATE "personal_memory_operations"
+SET "phase" = 'cognify_pending', "provider_document_id" = '40000000-0000-4000-8000-000000000001', "revision" = 3
+WHERE "id" = '10000000-0000-4000-8000-000000000001';
+UPDATE "personal_memory_operations"
+SET "indexing_operation_id" = '50000000-0000-4000-8000-000000000001',
+    "expected_input_evidence_digest" = 'sha256:' || repeat('d', 64), "revision" = 4
+WHERE "id" = '10000000-0000-4000-8000-000000000001';
+UPDATE "personal_memory_operations"
+SET "phase" = 'catalog_commit_pending', "pipeline_run_id" = '60000000-0000-4000-8000-000000000001', "revision" = 5
+WHERE "id" = '10000000-0000-4000-8000-000000000001';
+
+SELECT pg_temp.expect_failure(
+  'empty catalog event cannot complete Remember',
+  $statement$
+    UPDATE "personal_memory_operations" SET "phase" = 'completed', "completed_at" = clock_timestamp(), "revision" = 6
+    WHERE "id" = '10000000-0000-4000-8000-000000000001'
+  $statement$,
+  'CatalogCommitted requires its exact same-transaction fact evidence'
+);
+
+INSERT INTO "memory_fact_catalog" (
+  "id", "dataset_id", "cognee_external_id", "content_digest", "consent_state", "sensitivity", "provenance",
+  "source_message_id", "recorded_by"
+) VALUES (
+  'fact-remembered', 'dataset-provisioning', '40000000-0000-4000-8000-000000000001', 'sha256:' || repeat('4', 64),
+  'explicit', 'personal', '{"source":"human-message"}', 'message-1', 'memory-principal-1'
+);
+UPDATE "personal_memory_operations"
+SET "phase" = 'completed', "completed_at" = clock_timestamp(), "revision" = 6
+WHERE "id" = '10000000-0000-4000-8000-000000000001';
+
+SELECT pg_temp.expect_failure(
+  'completed operation cannot reopen',
+  $statement$
+    UPDATE "personal_memory_operations" SET "phase" = 'catalog_commit_pending', "completed_at" = NULL, "revision" = 7
+    WHERE "id" = '10000000-0000-4000-8000-000000000001'
+  $statement$,
+  'completed PersonalMemoryOperation is closed'
+);
+SELECT pg_temp.expect_failure(
+  'operations cannot be deleted',
+  $statement$ DELETE FROM "personal_memory_operations" WHERE "id" = '10000000-0000-4000-8000-000000000001' $statement$,
+  'PersonalMemoryOperation rows cannot be deleted'
+);
+
+INSERT INTO "memory_fact_catalog" (
+  "id", "dataset_id", "cognee_external_id", "content_digest", "consent_state", "sensitivity", "provenance",
+  "source_message_id", "recorded_by"
+) VALUES (
+  'fact-forget', 'dataset-provisioning', '40000000-0000-4000-8000-000000000002', 'sha256:' || repeat('e', 64),
+  'explicit', 'personal', '{"source":"human-message"}', 'message-forget', 'memory-principal-1'
+);
+
+UPDATE "memory_fact_catalog"
+SET "state" = 'forget_pending', "forget_requested_at" = clock_timestamp()
+WHERE "id" = 'fact-forget';
+INSERT INTO "personal_memory_operations" (
+  "id", "silo_id", "dataset_id", "actor_principal_id", "idempotency_key_digest", "command_digest", "kind", "phase",
+  "target_fact_id", "target_document_id", "expected_fact_revision", "admitted_provider_dataset_id", "provider_dataset_id",
+  "workflow_task_id", "workflow_task_name", "workflow_task_key"
+) VALUES (
+  '10000000-0000-4000-8000-000000000004', 'memory-silo-1', 'dataset-provisioning', 'memory-principal-1',
+  'sha256:' || repeat('f', 64), 'sha256:' || repeat('0', 64), 'forget', 'document_delete_pending',
+  'fact-forget', '40000000-0000-4000-8000-000000000002', 1,
+  '30000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000001',
+  '20000000-0000-4000-8000-000000000004', 'personal-memory-operation', 'forget-1'
+);
+
+SELECT pg_temp.assert_true(
+  'Forget admission observes the same-transaction hidden fact revision',
+  (SELECT "state" = 'forget_pending' AND "revision" = 2 FROM "memory_fact_catalog" WHERE "id" = 'fact-forget')
+);
+UPDATE "personal_memory_operations" SET "phase" = 'catalog_finalize_pending', "revision" = 2
+WHERE "id" = '10000000-0000-4000-8000-000000000004';
+SELECT pg_temp.expect_failure(
+  'empty catalog event cannot complete Forget',
+  $statement$
+    UPDATE "personal_memory_operations" SET "phase" = 'completed', "completed_at" = clock_timestamp(), "revision" = 3
+    WHERE "id" = '10000000-0000-4000-8000-000000000004'
+  $statement$,
+  'CatalogFinalized requires its exact same-transaction Forgotten fact'
+);
+UPDATE "memory_fact_catalog" SET "state" = 'forgotten', "forgotten_at" = clock_timestamp() WHERE "id" = 'fact-forget';
+UPDATE "personal_memory_operations" SET "phase" = 'completed', "completed_at" = clock_timestamp(), "revision" = 3
+WHERE "id" = '10000000-0000-4000-8000-000000000004';
+
+SELECT pg_temp.assert_true(
+  'Forget completion advances the fact revision exactly twice',
+  (SELECT "state" = 'forgotten' AND "revision" = 3 FROM "memory_fact_catalog" WHERE "id" = 'fact-forget')
+);
+
+INSERT INTO "memory_fact_catalog" (
+  "id", "dataset_id", "cognee_external_id", "content_digest", "consent_state", "sensitivity", "provenance",
+  "source_message_id", "recorded_by"
+) VALUES (
+  'fact-correct', 'dataset-provisioning', '40000000-0000-4000-8000-000000000004', 'sha256:' || repeat('b', 64),
+  'explicit', 'personal', '{"source":"human-message"}', 'message-old', 'memory-principal-1'
+);
+INSERT INTO "personal_memory_operations" (
+  "id", "silo_id", "dataset_id", "actor_principal_id", "idempotency_key_digest", "command_digest", "kind", "phase",
+  "source_conversation_id", "source_message_id", "source_message_position", "source_payload_ref", "source_ciphertext_digest",
+  "source_author_principal_id", "content_digest", "target_fact_id", "target_document_id", "expected_fact_revision",
+  "admitted_provider_dataset_id", "provider_dataset_id", "workflow_task_id", "workflow_task_name", "workflow_task_key"
+) VALUES (
+  '10000000-0000-4000-8000-000000000005', 'memory-silo-1', 'dataset-provisioning', 'memory-principal-1',
+  'sha256:' || repeat('1', 63) || '2', 'sha256:' || repeat('2', 63) || '3', 'correct', 'document_add_pending',
+  'conversation-5', 'message-new', 5, 'payload-5', 'sha256:' || repeat('3', 63) || '4', 'memory-principal-1',
+  'sha256:' || repeat('4', 63) || '5', 'fact-correct', '40000000-0000-4000-8000-000000000004', 1,
+  '30000000-0000-4000-8000-000000000001', '30000000-0000-4000-8000-000000000001',
+  '20000000-0000-4000-8000-000000000005', 'personal-memory-operation', 'correct-1'
+);
+UPDATE "personal_memory_operations"
+SET "phase" = 'cognify_pending', "provider_document_id" = '40000000-0000-4000-8000-000000000005', "revision" = 2
+WHERE "id" = '10000000-0000-4000-8000-000000000005';
+UPDATE "personal_memory_operations"
+SET "indexing_operation_id" = '50000000-0000-4000-8000-000000000005',
+    "expected_input_evidence_digest" = 'sha256:' || repeat('5', 64), "revision" = 3
+WHERE "id" = '10000000-0000-4000-8000-000000000005';
+UPDATE "personal_memory_operations"
+SET "phase" = 'catalog_commit_pending', "pipeline_run_id" = '60000000-0000-4000-8000-000000000005', "revision" = 4
+WHERE "id" = '10000000-0000-4000-8000-000000000005';
+SELECT pg_temp.expect_failure(
+  'empty catalog event cannot publish a correction',
+  $statement$
+    UPDATE "personal_memory_operations" SET "phase" = 'prior_document_delete_pending', "revision" = 5
+    WHERE "id" = '10000000-0000-4000-8000-000000000005'
+  $statement$,
+  'CatalogCommitted requires its exact same-transaction fact evidence'
+);
+INSERT INTO "memory_fact_catalog" (
+  "id", "dataset_id", "cognee_external_id", "content_digest", "consent_state", "sensitivity", "provenance",
+  "source_message_id", "supersedes_fact_id", "recorded_by"
+) VALUES (
+  'fact-corrected-successor', 'dataset-provisioning', '40000000-0000-4000-8000-000000000005',
+  'sha256:' || repeat('4', 63) || '5', 'explicit', 'personal', '{"source":"human-message"}',
+  'message-new', 'fact-correct', 'memory-principal-1'
+);
+UPDATE "personal_memory_operations" SET "phase" = 'prior_document_delete_pending', "revision" = 5
+WHERE "id" = '10000000-0000-4000-8000-000000000005';
+SELECT pg_temp.assert_true(
+  'correction atomically publishes the successor and advances the predecessor revision',
+  (SELECT "state" = 'corrected' AND "revision" = 2 FROM "memory_fact_catalog" WHERE "id" = 'fact-correct')
+  AND (SELECT "state" = 'active' AND "revision" = 1 FROM "memory_fact_catalog" WHERE "id" = 'fact-corrected-successor')
+);
+
+INSERT INTO "memory_fact_catalog" (
+  "id", "dataset_id", "cognee_external_id", "content_digest", "consent_state", "sensitivity", "provenance",
+  "source_message_id", "recorded_by"
+) VALUES (
+  'fact-revision', 'dataset-provisioning', '40000000-0000-4000-8000-000000000003', 'sha256:' || repeat('a', 64),
+  'explicit', 'personal', '{"source":"human-message"}', 'message-revision', 'memory-principal-1'
+);
+UPDATE "memory_fact_catalog" SET "state" = "state" WHERE "id" = 'fact-revision';
+SELECT pg_temp.assert_true(
+  'exact no-op keeps the fact revision',
+  (SELECT "revision" = 1 FROM "memory_fact_catalog" WHERE "id" = 'fact-revision')
+);
+SELECT pg_temp.expect_failure(
+  'caller cannot bump a fact revision',
+  $statement$ UPDATE "memory_fact_catalog" SET "revision" = 2 WHERE "id" = 'fact-revision' $statement$,
+  'MemoryFact revision is database-owned'
+);
+SELECT pg_temp.expect_failure(
+  'caller cannot combine a lifecycle change with its own next revision',
+  $statement$
+    UPDATE "memory_fact_catalog" SET "state" = 'forget_pending', "forget_requested_at" = clock_timestamp(), "revision" = 2
+    WHERE "id" = 'fact-revision'
+  $statement$,
+  'MemoryFact revision is database-owned'
+);
+SELECT pg_temp.assert_true(
+  'rejected revision update rolls back',
+  (SELECT "state" = 'active' AND "revision" = 1 FROM "memory_fact_catalog" WHERE "id" = 'fact-revision')
+);
+
+SELECT pg_temp.expect_failure(
+  'dataset cannot retire with an empty provider UUID',
+  $statement$
+    UPDATE "memory_datasets" SET "state" = 'retired', "cognee_dataset_id" = NULL, "retired_at" = clock_timestamp()
+    WHERE "id" = 'dataset-provisioning'
+  $statement$,
+  'Active MemoryDataset may only retire with immutable provider identity'
+);
+SELECT pg_temp.expect_failure(
+  'dataset cannot be deleted',
+  $statement$ DELETE FROM "memory_datasets" WHERE "id" = 'dataset-provisioning' $statement$,
+  'MemoryDataset catalog rows cannot be deleted'
+);
+
+ROLLBACK;

--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -3,6 +3,13 @@
 	"owners": {
 		"repositories": [
 			{
+				"path": "libs/backend/agents/personal/memory/main/src/operations/prisma-personal-memory-operation-repository.ts",
+				"adapter": "PrismaPersonalMemoryOperationRepository",
+				"contract": "PersonalMemoryOperationRepository",
+				"contractImportPath": "./personal-memory-operation-persistence.types",
+				"constructs": []
+			},
+			{
 				"path": "libs/backend/server/iam/audit-writer/main/src/audit-decision.ts",
 				"adapter": "PrismaAuditDecisionWriterRepository",
 				"contract": "AuditDecisionWriterRepository",
@@ -1416,6 +1423,18 @@
 			}
 		],
 		"unitsOfWork": [
+			{
+				"path": "libs/backend/agents/personal/memory/main/src/operations/prisma-personal-memory-operation-unit-of-work.ts",
+				"adapter": "PrismaPersonalMemoryOperationUnitOfWork",
+				"contract": "PersonalMemoryOperationUnitOfWork",
+				"contractImportPath": "./personal-memory-operation-persistence.types",
+				"constructs": [
+					{
+						"adapter": "PrismaPersonalMemoryOperationRepository",
+						"importPath": "./prisma-personal-memory-operation-repository"
+					}
+				]
+			},
 			{
 				"path": "libs/backend/agents/execution/inputs/main/src/prompt/prisma-prompt-compiler-repository.ts",
 				"adapter": "PrismaPromptCompilerUnitOfWork",

--- a/docs/design/personal-memory-operations.md
+++ b/docs/design/personal-memory-operations.md
@@ -1,0 +1,158 @@
+# Personal memory operations
+
+This is the implementation contract for explicit Remember, separately consented recall in another
+conversation, Correct and Forget. Work is in progress. The current status and validation evidence
+belong in [plan.md](../../plan.md); this document describes the intended behavior and ownership.
+
+## Content and authority
+
+| Owner | Responsibility |
+| --- | --- |
+| Conversation history and private payload store | Preserve the encrypted human message and its exact author, position and payload coordinates. |
+| Personal-memory domain | Admit commands under current authority; own dataset, fact catalog and operation state. |
+| Absurd | Admit the task with the command, save checkpoints and resume the same operation after interruption. |
+| OpenCrane server | Read an authorized source transiently, call the gateway and prepare a permitted recall result. |
+| Memory gateway | Validate the server identity, translate the private protocol and hold the provider credential. |
+| Cognee | Store document content, build the index and preserve correlated pipeline-run evidence. |
+
+OpenCrane's memory tables contain coordinates, consent, provenance, revisions, fixed failure codes
+and digests. They contain no remembered text, search chunks, provider responses or credentials.
+Workflow arguments contain identifiers and revisions. A task reads authorized content when it needs
+it; plaintext never crosses the operation's SQL transaction.
+
+There is one personal dataset per verified Principal and silo. Its immutable catalog ID is generated
+by the server before provisioning. The provider name is `opencrane-memory-${sha256(dataset.id)}`, derived
+from that saved ID; it is neither request input nor a second stored name. A Provisioning dataset
+has no provider UUID and cannot be used for recall. The UUID is adopted only after the gateway proves
+the dataset's permissions are complete. A model argument or caller-supplied subject cannot choose
+the dataset used for recall; the admitted conversation run freezes that coordinate. UUID adoption
+and the operation's DatasetEnsured transition activate the dataset in one transaction. New dataset
+creation explicitly chooses Provisioning; the existing Active default requires a provider UUID.
+
+## Command admission
+
+Remember initially accepts one completed human message written by the authenticated caller.
+It does not accept an arbitrary text field or another participant's message. Correct identifies a
+new authorized source message and an expected revision of the old fact. Forget identifies the exact
+fact and expected revision. These authenticated commands are explicit consent for their operation.
+
+The source reader binds silo, conversation, message ID, message position, author, private payload
+reference and ciphertext digest. It must still work after later messages are appended. A whole
+conversation-head equality check would incorrectly invalidate a saved Remember command.
+
+Admission reads and hashes the source outside SQL. One Serializable transaction then revalidates
+the source coordinates, current authority and command replay key, saves the operation and admits its
+Absurd task. The worker rereads the same source and requires the saved content digest before sending
+any document to the gateway. A changed source cannot replace the admitted command.
+
+Creating the first dataset requires the personal Principal's collection Create authority. Subsequent
+Remember and Correct commands require Manage on the exact memory scope; Forget requires Forget.
+Recall retains Dataset Use and MemoryScope Use as well as its invocation-specific permission.
+
+## One durable operation owner
+
+The fact catalog is the index used for authorization, rather than a record of partially dispatched
+effects. A separate personal-memory operation owns the admitted command, its immutable source,
+provider receipts, workflow identity, revision and recovery state. The common lock order is dataset,
+referenced facts sorted by ID, then operation.
+
+Command kind and lifecycle have separate responsibilities: kind selects Remember, Correct or Forget
+behavior; the lifecycle decides whether the saved evidence permits the next step. Repositories and
+controllers must not maintain their own competing transition tables.
+
+| Saved phase | Evidence needed to advance | Result |
+| --- | --- | --- |
+| Dataset ensure pending | Same saved provider name, adopted UUID and complete owner permissions | Prepare the document operation. |
+| Document add pending | Exact document UUID and full content digest matching the admitted source | Prepare indexing evidence. |
+| Cognify pending | Exact saved operation, input snapshot and completed provider run receipt | Permit catalog adoption. |
+| Catalog commit pending | Current authority, revisions and completed provider evidence | Publish one Active fact; Correct also retires the old fact from recall. |
+| Prior document delete pending | Exact absence of the corrected document | Finish correction cleanup. |
+| Document delete pending | Exact absence of the forgotten document | Permit catalog finalization. |
+| Catalog finalize pending | The fact remains ForgetPending at the expected revision | Mark it Forgotten. |
+| Completed | Same admitted command | Return the saved result without an effect. |
+| Recovery required | Explicit matching recovery evidence and current authority | Advance only through the operation owner; elapsed time alone permits nothing. |
+
+Every provider effect is preceded by a check of the current operation and dataset authority.
+Definite pre-dispatch failure and an uncertain dispatched effect remain different outcomes.
+Uncertain Add or Delete performs reconciliation reads; it does not blindly resend the mutation.
+
+## Save indexing evidence before dispatch
+
+Cognee's current random run ID is first returned in the response. Losing that response therefore
+loses the caller's ability to identify its run. The candidate extension uses the existing document
+list, dataset lock and pipeline-run history to close that gap.
+
+1. Save the exact Add receipt, including document UUID and content digest.
+2. Read the gateway's existing document-list operation with a provider-created input evidence
+   digest. The same snapshot includes each document's UUID, name, media type, content digest and
+   byte length. It exposes no provider-private metadata or raw content.
+3. Require the intended document and its saved content digest in that snapshot. Save a new indexing
+   operation UUID and the snapshot digest durably before the first indexing request.
+4. Send `{datasetId, operationId, expectedInputEvidenceDigest}`. Every recovery attempt uses those
+   same saved values.
+5. Under its existing dataset lock, the provider derives the run ID from the authorized pipeline
+   coordinates and operation UUID. It reads the complete ordered history for that exact run.
+6. For a new run, recompute the current input digest under the lock. A stale snapshot is rejected
+   before Started is written or a task is dispatched. An admitted run saves both the request-profile
+   digest and input-evidence digest in its existing run history.
+7. A matching completed history returns its saved dataset, operation, run and input-evidence
+   coordinates without another task, model or embedding call. A later dataset change does not alter
+   what that earlier receipt proves.
+
+The provider's versioned input digest binds the complete sorted document set, raw content digests
+and lengths, and the private metadata/status that affects input selection. Data UUIDs alone are
+insufficient because content and processing state can change under the same UUID.
+
+An abandoned Started run, inconsistent history, missing evidence or contradictory terminal state
+remains an ambiguous recovery failure. It must not become a pre-dispatch rejection. The gateway
+must preserve that distinction in its error response. An Errored history cannot become Completed.
+Dataset-latest status, Add completion, document presence and search results are not indexing proof.
+
+This candidate relies on one provider worker and replica with the existing local store and dataset
+lock. It makes no claim about admission across multiple provider workers.
+
+## Recall, correction and forgetting
+
+Recall is a built-in tool strategy within the existing ToolInvocation lifecycle. It is not an MCP
+assignment. Every invocation needs the existing permission receipt bound to its exact query, input
+snapshot, persona, invocation, actor and expiry. Dispatch uses only the personal dataset frozen in
+that admitted run and rechecks the current claim and memory authority.
+
+Proposal, dispatch and result admission have distinct evidence requirements. A permitted proposal
+can open the permission question before its answer exists. The search dispatch requires the active
+receipt, and result completion consumes it. The conversation's current dispatch authority is shared
+by proposal and result admission, so the memory strategy must preserve these stages rather than
+requiring an already-approved receipt before the question can be created.
+
+After search, the server keeps only returned documents whose catalog rows remain Active and
+consented in that exact dataset. Unknown, Corrected, ForgetPending and Forgotten documents cannot
+enter the tool result. Provider failure remains failure rather than an empty successful recall.
+The final catalog check, invocation completion and permission-receipt consumption share one atomic
+transaction through their existing owners. Recall completion and Forget therefore have one durable
+order. Content uses the existing protected result channel, never a plaintext memory SQL field.
+
+Correct first adds and indexes the new source. It atomically publishes the replacement and changes
+the old fact to Corrected, then removes the old provider document. Uncertain cleanup cannot make the
+old fact visible again. Forget first changes the fact to ForgetPending in the admission transaction,
+which immediately excludes it from recall. Only exact provider absence permits Forgotten.
+
+## Delivery and proof
+
+The domain owns operation policy and persistence. A workflow contract owns stable task identity and
+identifier-only inputs. The workflow implementation uses injected domain, source-reader and gateway
+ports; it imports neither Prisma nor the provider SDK. The app composes those owners and mounts the
+authenticated routes. New packages follow the existing functional folder and Nx boundary rules.
+
+Source validation must cover concurrent admission, command replay, changed input, current authority,
+stale revisions, every lifecycle transition and restart after each effect checkpoint. Provider tests
+must prove response loss and concurrent retries produce no extra paid work, including Started after
+restart and Errored replay. The completed journey must prove Remember, a restart, separately approved
+recall in another conversation, Correct, Forget and absence after another restart.
+
+Deployment of the candidate image, authentication/storage profile and gateway credential projection
+is a separate gate. Existing testv5 data must be preserved. Source checks and a disposable provider
+qualification do not authorize replacing a live silo or deleting its data.
+
+> See also: [MVP delivery plan](mvp-delivery-plan.md),
+> [memory gateway](../../apps/memory-gateway/README.md),
+> [Cognee candidate](../../apps/_infra/cognee/README.md).

--- a/libs/backend/agents/personal/memory/main/README.md
+++ b/libs/backend/agents/personal/memory/main/README.md
@@ -4,10 +4,10 @@
 
 ## What it owns
 
-This package is the personal-agent boundary for two admission decisions: which active Cognee dataset
-belongs to one verified user in one organisation, and which consented facts that user explicitly
-supplied may personalise a frozen run input. It receives the existing run-admission transaction, so
-both reads occur at the same final identity and revocation fence as every other snapshot input.
+This package owns personal-memory dataset selection, consented fact metadata, and the durable
+operation state for Remember, Correct, and Forget. Existing run-input reads receive the caller's
+admission transaction. The operation repository receives its own caller-supplied transaction and
+stores only encrypted source coordinates, provider identifiers, fixed failure evidence, and digests.
 
 ```
  verified user identity + RunAdmissionTransaction
@@ -25,13 +25,12 @@ both reads occur at the same final identity and revocation fence as every other 
 coordinates, and the [memory gateway](../../../../server/infra/memory-gateway-client/README.md)
 is the only fact-content boundary.
 
-The invariant is identity-bound selection: neither a request nor a tool argument can choose a
-dataset by identifier. The repository reads only the exact silo, organisation, and verified subject;
-it returns only active, consented facts whose provenance names that subject. Cognee search results
-keep separate chunk and document UUIDs. This slice leaves the catalog's `cogneeExternalId` field
-unchanged and does not claim that existing rows contain Cognee document UUIDs; a future durable
-operation must prove that mapping before it adopts a receipt. The catalog stores no fact text and
-never calls Cognee.
+The invariant is identity-bound selection and secret-free persistence: neither a request nor a tool
+argument can choose another person's dataset, and no memory table stores remembered text, search
+chunks, provider payloads, URLs, file paths, or credentials. The operation row retains the exact
+encrypted message coordinates and full digests needed to reread and verify content through the
+future gateway workflow. `cogneeExternalId` remains the existing catalog coordinate; this slice does
+not reinterpret old values.
 
 ## Public surface
 
@@ -46,10 +45,30 @@ never calls Cognee.
   the caller-owned admission transaction without exposing Prisma delegates to execution inputs.
 - `PersonalMemoryDatasetResolutionOutcomes` / `PersonalMemoryDatasetResolutionDenialReasons` — the
   stable, serialized allow/deny vocabulary for proof-bound dataset selection.
+- `__CreatePersonalMemoryOperationLifecycle` / `__PlanPersonalMemoryOperationLifecycle` — strict
+  command creation and State-by-Event planning with no I/O.
+- `PersonalMemoryOperationKinds` / `PersonalMemoryOperationPhases` /
+  `PersonalMemoryOperationEvents` / `PersonalMemoryOperationFailureCodes` — stable lifecycle
+  vocabulary, transition outcomes, denial reasons, and their public command and event types.
+- `PersonalMemoryOperationAdmissionOutcomes` / `PersonalMemoryOperationPersistenceOutcomes` —
+  stable replay and persistence results, errors, records, repository ports, and UnitOfWork ports.
+- `PrismaPersonalMemoryOperationRepository` — transaction-scoped replay, locking, validation, and
+  lifecycle CAS for a future product command owner.
+- `PrismaPersonalMemoryOperationUnitOfWork` — persistence-only serializable wrapper; it does not
+  admit authorization, workflow, or provider effects.
+- `__PersonalMemoryProviderDatasetName` — derives the opaque provider name from an immutable local
+  dataset ID without storing a user or tenant coordinate in that name.
+
+The `operations/` module owns the reviewed lifecycle, persistence validator,
+transaction-scoped `PrismaPersonalMemoryOperationRepository`, and
+`PrismaPersonalMemoryOperationUnitOfWork`. The repository locks the local dataset, referenced facts
+in sorted ID order, and then the operation. Exact command replays return the first row; conflicting
+evidence fails. Accepted events use the shared lifecycle planner and a revision compare-and-set, and
+a lost compare-and-set returns the validated row that won.
 
 ## Boundary
 
-The current production conversation path does not consume this package. The intended entry is
+The current production conversation path does not consume the operation persistence. The intended entry is
 [conversations](../../../../server/conversations/main/README.md): `POST /api/v1/me/conversations/:conversationId/messages` accepts
 only a `conversationId` and `requestIdempotencyKey`; the authenticated session supplies the subject, the
 trusted host supplies the silo, and the server re-resolves the participant-bound conversation and personal
@@ -62,10 +81,19 @@ managed service therefore cannot inherit a person's dataset merely because it ha
 Live end-to-end Cognee qualification is still pending; admitting and freezing coordinates does not
 claim that later gateway recall has been qualified in a running environment.
 
-This package itself must not write fact content, own a transaction, derive a dataset from a
-subject outside admission, read durable fact text, call Cognee, or compose a runtime. It remains the
-narrow identity-bound selection owner and cannot be used as a personal fallback when identity or
-dataset evidence is unavailable.
+This package must not write fact content, derive a dataset from a caller-supplied subject, call
+Cognee, or compose a runtime. A new dataset row must be created explicitly as `Provisioning` with a
+null provider UUID; existing creators retain the `Active` default only when they supply an adopted
+UUID. The future dataset owner derives the provider name as
+`opencrane-memory-${sha256(dataset.id)}` through `__PersonalMemoryProviderDatasetName`; the name is
+not stored.
+
+The persistence UnitOfWork saves a reserved workflow task UUID with the operation, but it does not
+admit an Absurd task or prove current product authority. The future product command transaction must
+compose dataset creation, authorization audit, the transaction-scoped repository, and workflow
+admission. Bare catalog completion events fail closed until that transaction also proves the exact
+catalog mutation. Forget admission hides its exact Active or Corrected target as `ForgetPending` in the same
+database transaction; the database owns the fact revision increment.
 
 ## Dependency direction
 
@@ -74,10 +102,12 @@ Tagged `scope:personal-memory`, this backend package may depend only on its own 
 
 ## Data & persistence
 
-Owns `MemoryDataset` and `MemoryFactCatalog` in `memory.prisma` and reads them through the repository
-port using the existing `RunAdmissionTransaction`. The existing durable workflow remains the future
-owner of operation keys and recovery; no memory outbox, queue or scheduler is introduced. Durable
-fact content remains behind the memory gateway.
+Owns `MemoryDataset`, `MemoryFactCatalog`, and `PersonalMemoryOperation` in `memory.prisma`.
+`MemoryDataset` distinguishes explicit `Provisioning` from `Active` and `Retired`, and its provider
+UUID is nullable only until the exact DatasetEnsured event adopts it. `MemoryFactCatalog.revision`
+fences target commands. The operation stores immutable replay, source, target, and reserved task
+evidence plus write-once provider receipts and current lifecycle recovery fields. No memory outbox,
+queue, scheduler, route, provider call, or plaintext store is introduced.
 
 ## See also
 

--- a/libs/backend/agents/personal/memory/main/project.json
+++ b/libs/backend/agents/personal/memory/main/project.json
@@ -3,6 +3,7 @@
   "sourceRoot": "libs/backend/agents/personal/memory/main/src", "tags": ["type:lib", "layer:backend", "scope:personal-memory"],
   "targets": {
     "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/agents/personal/memory/main" } },
-    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/agents/personal/memory/main" } }
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/agents/personal/memory/main" } },
+    "test:sql": { "executor": "nx:run-commands", "cache": false, "dependsOn": [{ "projects": ["opencrane"], "target": "db:generate" }], "options": { "command": "vitest run --config vitest.sql.config.ts", "cwd": "libs/backend/agents/personal/memory/main" } }
   }
 }

--- a/libs/backend/agents/personal/memory/main/src/__tests__/prisma-personal-memory-admission-repository.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/__tests__/prisma-personal-memory-admission-repository.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { PrismaPersonalMemoryAdmissionRepository } from "../prisma-personal-memory-admission-repository";
 
 /** Builds the smallest transaction fake with the two tables these reads use. */
-function _Transaction(dataset: { readonly id: string; readonly cogneeDatasetId: string } | null, facts: readonly unknown[] = [])
+function _Transaction(dataset: { readonly id: string; readonly cogneeDatasetId: string | null } | null, facts: readonly unknown[] = [])
 {
 	return { memoryDataset: { findFirst: vi.fn().mockResolvedValue(dataset) }, memoryFactCatalog: { findMany: vi.fn().mockResolvedValue(facts) } };
 }
@@ -32,5 +32,16 @@ describe("Prisma personal memory admission repository", function _DescribePrisma
 	it("returns no preference facts when the exact active personal scope is absent", async function _ReturnsMissingScope()
 	{
 		await expect(new PrismaPersonalMemoryAdmissionRepository(_Transaction(null) as never).findActivePreferenceFactIds({ siloId: "silo-1", principalId: "principal-1", subjectId: "user-1" })).resolves.toEqual([]);
+	});
+
+	it("refuses a dataset without an adopted provider id before reading any facts", async function _RejectsUnprovisionedDataset()
+	{
+		const transaction = _Transaction({ id: "dataset-pending", cogneeDatasetId: null });
+		const repository = new PrismaPersonalMemoryAdmissionRepository(transaction as never);
+		const command = { siloId: "silo-1", principalId: "principal-1", subjectId: "user-1" };
+
+		await expect(repository.findActivePersonalDataset(command)).resolves.toBeNull();
+		await expect(repository.findActivePreferenceFactIds(command)).resolves.toEqual([]);
+		expect(transaction.memoryFactCatalog.findMany).not.toHaveBeenCalled();
 	});
 });

--- a/libs/backend/agents/personal/memory/main/src/index.ts
+++ b/libs/backend/agents/personal/memory/main/src/index.ts
@@ -5,3 +5,11 @@ export { PrismaRuntimePersonalMemoryEffectEligibilityAuthority } from "./prisma-
 export { PersonalMemoryDatasetResolutionDenialReasons, PersonalMemoryDatasetResolutionOutcomes } from "./personal-memory-dataset.types";
 export type { PersonalMemoryAdmissionRepository, PersonalMemoryDataset, ResolvePersonalMemoryDatasetCommand, ResolvePersonalMemoryDatasetResult } from "./personal-memory-dataset.types";
 export type { RuntimePersonalMemoryEffectEligibility, RuntimePersonalMemoryEffectEligibilityCommand } from "./runtime-personal-memory-effect-eligibility.types";
+export { __CreatePersonalMemoryOperationLifecycle, __PlanPersonalMemoryOperationLifecycle } from "./operations/personal-memory-operation-lifecycle";
+export { __PersonalMemoryProviderDatasetName } from "./operations/personal-memory-dataset-name";
+export { PersonalMemoryOperationKinds, PersonalMemoryOperationPhases, PersonalMemoryOperationEvents, PersonalMemoryOperationFailureCodes, PersonalMemoryOperationTransitionOutcomes, PersonalMemoryOperationTransitionDenialReasons } from "./operations/personal-memory-operation.types";
+export type { CreatePersonalMemoryOperationLifecycleCommand, PersonalMemoryOperationLifecycle, PersonalMemoryOperationEvent, PersonalMemoryOperationTransitionResult } from "./operations/personal-memory-operation.types";
+export { PersonalMemoryOperationAdmissionOutcomes, PersonalMemoryOperationPersistenceOutcomes, PersonalMemoryOperationReplayConflict, PersonalMemoryOperationInvalidState } from "./operations/personal-memory-operation-persistence.types";
+export type { AdmitPersonalMemoryOperationCommand, PersonalMemoryOperationMessageSource, PersonalMemoryOperationTaskIdentity, PersonalMemoryOperationRecord, PersonalMemoryOperationAdmissionResult, PersonalMemoryOperationPersistenceResult, PersonalMemoryOperationRepository, PersonalMemoryOperationUnitOfWork } from "./operations/personal-memory-operation-persistence.types";
+export { PrismaPersonalMemoryOperationRepository } from "./operations/prisma-personal-memory-operation-repository";
+export { PrismaPersonalMemoryOperationUnitOfWork } from "./operations/prisma-personal-memory-operation-unit-of-work";

--- a/libs/backend/agents/personal/memory/main/src/operations/__tests__/personal-memory-dataset-name.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/__tests__/personal-memory-dataset-name.test.ts
@@ -1,0 +1,22 @@
+import { ___MemoryGatewayDatasetEnsureRequestSchema } from "@opencrane/contracts";
+import { describe, expect, it } from "vitest";
+
+import { __PersonalMemoryProviderDatasetName } from "../personal-memory-dataset-name";
+
+describe("personal-memory provider dataset name", function _DescribeDatasetName()
+{
+	it("produces a gateway-valid stable name for a short saved catalog id", function _DerivesValidName()
+	{
+		const datasetId = "cmemorycatalog000000000001";
+		const datasetName = __PersonalMemoryProviderDatasetName(datasetId);
+		expect(___MemoryGatewayDatasetEnsureRequestSchema.safeParse({ datasetName }).success).toBe(true);
+		expect(__PersonalMemoryProviderDatasetName(datasetId)).toBe(datasetName);
+		expect(__PersonalMemoryProviderDatasetName("cmemorycatalog000000000002")).not.toBe(datasetName);
+		expect(datasetName).not.toContain(datasetId);
+	});
+
+	it.each(["", " catalog-id", "catalog-id ", "a".repeat(129)])("refuses a noncanonical catalog id", function _RejectsInvalidId(datasetId)
+	{
+		expect(function _Derive() { return __PersonalMemoryProviderDatasetName(datasetId); }).toThrow("personal memory dataset identifier cannot form a provider name");
+	});
+});

--- a/libs/backend/agents/personal/memory/main/src/operations/__tests__/personal-memory-operation-lifecycle.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/__tests__/personal-memory-operation-lifecycle.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import { MemoryMutationDeliveryStates } from "@opencrane/contracts";
+
+import { __CreatePersonalMemoryOperationLifecycle, __PlanPersonalMemoryOperationLifecycle, _PersonalMemoryOperationLifecyclePolicy } from "../personal-memory-operation-lifecycle";
+import { PersonalMemoryOperationEvents, PersonalMemoryOperationFailureCodes, PersonalMemoryOperationKinds, PersonalMemoryOperationPhases, PersonalMemoryOperationTransitionDenialReasons, PersonalMemoryOperationTransitionOutcomes, type PersonalMemoryOperationEvent, type PersonalMemoryOperationLifecycle } from "../personal-memory-operation.types";
+import { ___CreatePersonalMemoryOperationLifecycleCommandSchema, ___PersonalMemoryOperationEventSchema, ___PersonalMemoryOperationLifecycleSchema } from "../personal-memory-operation.validator";
+
+const _OPERATION_ID = "00000000-0000-4000-8000-000000000001";
+const _DATASET_ID = "00000000-0000-4000-8000-000000000002";
+const _DOCUMENT_ID = "00000000-0000-4000-8000-000000000003";
+const _TARGET_DOCUMENT_ID = "00000000-0000-4000-8000-000000000004";
+const _INDEXING_ID = "00000000-0000-4000-8000-000000000005";
+const _PIPELINE_ID = "00000000-0000-4000-8000-000000000006";
+const _CONTENT_DIGEST = `sha256:${"a".repeat(64)}`;
+const _INPUT_DIGEST = `sha256:${"b".repeat(64)}`;
+
+describe("personal-memory operation lifecycle", function _DescribeLifecycle()
+{
+	it("creates strategy-specific initial phases without content or provider secrets", function _CreateInitialStates()
+	{
+		const remember = _Create(PersonalMemoryOperationKinds.Remember);
+		const correct = _Create(PersonalMemoryOperationKinds.Correct);
+		const forget = _Create(PersonalMemoryOperationKinds.Forget);
+		expect(remember).toMatchObject({ phase: PersonalMemoryOperationPhases.DatasetEnsurePending, providerDatasetId: null, expectedContentDigest: _CONTENT_DIGEST, targetFactId: null });
+		expect(correct).toMatchObject({ phase: PersonalMemoryOperationPhases.DocumentAddPending, providerDatasetId: _DATASET_ID, expectedContentDigest: _CONTENT_DIGEST, targetFactId: "fact-1" });
+		expect(forget).toMatchObject({ phase: PersonalMemoryOperationPhases.DocumentDeletePending, providerDatasetId: _DATASET_ID, expectedContentDigest: null, targetFactId: "fact-1" });
+		expect(remember).not.toHaveProperty("content");
+		expect(remember).not.toHaveProperty("credential");
+	});
+
+	it("advances Remember only through dataset, document, saved input evidence, indexing, and catalog", function _Remember()
+	{
+		let operation = _Create(PersonalMemoryOperationKinds.Remember);
+		operation = _Advance(operation, { event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId: _DATASET_ID });
+		operation = _Advance(operation, { event: PersonalMemoryOperationEvents.DocumentAdded, documentId: _DOCUMENT_ID, contentDigest: _CONTENT_DIGEST });
+		expect(operation.phase).toBe(PersonalMemoryOperationPhases.CognifyPending);
+		operation = _Advance(operation, { event: PersonalMemoryOperationEvents.IndexEvidenceSaved, indexingOperationId: _INDEXING_ID, expectedInputEvidenceDigest: _INPUT_DIGEST });
+		operation = _Advance(operation, { event: PersonalMemoryOperationEvents.IndexingCompleted, indexingOperationId: _INDEXING_ID, expectedInputEvidenceDigest: _INPUT_DIGEST, pipelineRunId: _PIPELINE_ID });
+		operation = _Advance(operation, { event: PersonalMemoryOperationEvents.CatalogCommitted });
+		expect(operation).toMatchObject({ phase: PersonalMemoryOperationPhases.Completed, revision: 6, providerDatasetId: _DATASET_ID, documentId: _DOCUMENT_ID, indexingOperationId: _INDEXING_ID, expectedInputEvidenceDigest: _INPUT_DIGEST, pipelineRunId: _PIPELINE_ID });
+	});
+
+	it("keeps correction cleanup after catalog adoption and forgetting finalization after deletion", function _CorrectionAndForget()
+	{
+		let correction = _Create(PersonalMemoryOperationKinds.Correct);
+		correction = _Advance(correction, { event: PersonalMemoryOperationEvents.DocumentAdded, documentId: _DOCUMENT_ID, contentDigest: _CONTENT_DIGEST });
+		correction = _Advance(correction, { event: PersonalMemoryOperationEvents.IndexEvidenceSaved, indexingOperationId: _INDEXING_ID, expectedInputEvidenceDigest: _INPUT_DIGEST });
+		correction = _Advance(correction, { event: PersonalMemoryOperationEvents.IndexingCompleted, indexingOperationId: _INDEXING_ID, expectedInputEvidenceDigest: _INPUT_DIGEST, pipelineRunId: _PIPELINE_ID });
+		correction = _Advance(correction, { event: PersonalMemoryOperationEvents.CatalogCommitted });
+		expect(correction.phase).toBe(PersonalMemoryOperationPhases.PriorDocumentDeletePending);
+		correction = _Advance(correction, { event: PersonalMemoryOperationEvents.PriorDocumentDeleted, documentId: _TARGET_DOCUMENT_ID });
+		expect(correction.phase).toBe(PersonalMemoryOperationPhases.Completed);
+
+		let forget = _Create(PersonalMemoryOperationKinds.Forget);
+		forget = _Advance(forget, { event: PersonalMemoryOperationEvents.DocumentDeleted, documentId: _TARGET_DOCUMENT_ID });
+		expect(forget.phase).toBe(PersonalMemoryOperationPhases.CatalogFinalizePending);
+		forget = _Advance(forget, { event: PersonalMemoryOperationEvents.CatalogFinalized });
+		expect(forget.phase).toBe(PersonalMemoryOperationPhases.Completed);
+	});
+
+	it("retries only proven-not-sent mutations and freezes ambiguous effects for evidence recovery", function _DeliveryEvidence()
+	{
+		const operation = _Create(PersonalMemoryOperationKinds.Remember);
+		const retry = __PlanPersonalMemoryOperationLifecycle(operation, _Event(operation, { event: PersonalMemoryOperationEvents.MutationFailed, failureCode: PersonalMemoryOperationFailureCodes.DatasetUnavailable, deliveryState: MemoryMutationDeliveryStates.ProvenNotSent }));
+		expect(retry).toEqual({ outcome: PersonalMemoryOperationTransitionOutcomes.Retry, operation });
+		const ambiguous = __PlanPersonalMemoryOperationLifecycle(operation, _Event(operation, { event: PersonalMemoryOperationEvents.MutationFailed, failureCode: PersonalMemoryOperationFailureCodes.DatasetUnavailable, deliveryState: MemoryMutationDeliveryStates.Ambiguous }));
+		expect(ambiguous).toMatchObject({ outcome: PersonalMemoryOperationTransitionOutcomes.Advanced, operation: { phase: PersonalMemoryOperationPhases.RecoveryRequired, recoveryPhase: PersonalMemoryOperationPhases.DatasetEnsurePending, failureCode: PersonalMemoryOperationFailureCodes.DatasetUnavailable, deliveryState: MemoryMutationDeliveryStates.Ambiguous, revision: 2 } });
+		const recovered = _Advance(ambiguous.operation!, { event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId: _DATASET_ID });
+		expect(recovered).toMatchObject({ phase: PersonalMemoryOperationPhases.DocumentAddPending, recoveryPhase: null, failureCode: null, deliveryState: null });
+	});
+
+	it("denies stale, foreign, unknown, and conflicting evidence without returning a state", function _DenyInvalidEvents()
+	{
+		const operation = _Create(PersonalMemoryOperationKinds.Remember);
+		const stale = __PlanPersonalMemoryOperationLifecycle(operation, { ..._Event(operation, { event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId: _DATASET_ID }), expectedRevision: 2 });
+		expect(stale).toEqual({ outcome: PersonalMemoryOperationTransitionOutcomes.Denied, reason: PersonalMemoryOperationTransitionDenialReasons.StaleRevision });
+		const foreign = __PlanPersonalMemoryOperationLifecycle(operation, { ..._Event(operation, { event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId: _DATASET_ID }), operationId: "00000000-0000-4000-8000-000000000099" });
+		expect(foreign).toEqual({ outcome: PersonalMemoryOperationTransitionOutcomes.Denied, reason: PersonalMemoryOperationTransitionDenialReasons.WrongOperation });
+		const unknown = __PlanPersonalMemoryOperationLifecycle(operation, { ..._Event(operation, { event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId: _DATASET_ID }), event: "other", token: "secret" } as unknown as PersonalMemoryOperationEvent);
+		expect(unknown).toEqual({ outcome: PersonalMemoryOperationTransitionOutcomes.Denied, reason: PersonalMemoryOperationTransitionDenialReasons.InvalidInput });
+		const documentPhase = _Advance(operation, { event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId: _DATASET_ID });
+		const wrongDigest = __PlanPersonalMemoryOperationLifecycle(documentPhase, _Event(documentPhase, { event: PersonalMemoryOperationEvents.DocumentAdded, documentId: _DOCUMENT_ID, contentDigest: `sha256:${"c".repeat(64)}` }));
+		expect(wrongDigest).toEqual({ outcome: PersonalMemoryOperationTransitionOutcomes.Denied, reason: PersonalMemoryOperationTransitionDenialReasons.ConflictingEvidence });
+		const wrongFailure = __PlanPersonalMemoryOperationLifecycle(documentPhase, _Event(documentPhase, { event: PersonalMemoryOperationEvents.MutationFailed, failureCode: PersonalMemoryOperationFailureCodes.DeletionUnavailable, deliveryState: MemoryMutationDeliveryStates.Ambiguous }));
+		expect(wrongFailure).toEqual({ outcome: PersonalMemoryOperationTransitionOutcomes.Denied, reason: PersonalMemoryOperationTransitionDenialReasons.ConflictingEvidence });
+	});
+
+	it("binds indexing completion to the saved operation UUID and complete input digest", function _IndexEvidence()
+	{
+		let operation = _Create(PersonalMemoryOperationKinds.Correct);
+		operation = _Advance(operation, { event: PersonalMemoryOperationEvents.DocumentAdded, documentId: _DOCUMENT_ID, contentDigest: _CONTENT_DIGEST });
+		operation = _Advance(operation, { event: PersonalMemoryOperationEvents.IndexEvidenceSaved, indexingOperationId: _INDEXING_ID, expectedInputEvidenceDigest: _INPUT_DIGEST });
+		const wrong = __PlanPersonalMemoryOperationLifecycle(operation, _Event(operation, { event: PersonalMemoryOperationEvents.IndexingCompleted, indexingOperationId: "00000000-0000-4000-8000-000000000099", expectedInputEvidenceDigest: _INPUT_DIGEST, pipelineRunId: _PIPELINE_ID }));
+		expect(wrong).toEqual({ outcome: PersonalMemoryOperationTransitionOutcomes.Denied, reason: PersonalMemoryOperationTransitionDenialReasons.ConflictingEvidence });
+		expect(operation.pipelineRunId).toBeNull();
+	});
+
+	it("requires positive recovery evidence and never resends an already ambiguous mutation", function _RecoveryEvidence()
+	{
+		let forget = _Create(PersonalMemoryOperationKinds.Forget);
+		const ambiguous = __PlanPersonalMemoryOperationLifecycle(forget, _Event(forget, { event: PersonalMemoryOperationEvents.MutationFailed, failureCode: PersonalMemoryOperationFailureCodes.DeletionUnavailable, deliveryState: MemoryMutationDeliveryStates.Ambiguous }));
+		expect(ambiguous).toMatchObject({ outcome: PersonalMemoryOperationTransitionOutcomes.Advanced, operation: { phase: PersonalMemoryOperationPhases.RecoveryRequired, recoveryPhase: PersonalMemoryOperationPhases.DocumentDeletePending } });
+		forget = ambiguous.operation!;
+		const resend = __PlanPersonalMemoryOperationLifecycle(forget, _Event(forget, { event: PersonalMemoryOperationEvents.MutationFailed, failureCode: PersonalMemoryOperationFailureCodes.DeletionUnavailable, deliveryState: MemoryMutationDeliveryStates.ProvenNotSent }));
+		expect(resend).toEqual({ outcome: PersonalMemoryOperationTransitionOutcomes.Denied, reason: PersonalMemoryOperationTransitionDenialReasons.InvalidTransition });
+		forget = _Advance(forget, { event: PersonalMemoryOperationEvents.DocumentDeleted, documentId: _TARGET_DOCUMENT_ID });
+		expect(forget).toMatchObject({ phase: PersonalMemoryOperationPhases.CatalogFinalizePending, recoveryPhase: null, failureCode: null, deliveryState: null });
+	});
+
+	it("defines a cell for every command, phase, and event", function _ExhaustivePolicy()
+	{
+		const policy = _PersonalMemoryOperationLifecyclePolicy();
+		for (const kind of Object.values(PersonalMemoryOperationKinds))
+		{
+			expect(Object.keys(policy[kind]).sort()).toEqual([...Object.values(PersonalMemoryOperationPhases)].sort());
+			for (const phase of Object.values(PersonalMemoryOperationPhases))
+				expect(Object.keys(policy[kind][phase]).sort()).toEqual([...Object.values(PersonalMemoryOperationEvents)].sort());
+		}
+	});
+
+	it("validators reject missing strategy evidence, inconsistent recovery, and extra secret fields", function _Validation()
+	{
+		expect(___CreatePersonalMemoryOperationLifecycleCommandSchema.safeParse({ operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Forget, expectedContentDigest: _CONTENT_DIGEST, targetFactId: "fact-1", targetDocumentId: _TARGET_DOCUMENT_ID, providerDatasetId: _DATASET_ID }).success).toBe(false);
+		const operation = _Create(PersonalMemoryOperationKinds.Remember);
+		expect(___PersonalMemoryOperationLifecycleSchema.safeParse({ ...operation, phase: PersonalMemoryOperationPhases.RecoveryRequired, recoveryPhase: null, failureCode: PersonalMemoryOperationFailureCodes.SourceUnavailable }).success).toBe(false);
+		expect(___PersonalMemoryOperationEventSchema.safeParse({ ..._Event(operation, { event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId: _DATASET_ID }), bearerToken: "secret" }).success).toBe(false);
+	});
+
+	it("rejects state evidence that the lifecycle planner can never save", function _RejectImpossibleSavedStates()
+	{
+		const remember = _Create(PersonalMemoryOperationKinds.Remember);
+		expect(___PersonalMemoryOperationLifecycleSchema.safeParse({ ...remember, failureCode: PersonalMemoryOperationFailureCodes.AuthorityEnded }).success).toBe(false);
+		expect(___PersonalMemoryOperationLifecycleSchema.safeParse({ ...remember, recoveryPhase: PersonalMemoryOperationPhases.DocumentAddPending }).success).toBe(false);
+
+		const ambiguous = __PlanPersonalMemoryOperationLifecycle(remember, _Event(remember, { event: PersonalMemoryOperationEvents.MutationFailed, failureCode: PersonalMemoryOperationFailureCodes.DatasetUnavailable, deliveryState: MemoryMutationDeliveryStates.Ambiguous }));
+		expect(ambiguous.outcome).toBe(PersonalMemoryOperationTransitionOutcomes.Advanced);
+		expect(___PersonalMemoryOperationLifecycleSchema.safeParse({ ...ambiguous.operation!, deliveryState: MemoryMutationDeliveryStates.ProvenNotSent }).success).toBe(false);
+		expect(___PersonalMemoryOperationLifecycleSchema.safeParse({ ...ambiguous.operation!, failureCode: PersonalMemoryOperationFailureCodes.DeletionUnavailable }).success).toBe(false);
+
+		const forget = _Create(PersonalMemoryOperationKinds.Forget);
+		expect(___PersonalMemoryOperationLifecycleSchema.safeParse({ ...forget, phase: PersonalMemoryOperationPhases.CatalogCommitPending }).success).toBe(false);
+		expect(___PersonalMemoryOperationLifecycleSchema.safeParse({ ...forget, phase: PersonalMemoryOperationPhases.RecoveryRequired, recoveryPhase: PersonalMemoryOperationPhases.DocumentAddPending, failureCode: PersonalMemoryOperationFailureCodes.DocumentConflict, deliveryState: MemoryMutationDeliveryStates.Ambiguous }).success).toBe(false);
+	});
+});
+
+function _Create(kind: PersonalMemoryOperationKinds): PersonalMemoryOperationLifecycle
+{
+	let expectedContentDigest: string | null = _CONTENT_DIGEST;
+	let targetFactId: string | null = "fact-1";
+	let targetDocumentId: string | null = _TARGET_DOCUMENT_ID;
+	let providerDatasetId: string | null = _DATASET_ID;
+	if (kind === PersonalMemoryOperationKinds.Remember)
+	{
+		targetFactId = null;
+		targetDocumentId = null;
+		providerDatasetId = null;
+	}
+	else if (kind === PersonalMemoryOperationKinds.Forget)
+		expectedContentDigest = null;
+	const operation = __CreatePersonalMemoryOperationLifecycle({ operationId: _OPERATION_ID, kind, expectedContentDigest, targetFactId, targetDocumentId, providerDatasetId });
+	expect(operation).not.toBeNull();
+	return operation!;
+}
+
+function _Event<TEvent extends Omit<PersonalMemoryOperationEvent, "operationId" | "kind" | "expectedRevision">>(operation: PersonalMemoryOperationLifecycle, event: TEvent): PersonalMemoryOperationEvent
+{
+	return { operationId: operation.operationId, kind: operation.kind, expectedRevision: operation.revision, ...event } as PersonalMemoryOperationEvent;
+}
+
+function _Advance<TEvent extends Omit<PersonalMemoryOperationEvent, "operationId" | "kind" | "expectedRevision">>(operation: PersonalMemoryOperationLifecycle, event: TEvent): PersonalMemoryOperationLifecycle
+{
+	const result = __PlanPersonalMemoryOperationLifecycle(operation, _Event(operation, event));
+	expect(result.outcome).toBe(PersonalMemoryOperationTransitionOutcomes.Advanced);
+	return result.operation!;
+}

--- a/libs/backend/agents/personal/memory/main/src/operations/__tests__/personal-memory-operation.sql.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/__tests__/personal-memory-operation.sql.test.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from "node:crypto";
+
+import { AuthorizationBoundaryKind, MemoryConsentState, MemoryDatasetState, MemoryFactState, PrincipalProvenance, Prisma, PrismaClient } from "@prisma/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { MemoryMutationDeliveryStates } from "@opencrane/contracts";
+
+import { PersonalMemoryOperationAdmissionOutcomes, PersonalMemoryOperationPersistenceOutcomes, type AdmitPersonalMemoryOperationCommand } from "../personal-memory-operation-persistence.types";
+import { PersonalMemoryOperationEvents, PersonalMemoryOperationFailureCodes, PersonalMemoryOperationKinds, PersonalMemoryOperationPhases } from "../personal-memory-operation.types";
+import { PrismaPersonalMemoryOperationRepository } from "../prisma-personal-memory-operation-repository";
+import { PrismaPersonalMemoryOperationUnitOfWork } from "../prisma-personal-memory-operation-unit-of-work";
+
+/** Separate database clients expose committed winners and Serializable retries. */
+const _First = new PrismaClient();
+/** Competing caller with no shared transaction state. */
+const _Second = new PrismaClient();
+/** Synthetic content digest; no plaintext is read or sent by these persistence proofs. */
+const _ContentDigest = `sha256:${"a".repeat(64)}`;
+
+/** Creates only the identity needed by the dataset's real foreign key. */
+async function _Principal(): Promise<string>
+{
+	const id = randomUUID();
+	await _First.principal.create({ data: { id, siloId: id, issuer: "https://identity.example.test", subject: id, provenance: PrincipalProvenance.External } });
+	return id;
+}
+
+/** Builds immutable synthetic message coordinates without creating a provider or workflow task. */
+function _Command(principalId: string, datasetId: string): AdmitPersonalMemoryOperationCommand
+{
+	const operationId = randomUUID();
+	return {
+		operationId, siloId: principalId, datasetId, actorPrincipalId: principalId,
+		idempotencyKeyDigest: `sha256:${operationId.replaceAll("-", "").repeat(2)}`,
+		commandDigest: `sha256:${"b".repeat(64)}`, kind: PersonalMemoryOperationKinds.Remember,
+		source: { conversationId: randomUUID(), messageId: randomUUID(), messagePosition: 0n, payloadRef: randomUUID(), ciphertextDigest: `sha256:${"c".repeat(64)}`, authorPrincipalId: principalId },
+		contentDigest: _ContentDigest, targetFactId: null, targetDocumentId: null, expectedFactRevision: null,
+		providerDatasetId: null, task: { taskId: randomUUID(), taskName: "personal-memory-operation", taskKey: operationId }, admittedAt: new Date(),
+	};
+}
+
+/** Creates a provisional dataset inside whichever transaction owns the command admission. */
+async function _Dataset(transaction: Prisma.TransactionClient, principalId: string, datasetId: string): Promise<void>
+{
+	await transaction.memoryDataset.create({ data: { id: datasetId, siloId: principalId, boundaryKind: AuthorizationBoundaryKind.Personal, boundaryPrincipalId: principalId, createdBy: principalId, state: MemoryDatasetState.Provisioning, cogneeDatasetId: null } });
+}
+
+/** Seeds one committed provisional dataset for concurrency and restart proofs. */
+async function _Fixture(): Promise<AdmitPersonalMemoryOperationCommand>
+{
+	const principalId = await _Principal();
+	const datasetId = randomUUID();
+	await _First.$transaction(async function _Seed(transaction) { await _Dataset(transaction, principalId, datasetId); });
+	return _Command(principalId, datasetId);
+}
+
+describe("personal-memory operations on fresh PostgreSQL", function _Suite()
+{
+	beforeAll(async function _Connect()
+	{
+		if (!process.env.DATABASE_URL)
+			throw new Error("Personal-memory SQL proofs require DATABASE_URL and the fresh target baseline");
+		await Promise.all([_First.$connect(), _Second.$connect()]);
+	});
+	afterAll(async function _Disconnect() { await Promise.all([_First.$disconnect(), _Second.$disconnect()]); });
+
+	it("admits one operation and one reserved task identity under concurrent replay", async function _ConcurrentAdmission()
+	{
+		const command = await _Fixture();
+		const first = new PrismaPersonalMemoryOperationUnitOfWork(_First);
+		const second = new PrismaPersonalMemoryOperationUnitOfWork(_Second);
+		const results = await Promise.all([first.admit(command), second.admit(command)]);
+		expect(results.filter(result => result.outcome === PersonalMemoryOperationAdmissionOutcomes.Created)).toHaveLength(1);
+		expect(results.filter(result => result.outcome === PersonalMemoryOperationAdmissionOutcomes.Replayed)).toHaveLength(1);
+		expect(results.map(result => result.operation.task.taskId)).toEqual([command.task.taskId, command.task.taskId]);
+		expect(await _First.personalMemoryOperation.count({ where: { siloId: command.siloId } })).toBe(1);
+	});
+
+	it("adopts a provider dataset once and returns the saved operation after client restart", async function _ConcurrentAdoption()
+	{
+		const command = await _Fixture();
+		const first = new PrismaPersonalMemoryOperationUnitOfWork(_First);
+		const second = new PrismaPersonalMemoryOperationUnitOfWork(_Second);
+		await first.admit(command);
+		const providerDatasetId = randomUUID();
+		const event = { operationId: command.operationId, kind: command.kind, expectedRevision: 1, event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId } as const;
+		const results = await Promise.all([first.apply(event, new Date()), second.apply(event, new Date())]);
+		expect(results.filter(result => result.outcome === PersonalMemoryOperationPersistenceOutcomes.Advanced)).toHaveLength(1);
+		expect(await _First.memoryDataset.findUnique({ where: { id: command.datasetId } })).toMatchObject({ state: MemoryDatasetState.Active, cogneeDatasetId: providerDatasetId });
+		const restartedClient = new PrismaClient();
+		try
+		{
+			const restarted = new PrismaPersonalMemoryOperationUnitOfWork(restartedClient);
+			await expect(restarted.admit(command)).resolves.toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Replayed, operation: { revision: 2, phase: PersonalMemoryOperationPhases.DocumentAddPending, admittedProviderDatasetId: null, providerDatasetId } });
+		}
+		finally { await restartedClient.$disconnect(); }
+	});
+
+	it("rolls back a provisional dataset and operation together when admission fails", async function _AdmissionRollback()
+	{
+		const principalId = await _Principal();
+		const command = _Command(principalId, randomUUID());
+		await expect(_First.$transaction(async function _FailAdmission(transaction)
+		{
+			await _Dataset(transaction, principalId, command.datasetId);
+			const repository = new PrismaPersonalMemoryOperationRepository(transaction);
+			await repository.admit(command);
+			throw new Error("synthetic admission failure");
+		}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })).rejects.toThrow("synthetic admission failure");
+		expect(await _Second.memoryDataset.findUnique({ where: { id: command.datasetId } })).toBeNull();
+		expect(await _Second.personalMemoryOperation.findUnique({ where: { id: command.operationId } })).toBeNull();
+	});
+
+	it("rolls back provider adoption together with the operation's saved step", async function _AdoptionRollback()
+	{
+		const command = await _Fixture();
+		const owner = new PrismaPersonalMemoryOperationUnitOfWork(_First);
+		await owner.admit(command);
+		await expect(_First.$transaction(async function _FailAdoption(transaction)
+		{
+			const repository = new PrismaPersonalMemoryOperationRepository(transaction);
+			await repository.apply({ operationId: command.operationId, kind: command.kind, expectedRevision: 1, event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId: randomUUID() }, new Date());
+			throw new Error("synthetic adoption failure");
+		}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })).rejects.toThrow("synthetic adoption failure");
+		expect(await _Second.memoryDataset.findUnique({ where: { id: command.datasetId } })).toMatchObject({ state: MemoryDatasetState.Provisioning, cogneeDatasetId: null });
+		expect(await _Second.personalMemoryOperation.findUnique({ where: { id: command.operationId } })).toMatchObject({ revision: 1, providerDatasetId: null });
+	});
+
+	it("keeps an uncertain document effect durable across a new client", async function _RecoveryAfterRestart()
+	{
+		const command = await _Fixture();
+		const owner = new PrismaPersonalMemoryOperationUnitOfWork(_First);
+		await owner.admit(command);
+		await owner.apply({ operationId: command.operationId, kind: command.kind, expectedRevision: 1, event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId: randomUUID() }, new Date());
+		await owner.apply({ operationId: command.operationId, kind: command.kind, expectedRevision: 2, event: PersonalMemoryOperationEvents.MutationFailed, failureCode: PersonalMemoryOperationFailureCodes.DocumentConflict, deliveryState: MemoryMutationDeliveryStates.Ambiguous }, new Date());
+		const restartedClient = new PrismaClient();
+		try
+		{
+			const restarted = new PrismaPersonalMemoryOperationUnitOfWork(restartedClient);
+			await expect(restarted.admit(command)).resolves.toMatchObject({ operation: { revision: 3, phase: PersonalMemoryOperationPhases.RecoveryRequired, recoveryPhase: PersonalMemoryOperationPhases.DocumentAddPending, failureCode: PersonalMemoryOperationFailureCodes.DocumentConflict, deliveryState: MemoryMutationDeliveryStates.Ambiguous } });
+		}
+		finally { await restartedClient.$disconnect(); }
+	});
+
+	it.each([MemoryFactState.Active, MemoryFactState.Corrected])("hides a %s fact once and replays against its original expected revision", async function _ForgetReplay(state)
+	{
+		const command = await _Fixture();
+		const providerDatasetId = randomUUID();
+		await _First.memoryDataset.update({ where: { id: command.datasetId }, data: { state: MemoryDatasetState.Active, cogneeDatasetId: providerDatasetId } });
+		const factId = randomUUID();
+		const documentId = randomUUID();
+		await _First.memoryFactCatalog.create({ data: { id: factId, datasetId: command.datasetId, cogneeExternalId: documentId, contentDigest: _ContentDigest, state: MemoryFactState.Active, consentState: MemoryConsentState.Explicit, sensitivity: "ordinary", provenance: { user_statement: true }, recordedBy: command.actorPrincipalId } });
+		if (state === MemoryFactState.Corrected)
+		{
+			await _First.memoryFactCatalog.create({ data: { id: randomUUID(), datasetId: command.datasetId, cogneeExternalId: randomUUID(), contentDigest: `sha256:${"d".repeat(64)}`, state: MemoryFactState.Active, consentState: MemoryConsentState.Explicit, sensitivity: "ordinary", provenance: { user_statement: true }, recordedBy: command.actorPrincipalId, supersedesFactId: factId } });
+		}
+		const expectedFactRevision = state === MemoryFactState.Corrected ? 2 : 1;
+		const forget = { ...command, kind: PersonalMemoryOperationKinds.Forget, source: null, contentDigest: null, targetFactId: factId, targetDocumentId: documentId, expectedFactRevision, providerDatasetId };
+		const first = new PrismaPersonalMemoryOperationUnitOfWork(_First);
+		const second = new PrismaPersonalMemoryOperationUnitOfWork(_Second);
+		const results = await Promise.all([first.admit(forget), second.admit(forget)]);
+		expect(results.filter(result => result.outcome === PersonalMemoryOperationAdmissionOutcomes.Created)).toHaveLength(1);
+		expect(await _First.memoryFactCatalog.findUnique({ where: { id: factId } })).toMatchObject({ revision: expectedFactRevision + 1, state: MemoryFactState.ForgetPending });
+		expect(results.every(result => result.operation.expectedFactRevision === expectedFactRevision)).toBe(true);
+	});
+});

--- a/libs/backend/agents/personal/memory/main/src/operations/__tests__/prisma-personal-memory-operation-repository.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/__tests__/prisma-personal-memory-operation-repository.test.ts
@@ -1,0 +1,439 @@
+import { AuthorizationBoundaryKind, MemoryDatasetState, MemoryFactState, PersonalMemoryOperationDeliveryState as PrismaDeliveryState, PersonalMemoryOperationFailureCode as PrismaFailureCode, PersonalMemoryOperationKind as PrismaKind, PersonalMemoryOperationPhase as PrismaPhase, type PersonalMemoryOperation as PrismaOperationRow, type Prisma } from "@prisma/client";
+import { describe, expect, it, vi, type Mock } from "vitest";
+
+import { MemoryMutationDeliveryStates } from "@opencrane/contracts";
+
+import { PersonalMemoryOperationAdmissionOutcomes, PersonalMemoryOperationInvalidState, PersonalMemoryOperationPersistenceOutcomes, PersonalMemoryOperationReplayConflict, type AdmitPersonalMemoryOperationCommand } from "../personal-memory-operation-persistence.types";
+import { PrismaPersonalMemoryOperationRepository } from "../prisma-personal-memory-operation-repository";
+import { PersonalMemoryOperationEvents, PersonalMemoryOperationFailureCodes, PersonalMemoryOperationKinds, type PersonalMemoryOperationEvent } from "../personal-memory-operation.types";
+
+const _OPERATION_ID = "00000000-0000-4000-8000-000000000001";
+const _DATASET_PROVIDER_ID = "00000000-0000-4000-8000-000000000002";
+const _TARGET_DOCUMENT_ID = "00000000-0000-4000-8000-000000000003";
+const _TASK_ID = "00000000-0000-4000-8000-000000000004";
+const _NEW_DOCUMENT_ID = "00000000-0000-4000-8000-000000000005";
+const _INDEXING_ID = "00000000-0000-4000-8000-000000000006";
+const _PIPELINE_ID = "00000000-0000-4000-8000-000000000007";
+const _CONTENT_DIGEST = `sha256:${"a".repeat(64)}`;
+const _CIPHERTEXT_DIGEST = `sha256:${"b".repeat(64)}`;
+const _IDEMPOTENCY_DIGEST = `sha256:${"c".repeat(64)}`;
+const _COMMAND_DIGEST = `sha256:${"d".repeat(64)}`;
+const _INPUT_DIGEST = `sha256:${"e".repeat(64)}`;
+const _ADMITTED_AT = new Date("2026-09-13T08:00:00.000Z");
+const _RECORDED_AT = new Date("2026-09-13T08:05:00.000Z");
+
+/** Prisma delegate shape used by behavior tests without a database process. */
+interface _TransactionFixture
+{
+	/** Transaction client passed to the repository. */
+	readonly transaction: Prisma.TransactionClient;
+	/** Dataset read used before its no-change lock update. */
+	readonly findDataset: Mock;
+	/** Dataset update that acquires the first row lock. */
+	readonly updateDataset: Mock;
+	/** Fact read used before the sorted fact lock. */
+	readonly findFact: Mock;
+	/** Fact update that acquires the second row lock. */
+	readonly updateFact: Mock;
+	/** Operation replay and lifecycle reads. */
+	readonly findOperation: Mock;
+	/** Operation no-change lock and lifecycle CAS updates. */
+	readonly updateOperation: Mock;
+	/** Operation insert used by a new admission. */
+	readonly createOperation: Mock;
+}
+
+describe("PrismaPersonalMemoryOperationRepository", function _Suite()
+{
+	it("creates a secret-free operation after locking its dataset and keeps only encrypted source coordinates", async function _Create()
+	{
+		const callOrder: string[] = [];
+		const row = _CorrectRow();
+		const fixture = _Fixture(row, callOrder);
+		fixture.findOperation.mockResolvedValueOnce(null);
+		fixture.createOperation.mockImplementation(async function _CreateRow()
+		{
+			callOrder.push("operation-create");
+			return row;
+		});
+		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+		const result = await repository.admit(_CorrectCommand());
+
+		expect(result).toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Created, operation: { operationId: _OPERATION_ID, source: { payloadRef: "payload-1", ciphertextDigest: _CIPHERTEXT_DIGEST } } });
+		expect(callOrder).toEqual(["dataset-read", "dataset-lock", "fact-read:fact-1", "fact-lock:fact-1", "operation-create"]);
+		const data = fixture.createOperation.mock.calls[0][0].data;
+		expect(data).not.toHaveProperty("content");
+		expect(data).not.toHaveProperty("plaintext");
+		expect(data).not.toHaveProperty("providerPayload");
+		expect(data).toMatchObject({ sourcePayloadRef: "payload-1", sourceCiphertextDigest: _CIPHERTEXT_DIGEST, contentDigest: _CONTENT_DIGEST, workflowTaskId: _TASK_ID });
+	});
+
+	it("returns the original operation for an exact replay and conflicts when immutable evidence changes", async function _Replay()
+	{
+		const exact = _Fixture(_CorrectRow());
+		const repository = new PrismaPersonalMemoryOperationRepository(exact.transaction);
+		await expect(repository.admit(_CorrectCommand())).resolves.toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Replayed, operation: { operationId: _OPERATION_ID, revision: 1 } });
+		const regenerated = _Fixture(_CorrectRow());
+		const regeneratedRepository = new PrismaPersonalMemoryOperationRepository(regenerated.transaction);
+		const retryGeneratedIdentity = { ..._CorrectCommand(), operationId: "00000000-0000-4000-8000-000000000099", task: { taskId: "00000000-0000-4000-8000-000000000098", taskName: "personal-memory-operation", taskKey: "retry-generated-key" } };
+		await expect(regeneratedRepository.admit(retryGeneratedIdentity)).resolves.toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Replayed, operation: { operationId: _OPERATION_ID, task: { taskId: _TASK_ID } } });
+
+		const changedCommands: AdmitPersonalMemoryOperationCommand[] = [
+			{ ..._CorrectCommand(), actorPrincipalId: "principal-2", source: { ..._CorrectCommand().source!, authorPrincipalId: "principal-2" } },
+			{ ..._CorrectCommand(), commandDigest: `sha256:${"e".repeat(64)}` },
+			{ ..._CorrectCommand(), source: { ..._CorrectCommand().source!, messageId: "message-2" } },
+			{ ..._CorrectCommand(), targetFactId: "fact-2" },
+			{ ..._CorrectCommand(), expectedFactRevision: 8 },
+			{ ..._CorrectCommand(), kind: PersonalMemoryOperationKinds.Forget, source: null, contentDigest: null },
+		];
+		for (const command of changedCommands)
+		{
+			const fixture = _Fixture(_CorrectRow());
+			const changedRepository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+			await expect(changedRepository.admit(command)).rejects.toBeInstanceOf(PersonalMemoryOperationReplayConflict);
+		}
+	});
+
+	it("replays Remember after provider dataset adoption by comparing the immutable admitted coordinate", async function _RememberReplayAfterProgress()
+	{
+		const newDatasetOperation = _RememberRow(null, _DATASET_PROVIDER_ID);
+		const newDatasetFixture = _Fixture(newDatasetOperation);
+		const newDatasetRepository = new PrismaPersonalMemoryOperationRepository(newDatasetFixture.transaction);
+		await expect(newDatasetRepository.admit(_RememberCommand(null))).resolves.toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Replayed, operation: { admittedProviderDatasetId: null, providerDatasetId: _DATASET_PROVIDER_ID, revision: 2 } });
+
+		const existingDatasetOperation = _RememberRow(_DATASET_PROVIDER_ID, _DATASET_PROVIDER_ID);
+		const existingDatasetFixture = _Fixture(existingDatasetOperation);
+		const existingDatasetRepository = new PrismaPersonalMemoryOperationRepository(existingDatasetFixture.transaction);
+		await expect(existingDatasetRepository.admit(_RememberCommand(_DATASET_PROVIDER_ID))).resolves.toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Replayed, operation: { admittedProviderDatasetId: _DATASET_PROVIDER_ID, providerDatasetId: _DATASET_PROVIDER_ID } });
+	});
+
+	it("admits Remember only for a new Provisioning dataset or an exact existing Active dataset", async function _RememberDatasetState()
+	{
+		const freshRow = _RememberInitialRow(null);
+		const freshFixture = _Fixture(freshRow, [], _Dataset(MemoryDatasetState.Provisioning, null));
+		freshFixture.findOperation.mockResolvedValueOnce(null);
+		freshFixture.createOperation.mockResolvedValueOnce(freshRow);
+		const freshRepository = new PrismaPersonalMemoryOperationRepository(freshFixture.transaction);
+		await expect(freshRepository.admit(_RememberCommand(null))).resolves.toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Created, operation: { providerDatasetId: null } });
+
+		const existingRow = _RememberInitialRow(_DATASET_PROVIDER_ID);
+		const existingFixture = _Fixture(existingRow);
+		existingFixture.findOperation.mockResolvedValueOnce(null);
+		existingFixture.createOperation.mockResolvedValueOnce(existingRow);
+		const existingRepository = new PrismaPersonalMemoryOperationRepository(existingFixture.transaction);
+		await expect(existingRepository.admit(_RememberCommand(_DATASET_PROVIDER_ID))).resolves.toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Created, operation: { providerDatasetId: _DATASET_PROVIDER_ID } });
+
+		const mismatchFixture = _Fixture(freshRow, [], _Dataset(MemoryDatasetState.Active, _DATASET_PROVIDER_ID));
+		mismatchFixture.findOperation.mockResolvedValueOnce(null);
+		const mismatchRepository = new PrismaPersonalMemoryOperationRepository(mismatchFixture.transaction);
+		await expect(mismatchRepository.admit(_RememberCommand(null))).rejects.toBeInstanceOf(PersonalMemoryOperationInvalidState);
+	});
+
+	it("adopts a Provisioning dataset UUID before saving the matching DatasetEnsured transition", async function _AdoptDataset()
+	{
+		const callOrder: string[] = [];
+		const initial = _RememberInitialRow(null);
+		const advanced = _RememberRow(null, _DATASET_PROVIDER_ID);
+		const fixture = _Fixture(initial, callOrder, _Dataset(MemoryDatasetState.Provisioning, null));
+		fixture.findOperation.mockReset().mockResolvedValueOnce(initial).mockResolvedValueOnce(initial).mockResolvedValueOnce(advanced);
+		fixture.updateOperation.mockReset()
+			.mockImplementationOnce(async function _Lock() { callOrder.push("operation-lock"); return { count: 1 }; })
+			.mockImplementationOnce(async function _Cas() { callOrder.push("operation-cas"); return { count: 1 }; });
+		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+		const event: PersonalMemoryOperationEvent = { operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Remember, expectedRevision: 1, event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId: _DATASET_PROVIDER_ID };
+
+		await expect(repository.apply(event, _RECORDED_AT)).resolves.toMatchObject({ outcome: PersonalMemoryOperationPersistenceOutcomes.Advanced, operation: { phase: "document_add_pending", providerDatasetId: _DATASET_PROVIDER_ID } });
+		expect(callOrder).toEqual(["dataset-read", "dataset-lock", "operation-lock", "dataset-adopt", "operation-cas"]);
+		expect(fixture.updateDataset.mock.calls[1][0]).toMatchObject({ where: { state: MemoryDatasetState.Provisioning, cogneeDatasetId: null }, data: { state: MemoryDatasetState.Active, cogneeDatasetId: _DATASET_PROVIDER_ID } });
+	});
+
+	it("rejects DatasetEnsured when an Active or Retired dataset cannot adopt that UUID", async function _RejectDatasetMismatch()
+	{
+		const initial = _RememberInitialRow(null);
+		const event: PersonalMemoryOperationEvent = { operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Remember, expectedRevision: 1, event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId: _DATASET_PROVIDER_ID };
+		for (const dataset of [_Dataset(MemoryDatasetState.Active, "00000000-0000-4000-8000-000000000099"), _Dataset(MemoryDatasetState.Retired, null)])
+		{
+			const fixture = _Fixture(initial, [], dataset);
+			const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+			await expect(repository.apply(event, _RECORDED_AT)).rejects.toBeInstanceOf(PersonalMemoryOperationInvalidState);
+		}
+	});
+
+	it("rejects a message attributed to another principal before taking a database lock", async function _OwnMessage()
+	{
+		const fixture = _Fixture(_CorrectRow());
+		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+		const command = _CorrectCommand();
+		const foreignSource = { ...command, source: { ...command.source!, authorPrincipalId: "principal-2" } };
+
+		await expect(repository.admit(foreignSource)).rejects.toBeInstanceOf(PersonalMemoryOperationInvalidState);
+		expect(fixture.findDataset).not.toHaveBeenCalled();
+	});
+
+	it("hides a new Forget target in the operation transaction and replays after the fact advances", async function _ForgetAdmission()
+	{
+		const row = _ForgetRow();
+		const freshFixture = _Fixture(row);
+		freshFixture.findOperation.mockResolvedValueOnce(null);
+		const freshRepository = new PrismaPersonalMemoryOperationRepository(freshFixture.transaction);
+		await expect(freshRepository.admit(_ForgetCommand())).resolves.toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Created, operation: { phase: "document_delete_pending" } });
+		expect(freshFixture.updateFact).toHaveBeenCalledTimes(2);
+		expect(freshFixture.updateFact.mock.calls[1][0]).toEqual({ where: { id: "fact-1", datasetId: "dataset-1", state: MemoryFactState.Active, revision: 7 }, data: { state: MemoryFactState.ForgetPending, forgetRequestedAt: _ADMITTED_AT } });
+
+		const replayFixture = _Fixture(row, [], _Dataset(MemoryDatasetState.Active, _DATASET_PROVIDER_ID), _Fact(MemoryFactState.ForgetPending, 8));
+		const replayRepository = new PrismaPersonalMemoryOperationRepository(replayFixture.transaction);
+		await expect(replayRepository.admit(_ForgetCommand())).resolves.toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Replayed });
+		expect(replayFixture.updateFact).toHaveBeenCalledTimes(1);
+	});
+
+	it("hides a Corrected Forget target without making the superseded fact recallable again", async function _ForgetCorrectedFact()
+	{
+		const row = _ForgetRow();
+		const fixture = _Fixture(row, [], _Dataset(MemoryDatasetState.Active, _DATASET_PROVIDER_ID), _Fact(MemoryFactState.Corrected, 7));
+		fixture.findOperation.mockResolvedValueOnce(null);
+		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+
+		await expect(repository.admit(_ForgetCommand())).resolves.toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Created });
+		expect(fixture.updateFact.mock.calls[1][0]).toEqual({ where: { id: "fact-1", datasetId: "dataset-1", state: MemoryFactState.Corrected, revision: 7 }, data: { state: MemoryFactState.ForgetPending, forgetRequestedAt: _ADMITTED_AT } });
+	});
+
+	it("fails closed when a bare catalog event supplies no exact fact mutation evidence", async function _CatalogEvidence()
+	{
+		const row = { ..._CorrectRow(), phase: PrismaPhase.CatalogCommitPending, revision: 4, providerDocumentId: _NEW_DOCUMENT_ID, indexingOperationId: _INDEXING_ID, expectedInputEvidenceDigest: _INPUT_DIGEST, pipelineRunId: _PIPELINE_ID };
+		const fixture = _Fixture(row);
+		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+		const event: PersonalMemoryOperationEvent = { operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Correct, expectedRevision: 4, event: PersonalMemoryOperationEvents.CatalogCommitted };
+
+		await expect(repository.apply(event, _RECORDED_AT)).rejects.toBeInstanceOf(PersonalMemoryOperationInvalidState);
+		expect(fixture.updateOperation).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects an impossible saved row before lifecycle planning or any database write", async function _RejectInvalidRow()
+	{
+		const invalid = { ..._CorrectRow(), phase: PrismaPhase.Completed, completedAt: null };
+		const fixture = _Fixture(invalid);
+		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+		const event: PersonalMemoryOperationEvent = { operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Correct, expectedRevision: 1, event: PersonalMemoryOperationEvents.DocumentAdded, documentId: _NEW_DOCUMENT_ID, contentDigest: _CONTENT_DIGEST };
+
+		await expect(repository.apply(event, _RECORDED_AT)).rejects.toBeInstanceOf(PersonalMemoryOperationInvalidState);
+		expect(fixture.updateDataset).not.toHaveBeenCalled();
+		expect(fixture.updateOperation).not.toHaveBeenCalled();
+	});
+
+	it("returns the validated concurrent winner when the revision CAS loses", async function _ConcurrentWinner()
+	{
+		const initial = _CorrectRow();
+		const winner = { ...initial, phase: PrismaPhase.CognifyPending, revision: 2, providerDocumentId: _NEW_DOCUMENT_ID };
+		const fixture = _Fixture(initial);
+		fixture.findOperation.mockReset().mockResolvedValueOnce(initial).mockResolvedValueOnce(initial).mockResolvedValueOnce(winner);
+		fixture.updateOperation.mockReset().mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 0 });
+		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+		const event: PersonalMemoryOperationEvent = { operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Correct, expectedRevision: 1, event: PersonalMemoryOperationEvents.DocumentAdded, documentId: _NEW_DOCUMENT_ID, contentDigest: _CONTENT_DIGEST };
+
+		await expect(repository.apply(event, _RECORDED_AT)).resolves.toMatchObject({ outcome: PersonalMemoryOperationPersistenceOutcomes.ConcurrentWinner, operation: { revision: 2, phase: "cognify_pending", documentId: _NEW_DOCUMENT_ID } });
+		expect(fixture.updateOperation).toHaveBeenCalledTimes(2);
+	});
+
+	it("takes dataset, target-fact, and operation locks before planning a retry result", async function _LockOrder()
+	{
+		const callOrder: string[] = [];
+		const recoveryReady = { ..._CorrectRow(), phase: PrismaPhase.DocumentAddPending };
+		const fixture = _Fixture(recoveryReady, callOrder);
+		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+		const event: PersonalMemoryOperationEvent = { operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Correct, expectedRevision: 1, event: PersonalMemoryOperationEvents.MutationFailed, failureCode: PersonalMemoryOperationFailureCodes.DocumentConflict, deliveryState: MemoryMutationDeliveryStates.ProvenNotSent };
+
+		await expect(repository.apply(event, _RECORDED_AT)).resolves.toMatchObject({ outcome: PersonalMemoryOperationPersistenceOutcomes.Retry, operation: { revision: 1 } });
+		expect(callOrder).toEqual(["operation-read", "dataset-read", "dataset-lock", "fact-read:fact-1", "fact-lock:fact-1", "operation-lock", "operation-reread"]);
+	});
+});
+
+/** Creates a valid correction admission command with no plaintext field. */
+function _CorrectCommand(): AdmitPersonalMemoryOperationCommand
+{
+	return {
+		operationId: _OPERATION_ID,
+		siloId: "silo-1",
+		datasetId: "dataset-1",
+		actorPrincipalId: "principal-1",
+		idempotencyKeyDigest: _IDEMPOTENCY_DIGEST,
+		commandDigest: _COMMAND_DIGEST,
+		kind: PersonalMemoryOperationKinds.Correct,
+		source: { conversationId: "conversation-1", messageId: "message-1", messagePosition: 4n, payloadRef: "payload-1", ciphertextDigest: _CIPHERTEXT_DIGEST, authorPrincipalId: "principal-1" },
+		contentDigest: _CONTENT_DIGEST,
+		targetFactId: "fact-1",
+		targetDocumentId: _TARGET_DOCUMENT_ID,
+		expectedFactRevision: 7,
+		providerDatasetId: _DATASET_PROVIDER_ID,
+		task: { taskId: _TASK_ID, taskName: "personal-memory-operation", taskKey: _OPERATION_ID },
+		admittedAt: _ADMITTED_AT,
+	};
+}
+
+/** Creates the matching initial Prisma row returned by the fake transaction. */
+function _CorrectRow(): PrismaOperationRow
+{
+	return {
+		id: _OPERATION_ID,
+		siloId: "silo-1",
+		datasetId: "dataset-1",
+		actorPrincipalId: "principal-1",
+		idempotencyKeyDigest: _IDEMPOTENCY_DIGEST,
+		commandDigest: _COMMAND_DIGEST,
+		kind: PrismaKind.Correct,
+		phase: PrismaPhase.DocumentAddPending,
+		recoveryPhase: null,
+		revision: 1,
+		sourceConversationId: "conversation-1",
+		sourceMessageId: "message-1",
+		sourceMessagePosition: 4n,
+		sourcePayloadRef: "payload-1",
+		sourceCiphertextDigest: _CIPHERTEXT_DIGEST,
+		sourceAuthorPrincipalId: "principal-1",
+		contentDigest: _CONTENT_DIGEST,
+		targetFactId: "fact-1",
+		targetDocumentId: _TARGET_DOCUMENT_ID,
+		expectedFactRevision: 7,
+		admittedProviderDatasetId: _DATASET_PROVIDER_ID,
+		providerDatasetId: _DATASET_PROVIDER_ID,
+		providerDocumentId: null,
+		indexingOperationId: null,
+		expectedInputEvidenceDigest: null,
+		pipelineRunId: null,
+		failureCode: null as PrismaFailureCode | null,
+		deliveryState: null as PrismaDeliveryState | null,
+		workflowTaskId: _TASK_ID,
+		workflowTaskName: "personal-memory-operation",
+		workflowTaskKey: _OPERATION_ID,
+		admittedAt: _ADMITTED_AT,
+		recoveryRecordedAt: null,
+		completedAt: null,
+	};
+}
+
+/** Creates a Remember command for a new or already adopted provider dataset. */
+function _RememberCommand(providerDatasetId: string | null): AdmitPersonalMemoryOperationCommand
+{
+	return {
+		..._CorrectCommand(),
+		kind: PersonalMemoryOperationKinds.Remember,
+		targetFactId: null,
+		targetDocumentId: null,
+		expectedFactRevision: null,
+		providerDatasetId,
+	};
+}
+
+/** Creates a progressed Remember row while retaining its original provider coordinate separately. */
+function _RememberRow(admittedProviderDatasetId: string | null, providerDatasetId: string): PrismaOperationRow
+{
+	return {
+		..._CorrectRow(),
+		kind: PrismaKind.Remember,
+		phase: PrismaPhase.DocumentAddPending,
+		revision: 2,
+		targetFactId: null,
+		targetDocumentId: null,
+		expectedFactRevision: null,
+		admittedProviderDatasetId,
+		providerDatasetId,
+	};
+}
+
+/** Creates a Remember row before provider dataset adoption. */
+function _RememberInitialRow(providerDatasetId: string | null): PrismaOperationRow
+{
+	return {
+		..._CorrectRow(),
+		kind: PrismaKind.Remember,
+		phase: PrismaPhase.DatasetEnsurePending,
+		targetFactId: null,
+		targetDocumentId: null,
+		expectedFactRevision: null,
+		admittedProviderDatasetId: providerDatasetId,
+		providerDatasetId,
+	};
+}
+
+/** Creates a valid Forget command that targets the active catalog revision. */
+function _ForgetCommand(): AdmitPersonalMemoryOperationCommand
+{
+	return {
+		..._CorrectCommand(),
+		kind: PersonalMemoryOperationKinds.Forget,
+		source: null,
+		contentDigest: null,
+	};
+}
+
+/** Creates the operation row inserted after a Forget target is hidden. */
+function _ForgetRow(): PrismaOperationRow
+{
+	return {
+		..._CorrectRow(),
+		kind: PrismaKind.Forget,
+		phase: PrismaPhase.DocumentDeletePending,
+		sourceConversationId: null,
+		sourceMessageId: null,
+		sourceMessagePosition: null,
+		sourcePayloadRef: null,
+		sourceCiphertextDigest: null,
+		sourceAuthorPrincipalId: null,
+		contentDigest: null,
+	};
+}
+
+/** Creates one local dataset state returned by the fake transaction. */
+function _Dataset(state: MemoryDatasetState, cogneeDatasetId: string | null)
+{
+	return { id: "dataset-1", siloId: "silo-1", boundaryKind: AuthorizationBoundaryKind.Personal, boundaryPrincipalId: "principal-1", cogneeDatasetId, state };
+}
+
+/** Creates one target fact state returned by the fake transaction. */
+function _Fact(state: MemoryFactState, revision: number)
+{
+	return { id: "fact-1", cogneeExternalId: _TARGET_DOCUMENT_ID, revision, state };
+}
+
+/** Creates fake Prisma delegates and optionally records the externally visible lock sequence. */
+function _Fixture(row: PrismaOperationRow, callOrder: string[] = [], dataset = _Dataset(MemoryDatasetState.Active, _DATASET_PROVIDER_ID), fact = _Fact(MemoryFactState.Active, 7)): _TransactionFixture
+{
+	const findDataset = vi.fn(async function _FindDataset()
+	{
+		callOrder.push("dataset-read");
+		return dataset;
+	});
+	const updateDataset = vi.fn(async function _UpdateDataset(query)
+	{
+		callOrder.push(query.data.cogneeDatasetId === undefined ? "dataset-lock" : "dataset-adopt");
+		return { count: 1 };
+	});
+	const findFact = vi.fn(async function _FindFact(query)
+	{
+		const id = query.where.id;
+		callOrder.push(`fact-read:${id}`);
+		return { ...fact, id };
+	});
+	const updateFact = vi.fn(async function _UpdateFact(query)
+	{
+		const id = query.where.id;
+		callOrder.push(`fact-lock:${id}`);
+		return { count: 1 };
+	});
+	const findOperation = vi.fn(async function _FindOperation()
+	{
+		callOrder.push(callOrder.includes("operation-lock") ? "operation-reread" : "operation-read");
+		return row;
+	});
+	const updateOperation = vi.fn(async function _UpdateOperation()
+	{
+		callOrder.push("operation-lock");
+		return { count: 1 };
+	});
+	const createOperation = vi.fn(async function _CreateOperation() { return row; });
+	const transaction = {
+		memoryDataset: { findFirst: findDataset, updateMany: updateDataset },
+		memoryFactCatalog: { findFirst: findFact, updateMany: updateFact },
+		personalMemoryOperation: { findUnique: findOperation, updateMany: updateOperation, create: createOperation },
+	} as unknown as Prisma.TransactionClient;
+	return { transaction, findDataset, updateDataset, findFact, updateFact, findOperation, updateOperation, createOperation };
+}

--- a/libs/backend/agents/personal/memory/main/src/operations/__tests__/prisma-personal-memory-operation-unit-of-work.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/__tests__/prisma-personal-memory-operation-unit-of-work.test.ts
@@ -1,0 +1,125 @@
+import { AuthorizationBoundaryKind, MemoryDatasetState, PersonalMemoryOperationKind as PrismaKind, PersonalMemoryOperationPhase as PrismaPhase, type PersonalMemoryOperation as PrismaOperationRow, type Prisma, type PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PersonalMemoryOperationAdmissionOutcomes, type AdmitPersonalMemoryOperationCommand } from "../personal-memory-operation-persistence.types";
+import { PrismaPersonalMemoryOperationUnitOfWork } from "../prisma-personal-memory-operation-unit-of-work";
+import { PersonalMemoryOperationKinds } from "../personal-memory-operation.types";
+
+const _OPERATION_ID = "00000000-0000-4000-8000-000000000001";
+const _DATASET_ID = "00000000-0000-4000-8000-000000000002";
+const _TASK_ID = "00000000-0000-4000-8000-000000000003";
+const _CONTENT_DIGEST = `sha256:${"a".repeat(64)}`;
+const _CIPHERTEXT_DIGEST = `sha256:${"b".repeat(64)}`;
+const _IDEMPOTENCY_DIGEST = `sha256:${"c".repeat(64)}`;
+const _COMMAND_DIGEST = `sha256:${"d".repeat(64)}`;
+const _ADMITTED_AT = new Date("2026-09-13T08:00:00.000Z");
+
+describe("PrismaPersonalMemoryOperationUnitOfWork", function _Suite()
+{
+	it("constructs the repository on the exact serializable callback transaction", async function _ExactTransaction()
+	{
+		const transaction = _Transaction();
+		const rootCreate = vi.fn(function _RootCreate() { throw new Error("root delegate must not be used"); });
+		const prisma = {
+			personalMemoryOperation: { create: rootCreate },
+			$transaction: vi.fn(async function _TransactionCallback(work, policy)
+			{
+				expect(policy).toMatchObject({ isolationLevel: "Serializable" });
+				return work(transaction);
+			}),
+		} as unknown as PrismaClient;
+		const unitOfWork = new PrismaPersonalMemoryOperationUnitOfWork(prisma);
+
+		await expect(unitOfWork.admit(_Command())).resolves.toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Created, operation: { operationId: _OPERATION_ID } });
+		expect(rootCreate).not.toHaveBeenCalled();
+		expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+	});
+
+	it("propagates a transaction failure without claiming task admission or retrying an unknown error", async function _RollbackFailure()
+	{
+		const failure = new Error("transaction rolled back");
+		const prisma = { $transaction: vi.fn(async function _FailTransaction() { throw failure; }) } as unknown as PrismaClient;
+		const unitOfWork = new PrismaPersonalMemoryOperationUnitOfWork(prisma);
+
+		await expect(unitOfWork.admit(_Command())).rejects.toBe(failure);
+		expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+	});
+});
+
+/** Creates a valid new-dataset Remember command with a reserved task UUID. */
+function _Command(): AdmitPersonalMemoryOperationCommand
+{
+	return {
+		operationId: _OPERATION_ID,
+		siloId: "silo-1",
+		datasetId: "dataset-1",
+		actorPrincipalId: "principal-1",
+		idempotencyKeyDigest: _IDEMPOTENCY_DIGEST,
+		commandDigest: _COMMAND_DIGEST,
+		kind: PersonalMemoryOperationKinds.Remember,
+		source: { conversationId: "conversation-1", messageId: "message-1", messagePosition: 2n, payloadRef: "payload-1", ciphertextDigest: _CIPHERTEXT_DIGEST, authorPrincipalId: "principal-1" },
+		contentDigest: _CONTENT_DIGEST,
+		targetFactId: null,
+		targetDocumentId: null,
+		expectedFactRevision: null,
+		providerDatasetId: null,
+		task: { taskId: _TASK_ID, taskName: "personal-memory-operation", taskKey: _OPERATION_ID },
+		admittedAt: _ADMITTED_AT,
+	};
+}
+
+/** Creates the callback transaction whose delegates own every operation read and write. */
+function _Transaction(): Prisma.TransactionClient
+{
+	const row: PrismaOperationRow = {
+		id: _OPERATION_ID,
+		siloId: "silo-1",
+		datasetId: "dataset-1",
+		actorPrincipalId: "principal-1",
+		idempotencyKeyDigest: _IDEMPOTENCY_DIGEST,
+		commandDigest: _COMMAND_DIGEST,
+		kind: PrismaKind.Remember,
+		phase: PrismaPhase.DatasetEnsurePending,
+		recoveryPhase: null,
+		revision: 1,
+		sourceConversationId: "conversation-1",
+		sourceMessageId: "message-1",
+		sourceMessagePosition: 2n,
+		sourcePayloadRef: "payload-1",
+		sourceCiphertextDigest: _CIPHERTEXT_DIGEST,
+		sourceAuthorPrincipalId: "principal-1",
+		contentDigest: _CONTENT_DIGEST,
+		targetFactId: null,
+		targetDocumentId: null,
+		expectedFactRevision: null,
+		admittedProviderDatasetId: null,
+		providerDatasetId: null,
+		providerDocumentId: null,
+		indexingOperationId: null,
+		expectedInputEvidenceDigest: null,
+		pipelineRunId: null,
+		failureCode: null,
+		deliveryState: null,
+		workflowTaskId: _TASK_ID,
+		workflowTaskName: "personal-memory-operation",
+		workflowTaskKey: _OPERATION_ID,
+		admittedAt: _ADMITTED_AT,
+		recoveryRecordedAt: null,
+		completedAt: null,
+	};
+	return {
+		memoryDataset: {
+			findFirst: vi.fn(async function _FindDataset() { return { id: "dataset-1", siloId: "silo-1", boundaryKind: AuthorizationBoundaryKind.Personal, boundaryPrincipalId: "principal-1", cogneeDatasetId: null, state: MemoryDatasetState.Provisioning }; }),
+			updateMany: vi.fn(async function _LockDataset() { return { count: 1 }; }),
+		},
+		memoryFactCatalog: {
+			findFirst: vi.fn(),
+			updateMany: vi.fn(),
+		},
+		personalMemoryOperation: {
+			findUnique: vi.fn(async function _FindOperation() { return null; }),
+			create: vi.fn(async function _CreateOperation() { return row; }),
+			updateMany: vi.fn(),
+		},
+	} as unknown as Prisma.TransactionClient;
+}

--- a/libs/backend/agents/personal/memory/main/src/operations/personal-memory-dataset-name.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/personal-memory-dataset-name.ts
@@ -1,0 +1,17 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Derives the provider name from an already saved, server-generated catalog identifier.
+ *
+ * The immutable dataset id lets an interrupted provisioning task address the same dataset before
+ * Cognee returns its UUID. Callers must load this id from the personal catalog, never from a tool
+ * argument or a subject identifier. Hashing keeps the name within the gateway's fixed length
+ * bounds even when the catalog uses short identifiers. The name grants no read authority.
+ */
+export function __PersonalMemoryProviderDatasetName(datasetId: string): string
+{
+	if (datasetId.length === 0 || datasetId.length > 128 || datasetId.trim() !== datasetId)
+		throw new Error("personal memory dataset identifier cannot form a provider name");
+	const digest = createHash("sha256").update(datasetId, "utf8").digest("hex");
+	return `opencrane-memory-${digest}`;
+}

--- a/libs/backend/agents/personal/memory/main/src/operations/personal-memory-operation-lifecycle.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/personal-memory-operation-lifecycle.ts
@@ -1,0 +1,237 @@
+import { MemoryMutationDeliveryStates } from "@opencrane/contracts";
+
+import { PersonalMemoryOperationEvents, PersonalMemoryOperationFailureCodes, PersonalMemoryOperationKinds, PersonalMemoryOperationPhases, PersonalMemoryOperationTransitionDenialReasons, PersonalMemoryOperationTransitionOutcomes, type CreatePersonalMemoryOperationLifecycleCommand, type PersonalMemoryOperationEvent, type PersonalMemoryOperationLifecycle, type PersonalMemoryOperationTransitionResult } from "./personal-memory-operation.types";
+import { ___CreatePersonalMemoryOperationLifecycleCommandSchema, ___PersonalMemoryOperationEventSchema, ___PersonalMemoryOperationLifecycleSchema, __PersonalMemoryBlockedFailureMatchesPhase, __PersonalMemoryMutationFailureMatchesPhase } from "./personal-memory-operation.validator";
+
+/** Internal table actions. These values are not stored or sent outside this module. */
+enum _PolicyCellActions
+{
+	/** Reject this event for the selected command and phase. */
+	Deny = "deny",
+	/** Apply delivery-state rules for a failed provider mutation. */
+	Mutation = "mutation",
+	/** Record recovery for a failed authority, source, read, or catalog guard. */
+	Blocked = "blocked",
+	/** Apply verified event evidence and move to the cell's next phase. */
+	Advance = "advance",
+}
+
+type _PolicyCell = { readonly action: _PolicyCellActions.Deny } | { readonly action: _PolicyCellActions.Mutation } | { readonly action: _PolicyCellActions.Blocked } | { readonly action: _PolicyCellActions.Advance; readonly nextPhase: PersonalMemoryOperationPhases };
+type _EventPolicy = Readonly<Record<PersonalMemoryOperationEvents, _PolicyCell>>;
+type _PhasePolicy = Readonly<Record<PersonalMemoryOperationPhases, _EventPolicy>>;
+
+/** Create the first valid lifecycle state from immutable admitted command evidence. */
+export function __CreatePersonalMemoryOperationLifecycle(command: CreatePersonalMemoryOperationLifecycleCommand): PersonalMemoryOperationLifecycle | null
+{
+	const parsed = ___CreatePersonalMemoryOperationLifecycleCommandSchema.safeParse(command);
+	if (!parsed.success)
+		return null;
+	let phase = PersonalMemoryOperationPhases.DocumentDeletePending;
+	if (parsed.data.kind === PersonalMemoryOperationKinds.Remember)
+		phase = PersonalMemoryOperationPhases.DatasetEnsurePending;
+	else if (parsed.data.kind === PersonalMemoryOperationKinds.Correct)
+		phase = PersonalMemoryOperationPhases.DocumentAddPending;
+	return {
+		...parsed.data,
+		phase,
+		revision: 1,
+		recoveryPhase: null,
+		documentId: null,
+		indexingOperationId: null,
+		expectedInputEvidenceDigest: null,
+		pipelineRunId: null,
+		failureCode: null,
+		deliveryState: null,
+	};
+}
+
+/**
+ * Decide one event without performing I/O or mutating the supplied operation.
+ *
+ * The caller must compare-and-set the returned revision before performing later work. A stale,
+ * unknown, or evidence-conflicting event returns `Denied` and no operation to persist.
+ */
+export function __PlanPersonalMemoryOperationLifecycle(operationInput: PersonalMemoryOperationLifecycle, eventInput: PersonalMemoryOperationEvent): PersonalMemoryOperationTransitionResult
+{
+	const operation = ___PersonalMemoryOperationLifecycleSchema.safeParse(operationInput);
+	const event = ___PersonalMemoryOperationEventSchema.safeParse(eventInput);
+	if (!operation.success || !event.success)
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.InvalidInput);
+	if (event.data.operationId !== operation.data.operationId || event.data.kind !== operation.data.kind)
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.WrongOperation);
+	if (event.data.expectedRevision !== operation.data.revision)
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.StaleRevision);
+	if (operation.data.phase === PersonalMemoryOperationPhases.Completed)
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.InvalidTransition);
+	if (operation.data.phase === PersonalMemoryOperationPhases.RecoveryRequired
+		&& (event.data.event === PersonalMemoryOperationEvents.MutationFailed || event.data.event === PersonalMemoryOperationEvents.OperationBlocked))
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.InvalidTransition);
+	const activePhase = operation.data.phase === PersonalMemoryOperationPhases.RecoveryRequired ? operation.data.recoveryPhase : operation.data.phase;
+	if (activePhase === null)
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.InvalidInput);
+	const cell = _POLICY[operation.data.kind][activePhase][event.data.event];
+	if (cell.action === _PolicyCellActions.Deny)
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.InvalidTransition);
+	if (cell.action === _PolicyCellActions.Mutation)
+		return _PlanMutationFailure(operation.data, activePhase, event.data);
+	if (cell.action === _PolicyCellActions.Blocked)
+		return _PlanBlocked(operation.data, activePhase, event.data);
+	return _PlanAdvance(operation.data, event.data, cell.nextPhase);
+}
+
+/** Return the exhaustive policy table for focused state-by-event contract tests. */
+export function _PersonalMemoryOperationLifecyclePolicy(): Readonly<Record<PersonalMemoryOperationKinds, _PhasePolicy>>
+{
+	return _POLICY;
+}
+
+function _PlanMutationFailure(operation: PersonalMemoryOperationLifecycle, activePhase: PersonalMemoryOperationPhases, event: PersonalMemoryOperationEvent): PersonalMemoryOperationTransitionResult
+{
+	if (event.event !== PersonalMemoryOperationEvents.MutationFailed)
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.InvalidTransition);
+	if (!__PersonalMemoryMutationFailureMatchesPhase(activePhase, event.failureCode))
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.ConflictingEvidence);
+	if (activePhase === PersonalMemoryOperationPhases.CognifyPending && operation.indexingOperationId === null)
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.ConflictingEvidence);
+	if (event.deliveryState === MemoryMutationDeliveryStates.ProvenNotSent)
+		return { outcome: PersonalMemoryOperationTransitionOutcomes.Retry, operation };
+	return _Advance(operation, {
+		phase: PersonalMemoryOperationPhases.RecoveryRequired,
+		recoveryPhase: activePhase,
+		failureCode: event.failureCode,
+		deliveryState: event.deliveryState,
+	});
+}
+
+function _PlanBlocked(operation: PersonalMemoryOperationLifecycle, activePhase: PersonalMemoryOperationPhases, event: PersonalMemoryOperationEvent): PersonalMemoryOperationTransitionResult
+{
+	if (event.event !== PersonalMemoryOperationEvents.OperationBlocked)
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.InvalidTransition);
+	if (!__PersonalMemoryBlockedFailureMatchesPhase(activePhase, event.failureCode))
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.ConflictingEvidence);
+	return _Advance(operation, {
+		phase: PersonalMemoryOperationPhases.RecoveryRequired,
+		recoveryPhase: activePhase,
+		failureCode: event.failureCode,
+		deliveryState: null,
+	});
+}
+
+function _PlanAdvance(operation: PersonalMemoryOperationLifecycle, event: PersonalMemoryOperationEvent, nextPhase: PersonalMemoryOperationPhases): PersonalMemoryOperationTransitionResult
+{
+	const evidence = _ApplyEventEvidence(operation, event);
+	if (evidence === null)
+		return _Denied(PersonalMemoryOperationTransitionDenialReasons.ConflictingEvidence);
+	return _Advance(operation, { ...evidence, phase: nextPhase, recoveryPhase: null, failureCode: null, deliveryState: null });
+}
+
+function _ApplyEventEvidence(operation: PersonalMemoryOperationLifecycle, event: PersonalMemoryOperationEvent): Partial<PersonalMemoryOperationLifecycle> | null
+{
+	switch (event.event)
+	{
+		case PersonalMemoryOperationEvents.DatasetEnsured:
+			return operation.providerDatasetId === null || operation.providerDatasetId === event.providerDatasetId ? { providerDatasetId: event.providerDatasetId } : null;
+		case PersonalMemoryOperationEvents.DocumentAdded:
+			return event.contentDigest === operation.expectedContentDigest && (operation.documentId === null || operation.documentId === event.documentId) ? { documentId: event.documentId } : null;
+		case PersonalMemoryOperationEvents.IndexEvidenceSaved:
+			return operation.indexingOperationId === null && operation.expectedInputEvidenceDigest === null ? { indexingOperationId: event.indexingOperationId, expectedInputEvidenceDigest: event.expectedInputEvidenceDigest } : null;
+		case PersonalMemoryOperationEvents.IndexingCompleted:
+			return event.indexingOperationId === operation.indexingOperationId && event.expectedInputEvidenceDigest === operation.expectedInputEvidenceDigest && operation.pipelineRunId === null ? { pipelineRunId: event.pipelineRunId } : null;
+		case PersonalMemoryOperationEvents.PriorDocumentDeleted:
+		case PersonalMemoryOperationEvents.DocumentDeleted:
+			return event.documentId === operation.targetDocumentId ? {} : null;
+		case PersonalMemoryOperationEvents.CatalogCommitted:
+		case PersonalMemoryOperationEvents.CatalogFinalized:
+			return {};
+		case PersonalMemoryOperationEvents.MutationFailed:
+		case PersonalMemoryOperationEvents.OperationBlocked:
+			return null;
+	}
+}
+
+function _Advance(operation: PersonalMemoryOperationLifecycle, update: Partial<PersonalMemoryOperationLifecycle>): PersonalMemoryOperationTransitionResult
+{
+	const next = { ...operation, ...update, revision: operation.revision + 1 };
+	return ___PersonalMemoryOperationLifecycleSchema.safeParse(next).success
+		? { outcome: PersonalMemoryOperationTransitionOutcomes.Advanced, operation: next }
+		: _Denied(PersonalMemoryOperationTransitionDenialReasons.ConflictingEvidence);
+}
+
+function _Denied(reason: PersonalMemoryOperationTransitionDenialReasons): PersonalMemoryOperationTransitionResult
+{
+	return { outcome: PersonalMemoryOperationTransitionOutcomes.Denied, reason };
+}
+
+function _Cells(overrides: Partial<_EventPolicy> = {}): _EventPolicy
+{
+	return {
+		[PersonalMemoryOperationEvents.DatasetEnsured]: { action: _PolicyCellActions.Deny },
+		[PersonalMemoryOperationEvents.DocumentAdded]: { action: _PolicyCellActions.Deny },
+		[PersonalMemoryOperationEvents.IndexEvidenceSaved]: { action: _PolicyCellActions.Deny },
+		[PersonalMemoryOperationEvents.IndexingCompleted]: { action: _PolicyCellActions.Deny },
+		[PersonalMemoryOperationEvents.CatalogCommitted]: { action: _PolicyCellActions.Deny },
+		[PersonalMemoryOperationEvents.PriorDocumentDeleted]: { action: _PolicyCellActions.Deny },
+		[PersonalMemoryOperationEvents.DocumentDeleted]: { action: _PolicyCellActions.Deny },
+		[PersonalMemoryOperationEvents.CatalogFinalized]: { action: _PolicyCellActions.Deny },
+		[PersonalMemoryOperationEvents.MutationFailed]: { action: _PolicyCellActions.Deny },
+		[PersonalMemoryOperationEvents.OperationBlocked]: { action: _PolicyCellActions.Deny },
+		...overrides,
+	};
+}
+
+function _Blocked(): _PolicyCell
+{
+	return { action: _PolicyCellActions.Blocked };
+}
+
+function _Mutation(): _PolicyCell
+{
+	return { action: _PolicyCellActions.Mutation };
+}
+
+function _AdvanceTo(nextPhase: PersonalMemoryOperationPhases): _PolicyCell
+{
+	return { action: _PolicyCellActions.Advance, nextPhase };
+}
+
+const _REMEMBER_POLICY: _PhasePolicy = {
+	[PersonalMemoryOperationPhases.DatasetEnsurePending]: _Cells({ [PersonalMemoryOperationEvents.DatasetEnsured]: _AdvanceTo(PersonalMemoryOperationPhases.DocumentAddPending), [PersonalMemoryOperationEvents.MutationFailed]: _Mutation(), [PersonalMemoryOperationEvents.OperationBlocked]: _Blocked() }),
+	[PersonalMemoryOperationPhases.DocumentAddPending]: _Cells({ [PersonalMemoryOperationEvents.DocumentAdded]: _AdvanceTo(PersonalMemoryOperationPhases.CognifyPending), [PersonalMemoryOperationEvents.MutationFailed]: _Mutation(), [PersonalMemoryOperationEvents.OperationBlocked]: _Blocked() }),
+	[PersonalMemoryOperationPhases.CognifyPending]: _Cells({ [PersonalMemoryOperationEvents.IndexEvidenceSaved]: _AdvanceTo(PersonalMemoryOperationPhases.CognifyPending), [PersonalMemoryOperationEvents.IndexingCompleted]: _AdvanceTo(PersonalMemoryOperationPhases.CatalogCommitPending), [PersonalMemoryOperationEvents.MutationFailed]: _Mutation(), [PersonalMemoryOperationEvents.OperationBlocked]: _Blocked() }),
+	[PersonalMemoryOperationPhases.CatalogCommitPending]: _Cells({ [PersonalMemoryOperationEvents.CatalogCommitted]: _AdvanceTo(PersonalMemoryOperationPhases.Completed), [PersonalMemoryOperationEvents.OperationBlocked]: _Blocked() }),
+	[PersonalMemoryOperationPhases.PriorDocumentDeletePending]: _Cells(),
+	[PersonalMemoryOperationPhases.DocumentDeletePending]: _Cells(),
+	[PersonalMemoryOperationPhases.CatalogFinalizePending]: _Cells(),
+	[PersonalMemoryOperationPhases.RecoveryRequired]: _Cells(),
+	[PersonalMemoryOperationPhases.Completed]: _Cells(),
+};
+
+const _CORRECT_POLICY: _PhasePolicy = {
+	[PersonalMemoryOperationPhases.DatasetEnsurePending]: _Cells(),
+	[PersonalMemoryOperationPhases.DocumentAddPending]: _Cells({ [PersonalMemoryOperationEvents.DocumentAdded]: _AdvanceTo(PersonalMemoryOperationPhases.CognifyPending), [PersonalMemoryOperationEvents.MutationFailed]: _Mutation(), [PersonalMemoryOperationEvents.OperationBlocked]: _Blocked() }),
+	[PersonalMemoryOperationPhases.CognifyPending]: _Cells({ [PersonalMemoryOperationEvents.IndexEvidenceSaved]: _AdvanceTo(PersonalMemoryOperationPhases.CognifyPending), [PersonalMemoryOperationEvents.IndexingCompleted]: _AdvanceTo(PersonalMemoryOperationPhases.CatalogCommitPending), [PersonalMemoryOperationEvents.MutationFailed]: _Mutation(), [PersonalMemoryOperationEvents.OperationBlocked]: _Blocked() }),
+	[PersonalMemoryOperationPhases.CatalogCommitPending]: _Cells({ [PersonalMemoryOperationEvents.CatalogCommitted]: _AdvanceTo(PersonalMemoryOperationPhases.PriorDocumentDeletePending), [PersonalMemoryOperationEvents.OperationBlocked]: _Blocked() }),
+	[PersonalMemoryOperationPhases.PriorDocumentDeletePending]: _Cells({ [PersonalMemoryOperationEvents.PriorDocumentDeleted]: _AdvanceTo(PersonalMemoryOperationPhases.Completed), [PersonalMemoryOperationEvents.MutationFailed]: _Mutation(), [PersonalMemoryOperationEvents.OperationBlocked]: _Blocked() }),
+	[PersonalMemoryOperationPhases.DocumentDeletePending]: _Cells(),
+	[PersonalMemoryOperationPhases.CatalogFinalizePending]: _Cells(),
+	[PersonalMemoryOperationPhases.RecoveryRequired]: _Cells(),
+	[PersonalMemoryOperationPhases.Completed]: _Cells(),
+};
+
+const _FORGET_POLICY: _PhasePolicy = {
+	[PersonalMemoryOperationPhases.DatasetEnsurePending]: _Cells(),
+	[PersonalMemoryOperationPhases.DocumentAddPending]: _Cells(),
+	[PersonalMemoryOperationPhases.CognifyPending]: _Cells(),
+	[PersonalMemoryOperationPhases.CatalogCommitPending]: _Cells(),
+	[PersonalMemoryOperationPhases.PriorDocumentDeletePending]: _Cells(),
+	[PersonalMemoryOperationPhases.DocumentDeletePending]: _Cells({ [PersonalMemoryOperationEvents.DocumentDeleted]: _AdvanceTo(PersonalMemoryOperationPhases.CatalogFinalizePending), [PersonalMemoryOperationEvents.MutationFailed]: _Mutation(), [PersonalMemoryOperationEvents.OperationBlocked]: _Blocked() }),
+	[PersonalMemoryOperationPhases.CatalogFinalizePending]: _Cells({ [PersonalMemoryOperationEvents.CatalogFinalized]: _AdvanceTo(PersonalMemoryOperationPhases.Completed), [PersonalMemoryOperationEvents.OperationBlocked]: _Blocked() }),
+	[PersonalMemoryOperationPhases.RecoveryRequired]: _Cells(),
+	[PersonalMemoryOperationPhases.Completed]: _Cells(),
+};
+
+const _POLICY: Readonly<Record<PersonalMemoryOperationKinds, _PhasePolicy>> = {
+	[PersonalMemoryOperationKinds.Remember]: _REMEMBER_POLICY,
+	[PersonalMemoryOperationKinds.Correct]: _CORRECT_POLICY,
+	[PersonalMemoryOperationKinds.Forget]: _FORGET_POLICY,
+};

--- a/libs/backend/agents/personal/memory/main/src/operations/personal-memory-operation-persistence.types.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/personal-memory-operation-persistence.types.ts
@@ -1,0 +1,187 @@
+import type { PersonalMemoryOperationEvent, PersonalMemoryOperationKinds, PersonalMemoryOperationLifecycle, PersonalMemoryOperationTransitionDenialReasons } from "./personal-memory-operation.types";
+
+/** Records the encrypted conversation entry admitted as the source of Remember or Correct. */
+export interface PersonalMemoryOperationMessageSource
+{
+	/** Conversation stream that owns the immutable message entry. */
+	readonly conversationId: string;
+	/** Message identifier within the conversation stream. */
+	readonly messageId: string;
+	/** Immutable zero-based message position in the conversation stream. */
+	readonly messagePosition: bigint;
+	/** Opaque reference used to reread the encrypted private payload. */
+	readonly payloadRef: string;
+	/** SHA-256 digest of the ciphertext saved at admission. */
+	readonly ciphertextDigest: string;
+	/** Principal that authored the admitted human message. */
+	readonly authorPrincipalId: string;
+}
+
+/** Reserves the workflow identity that a later product admission must create atomically. */
+export interface PersonalMemoryOperationTaskIdentity
+{
+	/** UUID chosen before admission; its presence does not prove a workflow task exists. */
+	readonly taskId: string;
+	/** Workflow definition name the later composition root must admit. */
+	readonly taskName: string;
+	/** Idempotency key passed to that workflow definition. */
+	readonly taskKey: string;
+}
+
+/** Complete secret-free command evidence needed to save one personal-memory operation. */
+export interface AdmitPersonalMemoryOperationCommand
+{
+	/** UUID saved before any provider or workflow action. */
+	readonly operationId: string;
+	/** Organisation boundary derived from the trusted request host. */
+	readonly siloId: string;
+	/** Local personal dataset row selected under current authority. */
+	readonly datasetId: string;
+	/** Authenticated principal that issued the command. */
+	readonly actorPrincipalId: string;
+	/** SHA-256 digest of the caller's idempotency key. */
+	readonly idempotencyKeyDigest: string;
+	/** SHA-256 digest binding every immutable field in this admitted command. */
+	readonly commandDigest: string;
+	/** User command kept separate from the lifecycle phase. */
+	readonly kind: PersonalMemoryOperationKinds;
+	/** Encrypted message coordinates for Remember and Correct; Forget has no new source. */
+	readonly source: PersonalMemoryOperationMessageSource | null;
+	/** Complete UTF-8 content digest for Remember and Correct; Forget stores none. */
+	readonly contentDigest: string | null;
+	/** Existing catalog fact selected by Correct or Forget. */
+	readonly targetFactId: string | null;
+	/** Existing provider document selected by Correct or Forget. */
+	readonly targetDocumentId: string | null;
+	/** Positive catalog revision checked by the later admission owner. */
+	readonly expectedFactRevision: number | null;
+	/** Provider dataset already adopted by Correct or Forget; Remember may still ensure it. */
+	readonly providerDatasetId: string | null;
+	/** Workflow identity reserved with this row but not asserted to exist. */
+	readonly task: PersonalMemoryOperationTaskIdentity;
+	/** Time the authenticated command was admitted. */
+	readonly admittedAt: Date;
+}
+
+/** Durable personal-memory operation, containing coordinates and digests but no remembered text. */
+export interface PersonalMemoryOperationRecord extends PersonalMemoryOperationLifecycle
+{
+	/** Organisation boundary retained with the operation. */
+	readonly siloId: string;
+	/** Local personal dataset row whose lock precedes every operation lock. */
+	readonly datasetId: string;
+	/** Authenticated principal that issued the original command. */
+	readonly actorPrincipalId: string;
+	/** SHA-256 digest used to find exact command replays. */
+	readonly idempotencyKeyDigest: string;
+	/** SHA-256 digest binding all admitted command coordinates. */
+	readonly commandDigest: string;
+	/** Encrypted source coordinates retained for Remember and Correct. */
+	readonly source: PersonalMemoryOperationMessageSource | null;
+	/** Expected target catalog revision for Correct and Forget. */
+	readonly expectedFactRevision: number | null;
+	/** Provider dataset coordinate admitted with the command before later lifecycle adoption. */
+	readonly admittedProviderDatasetId: string | null;
+	/** Workflow identity reserved at admission without claiming the task exists. */
+	readonly task: PersonalMemoryOperationTaskIdentity;
+	/** Time the command row was first admitted. */
+	readonly admittedAt: Date;
+	/** Time the current recovery evidence was recorded, or null outside recovery. */
+	readonly recoveryRecordedAt: Date | null;
+	/** Time the lifecycle first reached Completed. */
+	readonly completedAt: Date | null;
+}
+
+/** States whether admission inserted a new operation or returned an exact replay. */
+export enum PersonalMemoryOperationAdmissionOutcomes
+{
+	/** This transaction inserted the operation and its reserved task identity. */
+	Created = "created",
+	/** The same command was already admitted, so the existing operation is returned. */
+	Replayed = "replayed",
+}
+
+/** Result of creating or replaying an operation under its dataset and fact locks. */
+export interface PersonalMemoryOperationAdmissionResult
+{
+	/** Whether this call inserted the row or found the exact existing command. */
+	readonly outcome: PersonalMemoryOperationAdmissionOutcomes;
+	/** Validated durable operation that owns all later lifecycle events. */
+	readonly operation: PersonalMemoryOperationRecord;
+}
+
+/** States how persistence handled one lifecycle event after validating the saved row. */
+export enum PersonalMemoryOperationPersistenceOutcomes
+{
+	/** The accepted event won its revision compare-and-set. */
+	Advanced = "advanced",
+	/** The planner proved no bytes were sent and left the operation unchanged for retry. */
+	Retry = "retry",
+	/** The planner rejected the event before persistence changed the row. */
+	Denied = "denied",
+	/** Another writer changed the row first; this result returns that validated durable state. */
+	ConcurrentWinner = "concurrent_winner",
+}
+
+/** Persistence result for one event, including a concurrent row that won the same revision. */
+export interface PersonalMemoryOperationPersistenceResult
+{
+	/** How the repository handled the event. */
+	readonly outcome: PersonalMemoryOperationPersistenceOutcomes;
+	/** Validated saved state after this call, including a concurrent winner. */
+	readonly operation: PersonalMemoryOperationRecord;
+	/** Planner denial reason, present only when the event was rejected. */
+	readonly reason?: PersonalMemoryOperationTransitionDenialReasons;
+}
+
+/** Transaction-scoped port for operation admission and lifecycle compare-and-set updates. */
+export interface PersonalMemoryOperationRepository
+{
+	/**
+	 * Inserts one operation or returns its exact replay under the documented lock order.
+	 * @param command - Secret-free command evidence and reserved workflow identity.
+	 * @returns The validated created operation or existing exact replay.
+	 * @throws {@link PersonalMemoryOperationReplayConflict} when the replay key names different evidence.
+	 * @throws {@link PersonalMemoryOperationInvalidState} when input or a saved row is invalid.
+	 */
+	admit(command: AdmitPersonalMemoryOperationCommand): Promise<PersonalMemoryOperationAdmissionResult>;
+	/**
+	 * Plans and saves one event through the reviewed lifecycle policy.
+	 * @param event - Event bound to the operation UUID, kind, and expected revision.
+	 * @param recordedAt - Database-boundary time used for recovery and completion timestamps.
+	 * @returns The accepted result, denial, retry, or validated concurrent winner.
+	 * @throws {@link PersonalMemoryOperationInvalidState} when the saved row is missing or invalid.
+	 */
+	apply(event: PersonalMemoryOperationEvent, recordedAt: Date): Promise<PersonalMemoryOperationPersistenceResult>;
+}
+
+/** Opens serializable operation transactions and binds each repository to the callback client. */
+export interface PersonalMemoryOperationUnitOfWork
+{
+	/** Admits one operation in a fresh serializable transaction. */
+	admit(command: AdmitPersonalMemoryOperationCommand): Promise<PersonalMemoryOperationAdmissionResult>;
+	/** Applies one lifecycle event in a fresh serializable transaction. */
+	apply(event: PersonalMemoryOperationEvent, recordedAt: Date): Promise<PersonalMemoryOperationPersistenceResult>;
+}
+
+/** Reports that an idempotency key already belongs to different immutable command evidence. */
+export class PersonalMemoryOperationReplayConflict extends Error
+{
+	/** Creates the stable domain error without echoing conflicting evidence. */
+	constructor()
+	{
+		super("personal-memory operation replay conflicts with the admitted command");
+		this.name = "PersonalMemoryOperationReplayConflict";
+	}
+}
+
+/** Reports invalid command input, a missing authority row, or impossible saved operation state. */
+export class PersonalMemoryOperationInvalidState extends Error
+{
+	/** Creates a domain error whose message never includes source coordinates or provider payloads. */
+	constructor(message: string)
+	{
+		super(message);
+		this.name = "PersonalMemoryOperationInvalidState";
+	}
+}

--- a/libs/backend/agents/personal/memory/main/src/operations/personal-memory-operation-persistence.validator.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/personal-memory-operation-persistence.validator.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+
+import { MemoryMutationDeliveryStates } from "@opencrane/contracts";
+
+import { PersonalMemoryOperationKinds, PersonalMemoryOperationPhases, PersonalMemoryOperationFailureCodes, type PersonalMemoryOperationLifecycle } from "./personal-memory-operation.types";
+import { ___PersonalMemoryOperationLifecycleSchema } from "./personal-memory-operation.validator";
+import type { AdmitPersonalMemoryOperationCommand, PersonalMemoryOperationRecord } from "./personal-memory-operation-persistence.types";
+
+const _Identifier = z.string().trim().min(1).max(128);
+const _Uuid = z.string().uuid();
+const _Digest = z.string().regex(/^sha256:[0-9a-f]{64}$/u);
+const _Revision = z.number().int().positive();
+const _Timestamp = z.date().refine(function _IsValid(value) { return !Number.isNaN(value.getTime()); });
+const _MessageSource = z.object({
+	conversationId: _Identifier,
+	messageId: _Identifier,
+	messagePosition: z.bigint().nonnegative(),
+	payloadRef: _Identifier,
+	ciphertextDigest: _Digest,
+	authorPrincipalId: _Identifier,
+}).strict();
+const _TaskIdentity = z.object({ taskId: _Uuid, taskName: _Identifier, taskKey: _Identifier }).strict();
+
+/** Validates secret-free admission evidence before any lock or database write occurs. */
+export const ___AdmitPersonalMemoryOperationCommandSchema: z.ZodType<AdmitPersonalMemoryOperationCommand> = z.object({
+	operationId: _Uuid,
+	siloId: _Identifier,
+	datasetId: _Identifier,
+	actorPrincipalId: _Identifier,
+	idempotencyKeyDigest: _Digest,
+	commandDigest: _Digest,
+	kind: z.nativeEnum(PersonalMemoryOperationKinds),
+	source: _MessageSource.nullable(),
+	contentDigest: _Digest.nullable(),
+	targetFactId: _Identifier.nullable(),
+	targetDocumentId: _Uuid.nullable(),
+	expectedFactRevision: _Revision.nullable(),
+	providerDatasetId: _Uuid.nullable(),
+	task: _TaskIdentity,
+	admittedAt: _Timestamp,
+}).strict().superRefine(function _CommandShape(command, context)
+{
+	const remembers = command.kind === PersonalMemoryOperationKinds.Remember;
+	const forgets = command.kind === PersonalMemoryOperationKinds.Forget;
+	if (forgets !== (command.source === null && command.contentDigest === null))
+		context.addIssue({ code: "custom", message: "operation source does not match command kind" });
+	if (!forgets && (command.source === null || command.contentDigest === null))
+		context.addIssue({ code: "custom", message: "Remember and Correct require encrypted source evidence" });
+	if (remembers !== (command.targetFactId === null && command.targetDocumentId === null && command.expectedFactRevision === null))
+		context.addIssue({ code: "custom", message: "operation target does not match command kind" });
+	if (!remembers && (command.targetFactId === null || command.targetDocumentId === null || command.expectedFactRevision === null))
+		context.addIssue({ code: "custom", message: "Correct and Forget require complete target evidence" });
+	if (!remembers && command.providerDatasetId === null)
+		context.addIssue({ code: "custom", message: "existing-fact commands require an adopted provider dataset" });
+	if (command.source !== null && command.source.authorPrincipalId !== command.actorPrincipalId)
+		context.addIssue({ code: "custom", message: "operation source author must be the authenticated actor" });
+});
+
+/** Validates every persisted field plus the reviewed lifecycle invariants before a row is returned. */
+export const ___PersonalMemoryOperationRecordSchema: z.ZodType<PersonalMemoryOperationRecord> = z.object({
+	operationId: _Uuid,
+	siloId: _Identifier,
+	datasetId: _Identifier,
+	actorPrincipalId: _Identifier,
+	idempotencyKeyDigest: _Digest,
+	commandDigest: _Digest,
+	kind: z.nativeEnum(PersonalMemoryOperationKinds),
+	phase: z.nativeEnum(PersonalMemoryOperationPhases),
+	revision: _Revision,
+	recoveryPhase: z.nativeEnum(PersonalMemoryOperationPhases).nullable(),
+	expectedContentDigest: _Digest.nullable(),
+	targetFactId: _Identifier.nullable(),
+	targetDocumentId: _Uuid.nullable(),
+	providerDatasetId: _Uuid.nullable(),
+	documentId: _Uuid.nullable(),
+	indexingOperationId: _Uuid.nullable(),
+	expectedInputEvidenceDigest: _Digest.nullable(),
+	pipelineRunId: _Uuid.nullable(),
+	failureCode: z.nativeEnum(PersonalMemoryOperationFailureCodes).nullable(),
+	deliveryState: z.nativeEnum(MemoryMutationDeliveryStates).nullable(),
+	source: _MessageSource.nullable(),
+	expectedFactRevision: _Revision.nullable(),
+	admittedProviderDatasetId: _Uuid.nullable(),
+	task: _TaskIdentity,
+	admittedAt: _Timestamp,
+	recoveryRecordedAt: _Timestamp.nullable(),
+	completedAt: _Timestamp.nullable(),
+}).strict().superRefine(function _RecordShape(record, context)
+{
+	const lifecycle: PersonalMemoryOperationLifecycle = {
+		operationId: record.operationId,
+		kind: record.kind,
+		phase: record.phase,
+		revision: record.revision,
+		recoveryPhase: record.recoveryPhase,
+		expectedContentDigest: record.expectedContentDigest,
+		targetFactId: record.targetFactId,
+		targetDocumentId: record.targetDocumentId,
+		providerDatasetId: record.providerDatasetId,
+		documentId: record.documentId,
+		indexingOperationId: record.indexingOperationId,
+		expectedInputEvidenceDigest: record.expectedInputEvidenceDigest,
+		pipelineRunId: record.pipelineRunId,
+		failureCode: record.failureCode,
+		deliveryState: record.deliveryState,
+	};
+	if (!___PersonalMemoryOperationLifecycleSchema.safeParse(lifecycle).success)
+		context.addIssue({ code: "custom", message: "saved lifecycle evidence is invalid" });
+	const forgets = record.kind === PersonalMemoryOperationKinds.Forget;
+	if (forgets !== (record.source === null && record.expectedContentDigest === null))
+		context.addIssue({ code: "custom", message: "saved source does not match command kind" });
+	if (!forgets && (record.source === null || record.expectedContentDigest === null))
+		context.addIssue({ code: "custom", message: "saved operation requires encrypted source evidence" });
+	const remembers = record.kind === PersonalMemoryOperationKinds.Remember;
+	if (remembers !== (record.targetFactId === null && record.targetDocumentId === null && record.expectedFactRevision === null))
+		context.addIssue({ code: "custom", message: "saved target does not match command kind" });
+	if (!remembers && (record.targetFactId === null || record.targetDocumentId === null || record.expectedFactRevision === null))
+		context.addIssue({ code: "custom", message: "saved operation requires complete target evidence" });
+	if (!remembers && record.admittedProviderDatasetId === null)
+		context.addIssue({ code: "custom", message: "existing-fact operation lacks its admitted provider dataset" });
+	if (record.admittedProviderDatasetId !== null && record.providerDatasetId !== record.admittedProviderDatasetId)
+		context.addIssue({ code: "custom", message: "operation changed its admitted provider dataset" });
+	if (record.source !== null && record.source.authorPrincipalId !== record.actorPrincipalId)
+		context.addIssue({ code: "custom", message: "saved source author does not match the admitted actor" });
+	const recovery = record.phase === PersonalMemoryOperationPhases.RecoveryRequired;
+	if (recovery !== (record.recoveryRecordedAt !== null))
+		context.addIssue({ code: "custom", message: "recovery timestamp does not match operation phase" });
+	const completed = record.phase === PersonalMemoryOperationPhases.Completed;
+	if (completed !== (record.completedAt !== null))
+		context.addIssue({ code: "custom", message: "completion timestamp does not match operation phase" });
+});

--- a/libs/backend/agents/personal/memory/main/src/operations/personal-memory-operation.types.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/personal-memory-operation.types.ts
@@ -1,0 +1,213 @@
+import type { MemoryMutationDeliveryStates } from "@opencrane/contracts";
+
+/**
+ * Selects the independent personal-memory command whose durable lifecycle is being planned.
+ *
+ * This value will be stored with the operation. Renaming a member requires a fresh-baseline schema
+ * change. Command strategy stays separate from lifecycle phase so a phase never implies user intent.
+ */
+export enum PersonalMemoryOperationKinds
+{
+	/** Adds a new fact from an authorized source and makes it recallable after indexing. */
+	Remember = "remember",
+	/** Adds and indexes a replacement before retiring the prior fact and provider document. */
+	Correct = "correct",
+	/** Hides a fact immediately, deletes its provider document, and then finalizes forgetting. */
+	Forget = "forget",
+}
+
+/**
+ * Names the saved phase of one personal-memory operation.
+ *
+ * These values will be stored in PostgreSQL. Renaming one requires a fresh-baseline schema change.
+ * Only `Completed` is terminal. `RecoveryRequired` preserves the phase that needs reconciliation.
+ */
+export enum PersonalMemoryOperationPhases
+{
+	/** A Remember operation is waiting to ensure and adopt its personal provider dataset. */
+	DatasetEnsurePending = "dataset_ensure_pending",
+	/** Remember or Correct is waiting to add or reconcile its digest-bound document. */
+	DocumentAddPending = "document_add_pending",
+	/** The document is saved; input evidence and an exact completed Cognify receipt are still owed. */
+	CognifyPending = "cognify_pending",
+	/** Exact indexing completion is saved and the Active catalog mutation is pending. */
+	CatalogCommitPending = "catalog_commit_pending",
+	/** A correction is recallable and the prior provider document still needs exact deletion. */
+	PriorDocumentDeletePending = "prior_document_delete_pending",
+	/** A Forget operation has hidden its fact and is waiting for exact document absence. */
+	DocumentDeletePending = "document_delete_pending",
+	/** Exact provider absence is saved and the Forgotten catalog transition is pending. */
+	CatalogFinalizePending = "catalog_finalize_pending",
+	/** An uncertain or blocked step needs evidence before the saved phase can advance. */
+	RecoveryRequired = "recovery_required",
+	/** Every required provider and catalog effect for this command has completed. */
+	Completed = "completed",
+}
+
+/**
+ * Names events accepted by the personal-memory lifecycle planner.
+ *
+ * Events are internal planning inputs and are not stored or sent across an API. Each success event
+ * means the caller already verified the evidence named by that event.
+ */
+export enum PersonalMemoryOperationEvents
+{
+	/** The opaque personal dataset name resolved to one ACL-complete provider dataset UUID. */
+	DatasetEnsured = "dataset_ensured",
+	/** Add or read-only reconciliation proved one document with the saved content digest. */
+	DocumentAdded = "document_added",
+	/** A document-list receipt supplied the complete expected Cognify input digest. */
+	IndexEvidenceSaved = "index_evidence_saved",
+	/** The exact saved operation and input digest produced one completed pipeline-run receipt. */
+	IndexingCompleted = "indexing_completed",
+	/** The new Active catalog fact committed with the saved provider evidence. */
+	CatalogCommitted = "catalog_committed",
+	/** Exact absence of a corrected fact's prior provider document was proved. */
+	PriorDocumentDeleted = "prior_document_deleted",
+	/** Exact absence of the Forget target's provider document was proved. */
+	DocumentDeleted = "document_deleted",
+	/** The hidden fact advanced to Forgotten after exact provider absence was saved. */
+	CatalogFinalized = "catalog_finalized",
+	/** A provider mutation failed with evidence about whether bytes could have been delivered. */
+	MutationFailed = "mutation_failed",
+	/** A non-mutation guard or read cannot currently prove that the operation may advance. */
+	OperationBlocked = "operation_blocked",
+}
+
+/**
+ * Fixed failure evidence saved with an operation that needs recovery.
+ *
+ * These values will be stored and may be projected to product callers. Renaming one is a breaking
+ * persistence and API change. They contain no provider response, source text, or credential detail.
+ */
+export enum PersonalMemoryOperationFailureCodes
+{
+	/** Current product authorization or source ownership no longer permits the command. */
+	AuthorityEnded = "authority_ended",
+	/** The personal dataset cannot be safely ensured, adopted, or used. */
+	DatasetUnavailable = "dataset_unavailable",
+	/** The encrypted source cannot be re-read with its admitted coordinates and digest. */
+	SourceUnavailable = "source_unavailable",
+	/** Add reconciliation found no unique document matching the saved content digest. */
+	DocumentConflict = "document_conflict",
+	/** Current dataset input no longer matches the evidence saved before Cognify dispatch. */
+	IndexInputChanged = "index_input_changed",
+	/** Exact indexing completion cannot be established without repeating uncertain work. */
+	IndexingUnavailable = "indexing_unavailable",
+	/** The fact catalog winner conflicts with the operation's saved revision or coordinates. */
+	CatalogConflict = "catalog_conflict",
+	/** Exact provider document absence cannot currently be proved. */
+	DeletionUnavailable = "deletion_unavailable",
+}
+
+/** Why the lifecycle planner accepted or rejected one event. */
+export enum PersonalMemoryOperationTransitionOutcomes
+{
+	/** The event advances the saved operation to a new phase and revision. */
+	Advanced = "advanced",
+	/** The provider proved no mutation bytes were sent, so the same saved command may retry. */
+	Retry = "retry",
+	/** The event is stale, malformed, conflicts with saved evidence, or is invalid in this phase. */
+	Denied = "denied",
+}
+
+/** Fixed reason for rejecting an event without applying an effect. */
+export enum PersonalMemoryOperationTransitionDenialReasons
+{
+	/** The saved operation or event fails its model-adjacent validator. */
+	InvalidInput = "invalid_input",
+	/** The event names another operation or command strategy. */
+	WrongOperation = "wrong_operation",
+	/** The event expected a different saved revision. */
+	StaleRevision = "stale_revision",
+	/** This command strategy cannot accept the event in its current or recovery phase. */
+	InvalidTransition = "invalid_transition",
+	/** The event's provider coordinates or digests disagree with saved evidence. */
+	ConflictingEvidence = "conflicting_evidence",
+}
+
+/** Immutable evidence required when a personal-memory operation is first admitted. */
+export interface CreatePersonalMemoryOperationLifecycleCommand
+{
+	/** UUID saved before any workflow or provider action and repeated on every event. */
+	readonly operationId: string;
+	/** Independent command strategy selected by the authenticated product route. */
+	readonly kind: PersonalMemoryOperationKinds;
+	/** Complete source UTF-8 digest for Remember or Correct; Forget has no new content. */
+	readonly expectedContentDigest: string | null;
+	/** Existing local fact coordinate for Correct or Forget; Remember has no target. */
+	readonly targetFactId: string | null;
+	/** Existing provider document coordinate for Correct or Forget; Remember has no target. */
+	readonly targetDocumentId: string | null;
+	/** Already active provider dataset for Correct or Forget; first Remember may still provision it. */
+	readonly providerDatasetId: string | null;
+}
+
+/** Durable lifecycle projection that contains provider coordinates and hashes but never fact text. */
+export interface PersonalMemoryOperationLifecycle
+{
+	/** Stable UUID that fences every transition and later supplies the Cognify operation identity. */
+	readonly operationId: string;
+	/** User-command strategy, kept separate from lifecycle phase. */
+	readonly kind: PersonalMemoryOperationKinds;
+	/** Current saved lifecycle phase. */
+	readonly phase: PersonalMemoryOperationPhases;
+	/** Positive compare-and-set revision expected by the next event. */
+	readonly revision: number;
+	/** Phase whose evidence is unresolved while `phase` is `RecoveryRequired`. */
+	readonly recoveryPhase: PersonalMemoryOperationPhases | null;
+	/** Complete source digest admitted for Remember or Correct. */
+	readonly expectedContentDigest: string | null;
+	/** Existing fact replaced or forgotten by Correct or Forget. */
+	readonly targetFactId: string | null;
+	/** Existing provider document replaced or forgotten by Correct or Forget. */
+	readonly targetDocumentId: string | null;
+	/** Provider dataset adopted from ensure or required at Correct and Forget admission. */
+	readonly providerDatasetId: string | null;
+	/** New provider document adopted after Add or read-only reconciliation. */
+	readonly documentId: string | null;
+	/** Caller-saved UUID for the exact Cognify admission. */
+	readonly indexingOperationId: string | null;
+	/** Complete dataset input digest saved before the first Cognify dispatch. */
+	readonly expectedInputEvidenceDigest: string | null;
+	/** Provider pipeline run bound to the saved indexing operation and input digest. */
+	readonly pipelineRunId: string | null;
+	/** Fixed recovery reason with no source or provider data. */
+	readonly failureCode: PersonalMemoryOperationFailureCodes | null;
+	/** Mutation-delivery evidence; null for non-mutation recovery and ordinary phases. */
+	readonly deliveryState: MemoryMutationDeliveryStates | null;
+}
+
+interface PersonalMemoryOperationEventBase
+{
+	/** Operation UUID the caller read before producing the event. */
+	readonly operationId: string;
+	/** Command strategy the caller expects the saved operation to retain. */
+	readonly kind: PersonalMemoryOperationKinds;
+	/** Saved revision this event is allowed to advance. */
+	readonly expectedRevision: number;
+}
+
+/** One strictly shaped event accepted by the lifecycle planner. */
+export type PersonalMemoryOperationEvent =
+	| PersonalMemoryOperationEventBase & { readonly event: PersonalMemoryOperationEvents.DatasetEnsured; readonly providerDatasetId: string }
+	| PersonalMemoryOperationEventBase & { readonly event: PersonalMemoryOperationEvents.DocumentAdded; readonly documentId: string; readonly contentDigest: string }
+	| PersonalMemoryOperationEventBase & { readonly event: PersonalMemoryOperationEvents.IndexEvidenceSaved; readonly indexingOperationId: string; readonly expectedInputEvidenceDigest: string }
+	| PersonalMemoryOperationEventBase & { readonly event: PersonalMemoryOperationEvents.IndexingCompleted; readonly indexingOperationId: string; readonly expectedInputEvidenceDigest: string; readonly pipelineRunId: string }
+	| PersonalMemoryOperationEventBase & { readonly event: PersonalMemoryOperationEvents.CatalogCommitted }
+	| PersonalMemoryOperationEventBase & { readonly event: PersonalMemoryOperationEvents.PriorDocumentDeleted; readonly documentId: string }
+	| PersonalMemoryOperationEventBase & { readonly event: PersonalMemoryOperationEvents.DocumentDeleted; readonly documentId: string }
+	| PersonalMemoryOperationEventBase & { readonly event: PersonalMemoryOperationEvents.CatalogFinalized }
+	| PersonalMemoryOperationEventBase & { readonly event: PersonalMemoryOperationEvents.MutationFailed; readonly failureCode: PersonalMemoryOperationFailureCodes; readonly deliveryState: MemoryMutationDeliveryStates }
+	| PersonalMemoryOperationEventBase & { readonly event: PersonalMemoryOperationEvents.OperationBlocked; readonly failureCode: PersonalMemoryOperationFailureCodes };
+
+/** Flat result whose next state is present only when the planner accepts the event. */
+export interface PersonalMemoryOperationTransitionResult
+{
+	/** States whether the caller must persist an advance, retry unchanged, or stop. */
+	readonly outcome: PersonalMemoryOperationTransitionOutcomes;
+	/** Next state for an advance, or the unchanged state for a proven-not-sent retry. */
+	readonly operation?: PersonalMemoryOperationLifecycle;
+	/** Fixed denial reason populated only when `outcome` is `Denied`. */
+	readonly reason?: PersonalMemoryOperationTransitionDenialReasons;
+}

--- a/libs/backend/agents/personal/memory/main/src/operations/personal-memory-operation.validator.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/personal-memory-operation.validator.ts
@@ -1,0 +1,208 @@
+import { z } from "zod";
+
+import { MemoryMutationDeliveryStates } from "@opencrane/contracts";
+
+import { PersonalMemoryOperationEvents, PersonalMemoryOperationFailureCodes, PersonalMemoryOperationKinds, PersonalMemoryOperationPhases, type CreatePersonalMemoryOperationLifecycleCommand, type PersonalMemoryOperationEvent, type PersonalMemoryOperationLifecycle } from "./personal-memory-operation.types";
+
+const _Identifier = z.string().trim().min(1).max(128);
+const _Uuid = z.string().uuid();
+const _Digest = z.string().regex(/^sha256:[0-9a-f]{64}$/u);
+const _Revision = z.number().int().positive();
+
+type _PhaseAllowance = Readonly<Record<PersonalMemoryOperationPhases, boolean>>;
+
+const _REMEMBER_PHASES: _PhaseAllowance = {
+	[PersonalMemoryOperationPhases.DatasetEnsurePending]: true,
+	[PersonalMemoryOperationPhases.DocumentAddPending]: true,
+	[PersonalMemoryOperationPhases.CognifyPending]: true,
+	[PersonalMemoryOperationPhases.CatalogCommitPending]: true,
+	[PersonalMemoryOperationPhases.PriorDocumentDeletePending]: false,
+	[PersonalMemoryOperationPhases.DocumentDeletePending]: false,
+	[PersonalMemoryOperationPhases.CatalogFinalizePending]: false,
+	[PersonalMemoryOperationPhases.RecoveryRequired]: true,
+	[PersonalMemoryOperationPhases.Completed]: true,
+};
+
+const _CORRECT_PHASES: _PhaseAllowance = {
+	[PersonalMemoryOperationPhases.DatasetEnsurePending]: false,
+	[PersonalMemoryOperationPhases.DocumentAddPending]: true,
+	[PersonalMemoryOperationPhases.CognifyPending]: true,
+	[PersonalMemoryOperationPhases.CatalogCommitPending]: true,
+	[PersonalMemoryOperationPhases.PriorDocumentDeletePending]: true,
+	[PersonalMemoryOperationPhases.DocumentDeletePending]: false,
+	[PersonalMemoryOperationPhases.CatalogFinalizePending]: false,
+	[PersonalMemoryOperationPhases.RecoveryRequired]: true,
+	[PersonalMemoryOperationPhases.Completed]: true,
+};
+
+const _FORGET_PHASES: _PhaseAllowance = {
+	[PersonalMemoryOperationPhases.DatasetEnsurePending]: false,
+	[PersonalMemoryOperationPhases.DocumentAddPending]: false,
+	[PersonalMemoryOperationPhases.CognifyPending]: false,
+	[PersonalMemoryOperationPhases.CatalogCommitPending]: false,
+	[PersonalMemoryOperationPhases.PriorDocumentDeletePending]: false,
+	[PersonalMemoryOperationPhases.DocumentDeletePending]: true,
+	[PersonalMemoryOperationPhases.CatalogFinalizePending]: true,
+	[PersonalMemoryOperationPhases.RecoveryRequired]: true,
+	[PersonalMemoryOperationPhases.Completed]: true,
+};
+
+const _PHASES_BY_KIND: Readonly<Record<PersonalMemoryOperationKinds, _PhaseAllowance>> = {
+	[PersonalMemoryOperationKinds.Remember]: _REMEMBER_PHASES,
+	[PersonalMemoryOperationKinds.Correct]: _CORRECT_PHASES,
+	[PersonalMemoryOperationKinds.Forget]: _FORGET_PHASES,
+};
+
+const _MUTATION_FAILURES_BY_PHASE: Readonly<Record<PersonalMemoryOperationPhases, readonly PersonalMemoryOperationFailureCodes[]>> = {
+	[PersonalMemoryOperationPhases.DatasetEnsurePending]: [PersonalMemoryOperationFailureCodes.DatasetUnavailable],
+	[PersonalMemoryOperationPhases.DocumentAddPending]: [PersonalMemoryOperationFailureCodes.DocumentConflict],
+	[PersonalMemoryOperationPhases.CognifyPending]: [PersonalMemoryOperationFailureCodes.IndexingUnavailable],
+	[PersonalMemoryOperationPhases.CatalogCommitPending]: [],
+	[PersonalMemoryOperationPhases.PriorDocumentDeletePending]: [PersonalMemoryOperationFailureCodes.DeletionUnavailable],
+	[PersonalMemoryOperationPhases.DocumentDeletePending]: [PersonalMemoryOperationFailureCodes.DeletionUnavailable],
+	[PersonalMemoryOperationPhases.CatalogFinalizePending]: [],
+	[PersonalMemoryOperationPhases.RecoveryRequired]: [],
+	[PersonalMemoryOperationPhases.Completed]: [],
+};
+
+const _BLOCKED_FAILURES_BY_PHASE: Readonly<Record<PersonalMemoryOperationPhases, readonly PersonalMemoryOperationFailureCodes[]>> = {
+	[PersonalMemoryOperationPhases.DatasetEnsurePending]: [PersonalMemoryOperationFailureCodes.AuthorityEnded, PersonalMemoryOperationFailureCodes.DatasetUnavailable],
+	[PersonalMemoryOperationPhases.DocumentAddPending]: [PersonalMemoryOperationFailureCodes.AuthorityEnded, PersonalMemoryOperationFailureCodes.SourceUnavailable, PersonalMemoryOperationFailureCodes.DocumentConflict],
+	[PersonalMemoryOperationPhases.CognifyPending]: [PersonalMemoryOperationFailureCodes.AuthorityEnded, PersonalMemoryOperationFailureCodes.DatasetUnavailable, PersonalMemoryOperationFailureCodes.IndexInputChanged, PersonalMemoryOperationFailureCodes.IndexingUnavailable],
+	[PersonalMemoryOperationPhases.CatalogCommitPending]: [PersonalMemoryOperationFailureCodes.AuthorityEnded, PersonalMemoryOperationFailureCodes.CatalogConflict],
+	[PersonalMemoryOperationPhases.PriorDocumentDeletePending]: [PersonalMemoryOperationFailureCodes.AuthorityEnded, PersonalMemoryOperationFailureCodes.DeletionUnavailable],
+	[PersonalMemoryOperationPhases.DocumentDeletePending]: [PersonalMemoryOperationFailureCodes.AuthorityEnded, PersonalMemoryOperationFailureCodes.DeletionUnavailable],
+	[PersonalMemoryOperationPhases.CatalogFinalizePending]: [PersonalMemoryOperationFailureCodes.AuthorityEnded, PersonalMemoryOperationFailureCodes.CatalogConflict],
+	[PersonalMemoryOperationPhases.RecoveryRequired]: [],
+	[PersonalMemoryOperationPhases.Completed]: [],
+};
+
+/** Check whether a durable phase can belong to the selected command strategy. */
+export function __PersonalMemoryOperationPhaseMatchesKind(kind: PersonalMemoryOperationKinds, phase: PersonalMemoryOperationPhases): boolean
+{
+	return _PHASES_BY_KIND[kind][phase];
+}
+
+/** Check whether an uncertain mutation can save this failure against the unfinished phase. */
+export function __PersonalMemoryMutationFailureMatchesPhase(phase: PersonalMemoryOperationPhases, failureCode: PersonalMemoryOperationFailureCodes): boolean
+{
+	return _MUTATION_FAILURES_BY_PHASE[phase].includes(failureCode);
+}
+
+/** Check whether a failed read or guard can save this failure against the unfinished phase. */
+export function __PersonalMemoryBlockedFailureMatchesPhase(phase: PersonalMemoryOperationPhases, failureCode: PersonalMemoryOperationFailureCodes): boolean
+{
+	return _BLOCKED_FAILURES_BY_PHASE[phase].includes(failureCode);
+}
+
+/** Validates newly admitted immutable command evidence before the lifecycle creates state. */
+export const ___CreatePersonalMemoryOperationLifecycleCommandSchema: z.ZodType<CreatePersonalMemoryOperationLifecycleCommand> = z.object({
+	operationId: _Uuid,
+	kind: z.nativeEnum(PersonalMemoryOperationKinds),
+	expectedContentDigest: _Digest.nullable(),
+	targetFactId: _Identifier.nullable(),
+	targetDocumentId: _Uuid.nullable(),
+	providerDatasetId: _Uuid.nullable(),
+}).strict().superRefine(function _CommandEvidence(command, context)
+{
+	const remembers = command.kind === PersonalMemoryOperationKinds.Remember;
+	const forgets = command.kind === PersonalMemoryOperationKinds.Forget;
+	if ((remembers && (command.targetFactId !== null || command.targetDocumentId !== null))
+		|| (!remembers && (command.targetFactId === null || command.targetDocumentId === null)))
+		context.addIssue({ code: "custom", message: "operation target does not match command kind" });
+	if (forgets !== (command.expectedContentDigest === null))
+		context.addIssue({ code: "custom", message: "operation content digest does not match command kind" });
+	if (!remembers && command.providerDatasetId === null)
+		context.addIssue({ code: "custom", message: "existing-fact command requires its provider dataset" });
+});
+
+/** Validates a durable lifecycle row before any event decision uses its saved evidence. */
+export const ___PersonalMemoryOperationLifecycleSchema: z.ZodType<PersonalMemoryOperationLifecycle> = z.object({
+	operationId: _Uuid,
+	kind: z.nativeEnum(PersonalMemoryOperationKinds),
+	phase: z.nativeEnum(PersonalMemoryOperationPhases),
+	revision: _Revision,
+	recoveryPhase: z.nativeEnum(PersonalMemoryOperationPhases).nullable(),
+	expectedContentDigest: _Digest.nullable(),
+	targetFactId: _Identifier.nullable(),
+	targetDocumentId: _Uuid.nullable(),
+	providerDatasetId: _Uuid.nullable(),
+	documentId: _Uuid.nullable(),
+	indexingOperationId: _Uuid.nullable(),
+	expectedInputEvidenceDigest: _Digest.nullable(),
+	pipelineRunId: _Uuid.nullable(),
+	failureCode: z.nativeEnum(PersonalMemoryOperationFailureCodes).nullable(),
+	deliveryState: z.nativeEnum(MemoryMutationDeliveryStates).nullable(),
+}).strict().superRefine(function _StateEvidence(operation, context)
+{
+	const recovery = operation.phase === PersonalMemoryOperationPhases.RecoveryRequired;
+	if (!__PersonalMemoryOperationPhaseMatchesKind(operation.kind, operation.phase))
+		context.addIssue({ code: "custom", message: "operation phase does not match command kind" });
+	if (!recovery && (operation.recoveryPhase !== null || operation.failureCode !== null || operation.deliveryState !== null))
+		context.addIssue({ code: "custom", message: "recovery evidence does not match operation phase" });
+	if (recovery)
+	{
+		if (operation.recoveryPhase === null || operation.failureCode === null
+			|| !__PersonalMemoryOperationPhaseMatchesKind(operation.kind, operation.recoveryPhase)
+			|| operation.recoveryPhase === PersonalMemoryOperationPhases.RecoveryRequired
+			|| operation.recoveryPhase === PersonalMemoryOperationPhases.Completed)
+			context.addIssue({ code: "custom", message: "recovery phase must name unfinished work for this command" });
+		else if (operation.deliveryState === MemoryMutationDeliveryStates.Ambiguous)
+		{
+			if (!__PersonalMemoryMutationFailureMatchesPhase(operation.recoveryPhase, operation.failureCode))
+				context.addIssue({ code: "custom", message: "ambiguous mutation evidence does not match recovery phase" });
+		}
+		else if (operation.deliveryState === null)
+		{
+			if (!__PersonalMemoryBlockedFailureMatchesPhase(operation.recoveryPhase, operation.failureCode))
+				context.addIssue({ code: "custom", message: "blocked failure evidence does not match recovery phase" });
+		}
+		else
+			context.addIssue({ code: "custom", message: "proven-not-sent failure cannot be saved as recovery" });
+	}
+	const remembers = operation.kind === PersonalMemoryOperationKinds.Remember;
+	const forgets = operation.kind === PersonalMemoryOperationKinds.Forget;
+	if ((remembers && (operation.targetFactId !== null || operation.targetDocumentId !== null))
+		|| (!remembers && (operation.targetFactId === null || operation.targetDocumentId === null)))
+		context.addIssue({ code: "custom", message: "saved target does not match command kind" });
+	if (forgets !== (operation.expectedContentDigest === null))
+		context.addIssue({ code: "custom", message: "saved content digest does not match command kind" });
+	const activePhase = recovery ? operation.recoveryPhase : operation.phase;
+	const datasetMayBeMissing = remembers && activePhase === PersonalMemoryOperationPhases.DatasetEnsurePending;
+	if (!datasetMayBeMissing && operation.providerDatasetId === null)
+		context.addIssue({ code: "custom", message: "saved phase requires an adopted provider dataset" });
+	const documentRequired = !forgets && activePhase !== PersonalMemoryOperationPhases.DatasetEnsurePending && activePhase !== PersonalMemoryOperationPhases.DocumentAddPending;
+	if ((documentRequired && operation.documentId === null) || (!documentRequired && operation.documentId !== null))
+		context.addIssue({ code: "custom", message: "saved document evidence does not match operation phase" });
+	const indexingPairMatches = (operation.indexingOperationId === null) === (operation.expectedInputEvidenceDigest === null);
+	if (!indexingPairMatches)
+		context.addIssue({ code: "custom", message: "indexing operation and input digest must be saved together" });
+	const indexingReceiptRequired = !forgets && (activePhase === PersonalMemoryOperationPhases.CatalogCommitPending
+		|| activePhase === PersonalMemoryOperationPhases.PriorDocumentDeletePending
+		|| activePhase === PersonalMemoryOperationPhases.Completed);
+	if ((indexingReceiptRequired && (operation.indexingOperationId === null || operation.pipelineRunId === null))
+		|| (!indexingReceiptRequired && operation.pipelineRunId !== null))
+		context.addIssue({ code: "custom", message: "pipeline receipt does not match operation phase" });
+	if (forgets && (operation.documentId !== null || operation.indexingOperationId !== null || operation.expectedInputEvidenceDigest !== null || operation.pipelineRunId !== null))
+		context.addIssue({ code: "custom", message: "Forget cannot retain replacement or indexing evidence" });
+});
+
+const _EventBase = {
+	operationId: _Uuid,
+	kind: z.nativeEnum(PersonalMemoryOperationKinds),
+	expectedRevision: _Revision,
+} as const;
+
+/** Validates one event and rejects unknown evidence fields before lifecycle planning. */
+export const ___PersonalMemoryOperationEventSchema: z.ZodType<PersonalMemoryOperationEvent> = z.discriminatedUnion("event", [
+	z.object({ ..._EventBase, event: z.literal(PersonalMemoryOperationEvents.DatasetEnsured), providerDatasetId: _Uuid }).strict(),
+	z.object({ ..._EventBase, event: z.literal(PersonalMemoryOperationEvents.DocumentAdded), documentId: _Uuid, contentDigest: _Digest }).strict(),
+	z.object({ ..._EventBase, event: z.literal(PersonalMemoryOperationEvents.IndexEvidenceSaved), indexingOperationId: _Uuid, expectedInputEvidenceDigest: _Digest }).strict(),
+	z.object({ ..._EventBase, event: z.literal(PersonalMemoryOperationEvents.IndexingCompleted), indexingOperationId: _Uuid, expectedInputEvidenceDigest: _Digest, pipelineRunId: _Uuid }).strict(),
+	z.object({ ..._EventBase, event: z.literal(PersonalMemoryOperationEvents.CatalogCommitted) }).strict(),
+	z.object({ ..._EventBase, event: z.literal(PersonalMemoryOperationEvents.PriorDocumentDeleted), documentId: _Uuid }).strict(),
+	z.object({ ..._EventBase, event: z.literal(PersonalMemoryOperationEvents.DocumentDeleted), documentId: _Uuid }).strict(),
+	z.object({ ..._EventBase, event: z.literal(PersonalMemoryOperationEvents.CatalogFinalized) }).strict(),
+	z.object({ ..._EventBase, event: z.literal(PersonalMemoryOperationEvents.MutationFailed), failureCode: z.nativeEnum(PersonalMemoryOperationFailureCodes), deliveryState: z.nativeEnum(MemoryMutationDeliveryStates) }).strict(),
+	z.object({ ..._EventBase, event: z.literal(PersonalMemoryOperationEvents.OperationBlocked), failureCode: z.nativeEnum(PersonalMemoryOperationFailureCodes) }).strict(),
+]);

--- a/libs/backend/agents/personal/memory/main/src/operations/prisma-personal-memory-operation-mapper.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/prisma-personal-memory-operation-mapper.ts
@@ -1,0 +1,255 @@
+import { MemoryMutationDeliveryStates } from "@opencrane/contracts";
+
+import { ___PersonalMemoryOperationRecordSchema } from "./personal-memory-operation-persistence.validator";
+import { PersonalMemoryOperationInvalidState, type AdmitPersonalMemoryOperationCommand, type PersonalMemoryOperationMessageSource, type PersonalMemoryOperationRecord } from "./personal-memory-operation-persistence.types";
+import { PersonalMemoryOperationFailureCodes, PersonalMemoryOperationKinds, PersonalMemoryOperationPhases, type PersonalMemoryOperationLifecycle } from "./personal-memory-operation.types";
+
+/** Prisma command values accepted from the generated operation row. */
+type _PrismaKind = "Remember" | "Correct" | "Forget";
+
+/** Prisma phase values accepted from the generated operation row. */
+type _PrismaPhase = "DatasetEnsurePending" | "DocumentAddPending" | "CognifyPending" | "CatalogCommitPending" | "PriorDocumentDeletePending" | "DocumentDeletePending" | "CatalogFinalizePending" | "RecoveryRequired" | "Completed";
+
+/** Prisma failure values accepted from the generated operation row. */
+type _PrismaFailureCode = "AuthorityEnded" | "DatasetUnavailable" | "SourceUnavailable" | "DocumentConflict" | "IndexInputChanged" | "IndexingUnavailable" | "CatalogConflict" | "DeletionUnavailable";
+
+/** Prisma delivery values accepted from the generated operation row. */
+type _PrismaDeliveryState = "ProvenNotSent" | "Ambiguous";
+
+/** Structural operation row kept free of Prisma imports outside the authoritative repository. */
+interface _PrismaOperationRow
+{
+	readonly id: string;
+	readonly siloId: string;
+	readonly datasetId: string;
+	readonly actorPrincipalId: string;
+	readonly idempotencyKeyDigest: string;
+	readonly commandDigest: string;
+	readonly kind: _PrismaKind;
+	readonly phase: _PrismaPhase;
+	readonly recoveryPhase: _PrismaPhase | null;
+	readonly revision: number;
+	readonly sourceConversationId: string | null;
+	readonly sourceMessageId: string | null;
+	readonly sourceMessagePosition: bigint | null;
+	readonly sourcePayloadRef: string | null;
+	readonly sourceCiphertextDigest: string | null;
+	readonly sourceAuthorPrincipalId: string | null;
+	readonly contentDigest: string | null;
+	readonly targetFactId: string | null;
+	readonly targetDocumentId: string | null;
+	readonly expectedFactRevision: number | null;
+	readonly admittedProviderDatasetId: string | null;
+	readonly providerDatasetId: string | null;
+	readonly providerDocumentId: string | null;
+	readonly indexingOperationId: string | null;
+	readonly expectedInputEvidenceDigest: string | null;
+	readonly pipelineRunId: string | null;
+	readonly failureCode: _PrismaFailureCode | null;
+	readonly deliveryState: _PrismaDeliveryState | null;
+	readonly workflowTaskId: string;
+	readonly workflowTaskName: string;
+	readonly workflowTaskKey: string;
+	readonly admittedAt: Date;
+	readonly recoveryRecordedAt: Date | null;
+	readonly completedAt: Date | null;
+}
+
+/** Maps stored Prisma command kinds to the reviewed lifecycle vocabulary. */
+const _KIND_FROM_PRISMA: Readonly<Record<_PrismaKind, PersonalMemoryOperationKinds>> = {
+	Remember: PersonalMemoryOperationKinds.Remember,
+	Correct: PersonalMemoryOperationKinds.Correct,
+	Forget: PersonalMemoryOperationKinds.Forget,
+};
+
+/** Maps reviewed lifecycle command kinds to their Prisma values. */
+const _KIND_TO_PRISMA: Readonly<Record<PersonalMemoryOperationKinds, _PrismaKind>> = {
+	[PersonalMemoryOperationKinds.Remember]: "Remember",
+	[PersonalMemoryOperationKinds.Correct]: "Correct",
+	[PersonalMemoryOperationKinds.Forget]: "Forget",
+};
+
+/** Maps stored Prisma phases to the reviewed lifecycle vocabulary. */
+const _PHASE_FROM_PRISMA: Readonly<Record<_PrismaPhase, PersonalMemoryOperationPhases>> = {
+	DatasetEnsurePending: PersonalMemoryOperationPhases.DatasetEnsurePending,
+	DocumentAddPending: PersonalMemoryOperationPhases.DocumentAddPending,
+	CognifyPending: PersonalMemoryOperationPhases.CognifyPending,
+	CatalogCommitPending: PersonalMemoryOperationPhases.CatalogCommitPending,
+	PriorDocumentDeletePending: PersonalMemoryOperationPhases.PriorDocumentDeletePending,
+	DocumentDeletePending: PersonalMemoryOperationPhases.DocumentDeletePending,
+	CatalogFinalizePending: PersonalMemoryOperationPhases.CatalogFinalizePending,
+	RecoveryRequired: PersonalMemoryOperationPhases.RecoveryRequired,
+	Completed: PersonalMemoryOperationPhases.Completed,
+};
+
+/** Maps reviewed lifecycle phases to their Prisma values. */
+const _PHASE_TO_PRISMA: Readonly<Record<PersonalMemoryOperationPhases, _PrismaPhase>> = {
+	[PersonalMemoryOperationPhases.DatasetEnsurePending]: "DatasetEnsurePending",
+	[PersonalMemoryOperationPhases.DocumentAddPending]: "DocumentAddPending",
+	[PersonalMemoryOperationPhases.CognifyPending]: "CognifyPending",
+	[PersonalMemoryOperationPhases.CatalogCommitPending]: "CatalogCommitPending",
+	[PersonalMemoryOperationPhases.PriorDocumentDeletePending]: "PriorDocumentDeletePending",
+	[PersonalMemoryOperationPhases.DocumentDeletePending]: "DocumentDeletePending",
+	[PersonalMemoryOperationPhases.CatalogFinalizePending]: "CatalogFinalizePending",
+	[PersonalMemoryOperationPhases.RecoveryRequired]: "RecoveryRequired",
+	[PersonalMemoryOperationPhases.Completed]: "Completed",
+};
+
+/** Maps stored fixed failures to the reviewed lifecycle vocabulary. */
+const _FAILURE_FROM_PRISMA: Readonly<Record<_PrismaFailureCode, PersonalMemoryOperationFailureCodes>> = {
+	AuthorityEnded: PersonalMemoryOperationFailureCodes.AuthorityEnded,
+	DatasetUnavailable: PersonalMemoryOperationFailureCodes.DatasetUnavailable,
+	SourceUnavailable: PersonalMemoryOperationFailureCodes.SourceUnavailable,
+	DocumentConflict: PersonalMemoryOperationFailureCodes.DocumentConflict,
+	IndexInputChanged: PersonalMemoryOperationFailureCodes.IndexInputChanged,
+	IndexingUnavailable: PersonalMemoryOperationFailureCodes.IndexingUnavailable,
+	CatalogConflict: PersonalMemoryOperationFailureCodes.CatalogConflict,
+	DeletionUnavailable: PersonalMemoryOperationFailureCodes.DeletionUnavailable,
+};
+
+/** Maps reviewed lifecycle failures to their Prisma values. */
+const _FAILURE_TO_PRISMA: Readonly<Record<PersonalMemoryOperationFailureCodes, _PrismaFailureCode>> = {
+	[PersonalMemoryOperationFailureCodes.AuthorityEnded]: "AuthorityEnded",
+	[PersonalMemoryOperationFailureCodes.DatasetUnavailable]: "DatasetUnavailable",
+	[PersonalMemoryOperationFailureCodes.SourceUnavailable]: "SourceUnavailable",
+	[PersonalMemoryOperationFailureCodes.DocumentConflict]: "DocumentConflict",
+	[PersonalMemoryOperationFailureCodes.IndexInputChanged]: "IndexInputChanged",
+	[PersonalMemoryOperationFailureCodes.IndexingUnavailable]: "IndexingUnavailable",
+	[PersonalMemoryOperationFailureCodes.CatalogConflict]: "CatalogConflict",
+	[PersonalMemoryOperationFailureCodes.DeletionUnavailable]: "DeletionUnavailable",
+};
+
+/** Maps stored delivery evidence to the shared contract vocabulary. */
+const _DELIVERY_FROM_PRISMA: Readonly<Record<_PrismaDeliveryState, MemoryMutationDeliveryStates>> = {
+	ProvenNotSent: MemoryMutationDeliveryStates.ProvenNotSent,
+	Ambiguous: MemoryMutationDeliveryStates.Ambiguous,
+};
+
+/** Maps shared delivery evidence to its Prisma values. */
+const _DELIVERY_TO_PRISMA: Readonly<Record<MemoryMutationDeliveryStates, _PrismaDeliveryState>> = {
+	[MemoryMutationDeliveryStates.ProvenNotSent]: "ProvenNotSent",
+	[MemoryMutationDeliveryStates.Ambiguous]: "Ambiguous",
+};
+
+/** Converts one Prisma row and rejects impossible lifecycle or persistence evidence. */
+export function _PersonalMemoryOperationRecord(row: _PrismaOperationRow): PersonalMemoryOperationRecord
+{
+	const source = _SourceFromRow(row);
+	const candidate: PersonalMemoryOperationRecord = {
+		operationId: row.id,
+		siloId: row.siloId,
+		datasetId: row.datasetId,
+		actorPrincipalId: row.actorPrincipalId,
+		idempotencyKeyDigest: row.idempotencyKeyDigest,
+		commandDigest: row.commandDigest,
+		kind: _KIND_FROM_PRISMA[row.kind],
+		phase: _PHASE_FROM_PRISMA[row.phase],
+		revision: row.revision,
+		recoveryPhase: row.recoveryPhase === null ? null : _PHASE_FROM_PRISMA[row.recoveryPhase],
+		expectedContentDigest: row.contentDigest,
+		targetFactId: row.targetFactId,
+		targetDocumentId: row.targetDocumentId,
+		providerDatasetId: row.providerDatasetId,
+		documentId: row.providerDocumentId,
+		indexingOperationId: row.indexingOperationId,
+		expectedInputEvidenceDigest: row.expectedInputEvidenceDigest,
+		pipelineRunId: row.pipelineRunId,
+		failureCode: row.failureCode === null ? null : _FAILURE_FROM_PRISMA[row.failureCode],
+		deliveryState: row.deliveryState === null ? null : _DELIVERY_FROM_PRISMA[row.deliveryState],
+		source,
+		expectedFactRevision: row.expectedFactRevision,
+		admittedProviderDatasetId: row.admittedProviderDatasetId,
+		task: { taskId: row.workflowTaskId, taskName: row.workflowTaskName, taskKey: row.workflowTaskKey },
+		admittedAt: row.admittedAt,
+		recoveryRecordedAt: row.recoveryRecordedAt,
+		completedAt: row.completedAt,
+	};
+	const parsed = ___PersonalMemoryOperationRecordSchema.safeParse(candidate);
+	if (!parsed.success)
+		throw new PersonalMemoryOperationInvalidState("saved personal-memory operation evidence is invalid");
+	return parsed.data;
+}
+
+/** Projects a validated persistence record to the exact strict lifecycle planner shape. */
+export function _PersonalMemoryOperationLifecycle(record: PersonalMemoryOperationRecord): PersonalMemoryOperationLifecycle
+{
+	return {
+		operationId: record.operationId,
+		kind: record.kind,
+		phase: record.phase,
+		revision: record.revision,
+		recoveryPhase: record.recoveryPhase,
+		expectedContentDigest: record.expectedContentDigest,
+		targetFactId: record.targetFactId,
+		targetDocumentId: record.targetDocumentId,
+		providerDatasetId: record.providerDatasetId,
+		documentId: record.documentId,
+		indexingOperationId: record.indexingOperationId,
+		expectedInputEvidenceDigest: record.expectedInputEvidenceDigest,
+		pipelineRunId: record.pipelineRunId,
+		failureCode: record.failureCode,
+		deliveryState: record.deliveryState,
+	};
+}
+
+/** Builds the Prisma insert from validated command and lifecycle evidence. */
+export function _PersonalMemoryOperationCreateData(command: AdmitPersonalMemoryOperationCommand, lifecycle: PersonalMemoryOperationLifecycle)
+{
+	return {
+		id: command.operationId,
+		siloId: command.siloId,
+		datasetId: command.datasetId,
+		actorPrincipalId: command.actorPrincipalId,
+		idempotencyKeyDigest: command.idempotencyKeyDigest,
+		commandDigest: command.commandDigest,
+		kind: _KIND_TO_PRISMA[command.kind],
+		phase: _PHASE_TO_PRISMA[lifecycle.phase],
+		revision: lifecycle.revision,
+		sourceConversationId: command.source?.conversationId ?? null,
+		sourceMessageId: command.source?.messageId ?? null,
+		sourceMessagePosition: command.source?.messagePosition ?? null,
+		sourcePayloadRef: command.source?.payloadRef ?? null,
+		sourceCiphertextDigest: command.source?.ciphertextDigest ?? null,
+		sourceAuthorPrincipalId: command.source?.authorPrincipalId ?? null,
+		contentDigest: command.contentDigest,
+		targetFactId: command.targetFactId,
+		targetDocumentId: command.targetDocumentId,
+		expectedFactRevision: command.expectedFactRevision,
+		admittedProviderDatasetId: command.providerDatasetId,
+		providerDatasetId: lifecycle.providerDatasetId,
+		workflowTaskId: command.task.taskId,
+		workflowTaskName: command.task.taskName,
+		workflowTaskKey: command.task.taskKey,
+		admittedAt: command.admittedAt,
+	};
+}
+
+/** Maps an accepted lifecycle state to one revision-fenced Prisma update. */
+export function _PersonalMemoryOperationLifecycleUpdate(next: PersonalMemoryOperationLifecycle, recordedAt: Date)
+{
+	return {
+		phase: _PHASE_TO_PRISMA[next.phase],
+		recoveryPhase: next.recoveryPhase === null ? null : _PHASE_TO_PRISMA[next.recoveryPhase],
+		revision: next.revision,
+		providerDatasetId: next.providerDatasetId,
+		providerDocumentId: next.documentId,
+		indexingOperationId: next.indexingOperationId,
+		expectedInputEvidenceDigest: next.expectedInputEvidenceDigest,
+		pipelineRunId: next.pipelineRunId,
+		failureCode: next.failureCode === null ? null : _FAILURE_TO_PRISMA[next.failureCode],
+		deliveryState: next.deliveryState === null ? null : _DELIVERY_TO_PRISMA[next.deliveryState],
+		recoveryRecordedAt: next.phase === PersonalMemoryOperationPhases.RecoveryRequired ? recordedAt : null,
+		completedAt: next.phase === PersonalMemoryOperationPhases.Completed ? recordedAt : null,
+	};
+}
+
+/** Rebuilds all-or-none encrypted source coordinates from a Prisma row. */
+function _SourceFromRow(row: _PrismaOperationRow): PersonalMemoryOperationMessageSource | null
+{
+	const values = [row.sourceConversationId, row.sourceMessageId, row.sourceMessagePosition, row.sourcePayloadRef, row.sourceCiphertextDigest, row.sourceAuthorPrincipalId];
+	if (values.every(value => value === null))
+		return null;
+	if (values.some(value => value === null))
+		throw new PersonalMemoryOperationInvalidState("saved personal-memory source coordinates are incomplete");
+	return { conversationId: row.sourceConversationId!, messageId: row.sourceMessageId!, messagePosition: row.sourceMessagePosition!, payloadRef: row.sourcePayloadRef!, ciphertextDigest: row.sourceCiphertextDigest!, authorPrincipalId: row.sourceAuthorPrincipalId! };
+}

--- a/libs/backend/agents/personal/memory/main/src/operations/prisma-personal-memory-operation-repository.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/prisma-personal-memory-operation-repository.ts
@@ -1,0 +1,222 @@
+import { AuthorizationBoundaryKind, MemoryDatasetState, MemoryFactState, type PersonalMemoryOperation as PrismaOperationRow, type Prisma } from "@prisma/client";
+
+import { __CreatePersonalMemoryOperationLifecycle, __PlanPersonalMemoryOperationLifecycle } from "./personal-memory-operation-lifecycle";
+import { ___AdmitPersonalMemoryOperationCommandSchema } from "./personal-memory-operation-persistence.validator";
+import { PersonalMemoryOperationAdmissionOutcomes, PersonalMemoryOperationInvalidState, PersonalMemoryOperationPersistenceOutcomes, PersonalMemoryOperationReplayConflict, type AdmitPersonalMemoryOperationCommand, type PersonalMemoryOperationAdmissionResult, type PersonalMemoryOperationMessageSource, type PersonalMemoryOperationPersistenceResult, type PersonalMemoryOperationRecord, type PersonalMemoryOperationRepository } from "./personal-memory-operation-persistence.types";
+import { _PersonalMemoryOperationCreateData, _PersonalMemoryOperationLifecycle, _PersonalMemoryOperationLifecycleUpdate, _PersonalMemoryOperationRecord } from "./prisma-personal-memory-operation-mapper";
+import { PersonalMemoryOperationEvents, PersonalMemoryOperationKinds, PersonalMemoryOperationTransitionOutcomes, type PersonalMemoryOperationEvent } from "./personal-memory-operation.types";
+
+/** Uses one caller-owned Prisma transaction for replay, locking, validation, and revision CAS. */
+export class PrismaPersonalMemoryOperationRepository implements PersonalMemoryOperationRepository
+{
+	/** Transaction supplied by the operation unit of work. */
+	private readonly transaction: Prisma.TransactionClient;
+
+	/** Binds every read and write to the transaction that the unit of work opened. */
+	constructor(transaction: Prisma.TransactionClient)
+	{
+		this.transaction = transaction;
+	}
+
+	/** @inheritdoc */
+	async admit(commandInput: AdmitPersonalMemoryOperationCommand): Promise<PersonalMemoryOperationAdmissionResult>
+	{
+		const parsed = ___AdmitPersonalMemoryOperationCommandSchema.safeParse(commandInput);
+		if (!parsed.success)
+			throw new PersonalMemoryOperationInvalidState("personal-memory operation admission evidence is invalid");
+		const command = parsed.data;
+		const lifecycle = __CreatePersonalMemoryOperationLifecycle({ operationId: command.operationId, kind: command.kind, expectedContentDigest: command.contentDigest, targetFactId: command.targetFactId, targetDocumentId: command.targetDocumentId, providerDatasetId: command.providerDatasetId });
+		if (lifecycle === null)
+			throw new PersonalMemoryOperationInvalidState("personal-memory operation lifecycle could not be created");
+
+		// Lock the dataset before any referenced fact or operation row so all writers wait in one order.
+		const dataset = await this._lockDataset(command.datasetId, command.siloId);
+		const existing = await this.transaction.personalMemoryOperation.findUnique({ where: { siloId_idempotencyKeyDigest: { siloId: command.siloId, idempotencyKeyDigest: command.idempotencyKeyDigest } } });
+		const lockedTargetFactId = existing?.targetFactId ?? command.targetFactId;
+		const lockedTargetDocumentId = existing?.targetDocumentId ?? command.targetDocumentId;
+		const facts = await this._lockFacts(command.datasetId, lockedTargetFactId === null ? [] : [lockedTargetFactId], lockedTargetDocumentId);
+		if (existing !== null)
+		{
+			const locked = await this._lockOperation(existing);
+			if (!this._isExactReplay(locked, command))
+				throw new PersonalMemoryOperationReplayConflict();
+			return { outcome: PersonalMemoryOperationAdmissionOutcomes.Replayed, operation: locked };
+		}
+		this._assertAdmissionDataset(dataset, command);
+		if (facts.some(fact => fact.revision !== command.expectedFactRevision))
+			throw new PersonalMemoryOperationInvalidState("personal-memory target fact revision changed before admission");
+		if (command.kind === PersonalMemoryOperationKinds.Forget)
+			await this._hideForgottenTarget(facts, command);
+
+		const created = await this.transaction.personalMemoryOperation.create({ data: _PersonalMemoryOperationCreateData(command, lifecycle) });
+		return { outcome: PersonalMemoryOperationAdmissionOutcomes.Created, operation: _PersonalMemoryOperationRecord(created) };
+	}
+
+	/** @inheritdoc */
+	async apply(event: PersonalMemoryOperationEvent, recordedAt: Date): Promise<PersonalMemoryOperationPersistenceResult>
+	{
+		if (Number.isNaN(recordedAt.getTime()))
+			throw new PersonalMemoryOperationInvalidState("personal-memory operation event time is invalid");
+		const initialRow = await this.transaction.personalMemoryOperation.findUnique({ where: { id: event.operationId } });
+		if (initialRow === null)
+			throw new PersonalMemoryOperationInvalidState("personal-memory operation does not exist");
+		const initial = _PersonalMemoryOperationRecord(initialRow);
+
+		// Read coordinates first, then take the dataset, sorted fact, and operation locks in that order.
+		const dataset = await this._lockDataset(initial.datasetId, initial.siloId);
+		await this._lockFacts(initial.datasetId, initial.targetFactId === null ? [] : [initial.targetFactId], initial.targetDocumentId);
+		const operation = await this._lockOperation(initialRow);
+		if (operation.revision !== initial.revision)
+			return { outcome: PersonalMemoryOperationPersistenceOutcomes.ConcurrentWinner, operation };
+		if (event.event === PersonalMemoryOperationEvents.CatalogCommitted || event.event === PersonalMemoryOperationEvents.CatalogFinalized)
+			throw new PersonalMemoryOperationInvalidState("personal-memory catalog event requires exact fact mutation evidence in this transaction");
+
+		const planned = __PlanPersonalMemoryOperationLifecycle(_PersonalMemoryOperationLifecycle(operation), event);
+		if (planned.outcome === PersonalMemoryOperationTransitionOutcomes.Denied)
+			return { outcome: PersonalMemoryOperationPersistenceOutcomes.Denied, operation, reason: planned.reason };
+		if (planned.outcome === PersonalMemoryOperationTransitionOutcomes.Retry)
+			return { outcome: PersonalMemoryOperationPersistenceOutcomes.Retry, operation };
+		if (planned.operation === undefined)
+			throw new PersonalMemoryOperationInvalidState("personal-memory lifecycle accepted an event without next state");
+		const adoptedDataset = await this._adoptDatasetForEvent(dataset, operation, event);
+
+		const update = await this.transaction.personalMemoryOperation.updateMany({
+			where: { id: operation.operationId, revision: operation.revision },
+			data: _PersonalMemoryOperationLifecycleUpdate(planned.operation, recordedAt),
+		});
+		const saved = await this.transaction.personalMemoryOperation.findUnique({ where: { id: operation.operationId } });
+		if (saved === null)
+			throw new PersonalMemoryOperationInvalidState("personal-memory operation disappeared during lifecycle update");
+		const durable = _PersonalMemoryOperationRecord(saved);
+		if (update.count === 0)
+		{
+			if (adoptedDataset)
+				throw new PersonalMemoryOperationInvalidState("dataset adoption lost the matching operation revision");
+			return { outcome: PersonalMemoryOperationPersistenceOutcomes.ConcurrentWinner, operation: durable };
+		}
+		return { outcome: PersonalMemoryOperationPersistenceOutcomes.Advanced, operation: durable };
+	}
+
+	/** Locks and verifies the local dataset through an ORM update that does not change its state. */
+	private async _lockDataset(datasetId: string, siloId: string): Promise<{ readonly id: string; readonly siloId: string; readonly boundaryKind: AuthorizationBoundaryKind; readonly boundaryPrincipalId: string | null; readonly cogneeDatasetId: string | null; readonly state: MemoryDatasetState }>
+	{
+		const dataset = await this.transaction.memoryDataset.findFirst({ where: { id: datasetId, siloId }, select: { id: true, siloId: true, boundaryKind: true, boundaryPrincipalId: true, cogneeDatasetId: true, state: true } });
+		if (dataset === null)
+			throw new PersonalMemoryOperationInvalidState("personal-memory dataset does not exist in the operation silo");
+		const locked = await this.transaction.memoryDataset.updateMany({ where: { id: dataset.id, siloId, state: dataset.state }, data: { state: dataset.state } });
+		if (locked.count !== 1)
+			throw new PersonalMemoryOperationInvalidState("personal-memory dataset changed before it could be locked");
+		return dataset;
+	}
+
+	/** Verifies whether a new or existing dataset matches the admitted command and personal owner. */
+	private _assertAdmissionDataset(dataset: { readonly boundaryKind: AuthorizationBoundaryKind; readonly boundaryPrincipalId: string | null; readonly cogneeDatasetId: string | null; readonly state: MemoryDatasetState }, command: AdmitPersonalMemoryOperationCommand): void
+	{
+		if (dataset.boundaryKind !== AuthorizationBoundaryKind.Personal || dataset.boundaryPrincipalId !== command.actorPrincipalId)
+			throw new PersonalMemoryOperationInvalidState("personal-memory dataset does not belong to the authenticated actor");
+		if (command.kind === PersonalMemoryOperationKinds.Remember && command.providerDatasetId === null)
+		{
+			if (dataset.state !== MemoryDatasetState.Provisioning || dataset.cogneeDatasetId !== null)
+				throw new PersonalMemoryOperationInvalidState("new personal-memory dataset is not waiting for provider adoption");
+			return;
+		}
+		if (dataset.state !== MemoryDatasetState.Active || dataset.cogneeDatasetId !== command.providerDatasetId)
+			throw new PersonalMemoryOperationInvalidState("personal-memory command does not match an active adopted dataset");
+	}
+
+	/** Adopts the provider UUID before the matching operation transition, within the same transaction. */
+	private async _adoptDatasetForEvent(dataset: { readonly id: string; readonly siloId: string; readonly boundaryKind: AuthorizationBoundaryKind; readonly boundaryPrincipalId: string | null; readonly cogneeDatasetId: string | null; readonly state: MemoryDatasetState }, operation: PersonalMemoryOperationRecord, event: PersonalMemoryOperationEvent): Promise<boolean>
+	{
+		if (event.event !== PersonalMemoryOperationEvents.DatasetEnsured)
+			return false;
+		if (dataset.boundaryKind !== AuthorizationBoundaryKind.Personal || dataset.boundaryPrincipalId !== operation.actorPrincipalId)
+			throw new PersonalMemoryOperationInvalidState("personal-memory dataset adoption lost its personal owner");
+		if (dataset.state === MemoryDatasetState.Active)
+		{
+			if (dataset.cogneeDatasetId !== event.providerDatasetId)
+				throw new PersonalMemoryOperationInvalidState("active personal-memory dataset has another provider UUID");
+			return false;
+		}
+		if (dataset.state !== MemoryDatasetState.Provisioning || dataset.cogneeDatasetId !== null)
+			throw new PersonalMemoryOperationInvalidState("personal-memory dataset cannot adopt a provider UUID in its current state");
+		const adopted = await this.transaction.memoryDataset.updateMany({
+			where: { id: dataset.id, siloId: dataset.siloId, boundaryKind: AuthorizationBoundaryKind.Personal, boundaryPrincipalId: operation.actorPrincipalId, state: MemoryDatasetState.Provisioning, cogneeDatasetId: null },
+			data: { state: MemoryDatasetState.Active, cogneeDatasetId: event.providerDatasetId },
+		});
+		if (adopted.count !== 1)
+			throw new PersonalMemoryOperationInvalidState("personal-memory dataset provider adoption lost its state fence");
+		return true;
+	}
+
+	/** Locks referenced facts by sorted ID and verifies the target provider document coordinate. */
+	private async _lockFacts(datasetId: string, factIds: readonly string[], targetDocumentId: string | null): Promise<readonly { readonly id: string; readonly revision: number; readonly state: MemoryFactState }[]>
+	{
+		const ordered = [...new Set(factIds)].sort();
+		const lockedFacts: { readonly id: string; readonly revision: number; readonly state: MemoryFactState }[] = [];
+		for (const factId of ordered)
+		{
+			const fact = await this.transaction.memoryFactCatalog.findFirst({ where: { id: factId, datasetId }, select: { id: true, cogneeExternalId: true, revision: true, state: true } });
+			if (fact === null || (targetDocumentId !== null && fact.cogneeExternalId !== targetDocumentId))
+				throw new PersonalMemoryOperationInvalidState("personal-memory target fact does not match the admitted dataset and document");
+			const locked = await this.transaction.memoryFactCatalog.updateMany({ where: { id: fact.id, datasetId, state: fact.state }, data: { state: fact.state } });
+			if (locked.count !== 1)
+				throw new PersonalMemoryOperationInvalidState("personal-memory target fact changed before it could be locked");
+			lockedFacts.push({ id: fact.id, revision: fact.revision, state: fact.state });
+		}
+		return lockedFacts;
+	}
+
+	/** Hides a new Forget target in the same transaction that saves its operation. */
+	private async _hideForgottenTarget(facts: readonly { readonly id: string; readonly revision: number; readonly state: MemoryFactState }[], command: AdmitPersonalMemoryOperationCommand): Promise<void>
+	{
+		const target = facts[0];
+		if (target === undefined || (target.state !== MemoryFactState.Active && target.state !== MemoryFactState.Corrected) || target.revision !== command.expectedFactRevision)
+			throw new PersonalMemoryOperationInvalidState("personal-memory Forget target is not Active or Corrected at the expected revision");
+		const hidden = await this.transaction.memoryFactCatalog.updateMany({
+			where: { id: target.id, datasetId: command.datasetId, state: target.state, revision: command.expectedFactRevision! },
+			data: { state: MemoryFactState.ForgetPending, forgetRequestedAt: command.admittedAt },
+		});
+		if (hidden.count !== 1)
+			throw new PersonalMemoryOperationInvalidState("personal-memory Forget target lost its admission fence");
+	}
+
+	/** Locks the operation after its dataset and facts, then returns the reread validated state. */
+	private async _lockOperation(row: PrismaOperationRow): Promise<PersonalMemoryOperationRecord>
+	{
+		await this.transaction.personalMemoryOperation.updateMany({ where: { id: row.id, revision: row.revision }, data: { phase: row.phase } });
+		const locked = await this.transaction.personalMemoryOperation.findUnique({ where: { id: row.id } });
+		if (locked === null)
+			throw new PersonalMemoryOperationInvalidState("personal-memory operation disappeared while acquiring its lock");
+		return _PersonalMemoryOperationRecord(locked);
+	}
+
+	/** Compares immutable user-command evidence without requiring retry-generated identities to match. */
+	private _isExactReplay(operation: PersonalMemoryOperationRecord, command: AdmitPersonalMemoryOperationCommand): boolean
+	{
+		return operation.siloId === command.siloId
+			&& operation.datasetId === command.datasetId
+			&& operation.actorPrincipalId === command.actorPrincipalId
+			&& operation.idempotencyKeyDigest === command.idempotencyKeyDigest
+			&& operation.commandDigest === command.commandDigest
+			&& operation.kind === command.kind
+			&& operation.expectedContentDigest === command.contentDigest
+			&& operation.targetFactId === command.targetFactId
+			&& operation.targetDocumentId === command.targetDocumentId
+			&& operation.expectedFactRevision === command.expectedFactRevision
+			&& operation.admittedProviderDatasetId === command.providerDatasetId
+			&& this._sameSource(operation.source, command.source);
+	}
+
+	/** Compares exact source coordinates while treating two absent sources as equal. */
+	private _sameSource(left: PersonalMemoryOperationMessageSource | null, right: PersonalMemoryOperationMessageSource | null): boolean
+	{
+		if (left === null || right === null)
+			return left === right;
+		return left.conversationId === right.conversationId
+			&& left.messageId === right.messageId
+			&& left.messagePosition === right.messagePosition
+			&& left.payloadRef === right.payloadRef
+			&& left.ciphertextDigest === right.ciphertextDigest
+			&& left.authorPrincipalId === right.authorPrincipalId;
+	}
+}

--- a/libs/backend/agents/personal/memory/main/src/operations/prisma-personal-memory-operation-unit-of-work.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/prisma-personal-memory-operation-unit-of-work.ts
@@ -1,0 +1,47 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { ___RunInPrismaUnitOfWork } from "@opencrane/backend/server/infra/prisma-unit-of-work";
+
+import { PrismaPersonalMemoryOperationRepository } from "./prisma-personal-memory-operation-repository";
+import type { AdmitPersonalMemoryOperationCommand, PersonalMemoryOperationAdmissionResult, PersonalMemoryOperationPersistenceResult, PersonalMemoryOperationUnitOfWork } from "./personal-memory-operation-persistence.types";
+import type { PersonalMemoryOperationEvent } from "./personal-memory-operation.types";
+
+/**
+ * Opens personal-memory operation transactions and creates the repository inside each attempt.
+ *
+ * Proven full rollbacks may retry the complete idempotent database operation. No provider or
+ * workflow call belongs inside this persistence-only envelope. The reserved task identity saved in
+ * the operation is therefore evidence for later composition, rather than proof that Absurd admitted
+ * a task atomically with this row.
+ */
+export class PrismaPersonalMemoryOperationUnitOfWork implements PersonalMemoryOperationUnitOfWork
+{
+	/** Root Prisma client used only to open a fresh transaction attempt. */
+	private readonly prisma: PrismaClient;
+
+	/** Creates the operation transaction boundary. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	/** @inheritdoc */
+	async admit(command: AdmitPersonalMemoryOperationCommand): Promise<PersonalMemoryOperationAdmissionResult>
+	{
+		return ___RunInPrismaUnitOfWork(this.prisma, async function _Admit(transaction)
+		{
+			const repository = new PrismaPersonalMemoryOperationRepository(transaction);
+			return repository.admit(command);
+		}, { isolationLevel: "Serializable", attemptLimit: 3, operation: "personal-memory operation admission" });
+	}
+
+	/** @inheritdoc */
+	async apply(event: PersonalMemoryOperationEvent, recordedAt: Date): Promise<PersonalMemoryOperationPersistenceResult>
+	{
+		return ___RunInPrismaUnitOfWork(this.prisma, async function _Apply(transaction)
+		{
+			const repository = new PrismaPersonalMemoryOperationRepository(transaction);
+			return repository.apply(event, recordedAt);
+		}, { isolationLevel: "Serializable", attemptLimit: 3, operation: "personal-memory operation lifecycle" });
+	}
+}

--- a/libs/backend/agents/personal/memory/main/src/prisma-personal-memory-admission-repository.ts
+++ b/libs/backend/agents/personal/memory/main/src/prisma-personal-memory-admission-repository.ts
@@ -42,7 +42,9 @@ export class PrismaPersonalMemoryAdmissionRepository implements PersonalMemoryAd
 			},
 			select: { id: true, cogneeDatasetId: true },
 		});
-		return dataset === null ? null : { datasetId: dataset.id, cogneeDatasetId: dataset.cogneeDatasetId };
+		if (dataset === null || dataset.cogneeDatasetId === null)
+			return null;
+		return { datasetId: dataset.id, cogneeDatasetId: dataset.cogneeDatasetId };
 	}
 
 	/**

--- a/libs/backend/agents/personal/memory/main/vitest.config.ts
+++ b/libs/backend/agents/personal/memory/main/vitest.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 import { _PackageCacheDir } from "../../../../../../vitest.cache";
 
 /** Vitest configuration for the personal memory package. */
-export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../../../tsconfig.vitest.json"] })] });
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../../../tsconfig.vitest.json"] })], test: { exclude: [...configDefaults.exclude, "**/*.sql.test.ts"] } });

--- a/libs/backend/agents/personal/memory/main/vitest.sql.config.ts
+++ b/libs/backend/agents/personal/memory/main/vitest.sql.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../../../vitest.cache";
+
+/** Runs the real transaction proofs only through the explicit database test target. */
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../../../tsconfig.vitest.json"] })], test: { include: ["src/**/__tests__/*.sql.test.ts"] } });

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,34 @@
 # OpenCrane — Active Plan
 
+## Durable personal memory operations — persistence and integration proof
+
+The operation repository now saves Remember, Correct and Forget command coordinates, encrypted
+source references, reserved workflow identity and monotonic provider receipts. Exact replay returns
+the original operation after dataset adoption or a fact revision change. Concurrent writers use
+the existing transaction helper and dataset → fact → operation lock order.
+
+A new personal dataset can remain Provisioning without a provider UUID. Adoption and the saved
+operation step commit together; recall selects only Active datasets with adopted UUIDs. Forget
+hides the fact in its admission transaction. PostgreSQL owns fact revision increments, and catalog
+completion requires matching durable fact evidence. Names derive from the immutable catalog ID
+through the shared gateway format; no second name column or remembered plaintext is stored.
+
+Local proof passes 38 package tests, seven real PostgreSQL repository cases, all 12 workspace SQL
+targets, package lint/type checks and the server build. The new SQL authority suite has 23
+assertions. Repository cases cover concurrent admission/adoption, exact replay after a new client,
+recovery evidence, Forget visibility for Active and Corrected facts, and rollback. Both the
+disposable database and test process use UTC, matching CI: local timezone offsets otherwise change
+the existing timestamp-without-time-zone authority fixtures. No fixture or authority check was
+weakened. Style, Prisma and ownership boundaries, module growth, release binding and fresh-baseline
+regeneration pass. Architecture preflight/post-review and independent review of the complete source
+overlay pass with no unresolved findings. Exact-head CI and live qualification remain separate.
+
+This is persistence infrastructure. The complete authenticated command transaction must still
+compose current authority, dataset/catalog mutations and typed Absurd task admission. Reserved task
+identifiers do not prove that a task was admitted. Catalog completion is deliberately unavailable
+through the standalone operation UoW until its exact mutation owner is composed. Gateway/client
+integration, product routes, permitted recall and live qualification remain unfinished.
+
 ## Recover interrupted memory indexing — source implementation
 
 This slice starts directly above #874 at `b7acc1f94e24a41d0c151da252592c36dc613582`.
@@ -29,8 +58,10 @@ failed. The candidate stopped on its first Add before any indexing-recovery requ
 tokenizer discovery exhausted the connection-test deadline before reaching the synthetic provider.
 The reviewed harness repair disables that external discovery while retaining the actual synthetic
 model and embedding connection tests. All eight focused harness tests and Cognee lint pass.
-Exact-image indexing recovery remains unqualified until the repaired commit passes CI; source
-checks do not promote the candidate image or establish testv5 readiness.
+The repaired candidate passed exact-image qualification at `320a16caff0fa6511825c396c91c4ce4371fb517`
+(run `34724401692`, job `103635957933`), including retained recovery evidence. The separate
+production-provider job still failed, so the overall workflow is not green. Candidate proof does
+not promote the image or establish testv5 readiness.
 
 ## Recover interrupted memory dataset permissions — implementation and validation
 
@@ -877,7 +908,7 @@ their own completion track; they are not silently bundled into the first tool PR
 | T1 — first permitted tool retrieval | IN PROGRESS — the server's one-tool continuation is implemented and now progresses through Absurd in #849. Company tool assignment is the first active follow-up. Connection activation, a real integration and participant result evidence remain required. |
 | T2 | IN PROGRESS: personal approval and durable resume pass local integration; company approval and real external-action qualification remain. |
 | U1 | IN PROGRESS: requester-only personal Stop passes source review and exact-head CI in #862; live qualification and wider participant controls remain separate. |
-| M1 | IN PROGRESS: the repaired candidate in #872 passes exact-image deletion, isolation and restart qualification. Dataset permission recovery, gateway integration and the product memory journeys remain. |
+| M1 | IN PROGRESS: the candidate in #875 passes exact-image deletion, isolation, permission recovery and interrupted-indexing qualification. Durable Remember/Correct/Forget persistence passes local database proof. Authenticated commands, Absurd admission, gateway/client integration and product memory journeys remain. The separate production-provider qualification still fails. |
 | U2 | PAUSED: partial runtime-question source awaits its separate explicit approval. |
 | F1 | IN PROGRESS: Ready-file Open/Preview/Download and PDF-informed answers pass exact-head CI in #868 and #869. Generated outputs and live qualification remain. |
 | D1, S1, A2, T3 | PLANNED in the exact priority order above, with separate acceptance for each journey. |

--- a/releases/0.11.0.json
+++ b/releases/0.11.0.json
@@ -4,7 +4,7 @@
   "database": {
     "schemaVersion": "0.11.0",
     "baselinePath": "apps/opencrane/prisma/bootstrap/target-baseline.sql",
-    "baselineSha256": "3959858581e22da919d98dfd4c4cfc6eb27687a342b8bfc47036f766278f9d19",
+    "baselineSha256": "1e8b1c4828d1e06d0e3caf338773e5a9393497677441df89aff0bd66a7a9dd79",
     "operandImage": "ghcr.io/elewa-git/opencrane-postgres:17.5-sha-be461113253b9cd6d51532cf007775ec8385bfe7@sha256:9c27816e67b9f0b23e771a4c8a8a4c8eb4c84abeefead14f727747d21d7d70c7"
   },
   "projects": {


### PR DESCRIPTION
Memory commands need to retain one saved operation when a response is lost, a process restarts, or two deliveries arrive together. This change adds the persistence boundary for Remember, Correct and Forget: retries return the original command and task identity, dataset adoption commits with the saved step, and admitting Forget immediately hides an Active or Corrected fact.

The existing personal-memory package owns the lifecycle, transaction-bound repository and unit of work. PostgreSQL enforces immutable command coordinates, append-only provider receipts, valid phase transitions and fact revisions. Only metadata and encrypted source references are stored here. Recall rejects a dataset without an adopted provider UUID. The schema change regenerates the sole fresh-install baseline and updates its release-manifest digest.

This is a persistence slice. Authenticated command admission must still compose current authority, dataset/catalog mutation and typed Absurd task admission in one transaction. A reserved task identifier does not mean Absurd admitted work. The standalone repository deliberately rejects catalog completion until the catalog mutation owner is composed. Gateway/client integration, product routes and the complete Remember → recall → Correct → Forget journey remain unfinished.

Direct parent: #875 (`feat/0.12-memory-indexing-recovery`), exact base `320a16caff0fa6511825c396c91c4ce4371fb517`.

## Review order

#831 → #843 → #849 → #850 → #851 → #852 → #853 → #854 → #855 → #856 → #857 → #858 → #862 → #863 → #867 → #868 → #869 → #870 → #871 → #872 → #873 → #874 → #875 → #876. No predecessors are absorbed or closed.

## Validation completed

- Nx personal-memory tests: 38 unit cases across seven files; lint and TypeScript checks pass.
- Seven real PostgreSQL repository cases cover concurrent admission/adoption, replay after a new client, recovery evidence, transaction rollback, and Forget of both Active and Corrected facts.
- All 12 workspace `test:sql` targets pass on the fresh disposable baseline, including 23 new raw SQL authority assertions. Database and test-process timezones were both UTC, matching CI; earlier local timezone failures were diagnosed without weakening fixtures or authority checks.
- Server Nx build, Prisma generation, baseline regeneration/check, authority-baseline verifier and release-manifest binding pass.
- Style and Prisma boundaries report zero errors/warnings; workload ownership/app composition and agent-domain checks and their negative tests pass.
- Module growth reports zero errors; independent review covers all six responsibility-inventory candidates.
- Architecture preflight/post-review and independent review of the complete 31-file source overlay pass with no unresolved findings.

Exact-head CI is pending for this PR. Parent #875's disposable candidate-image qualification passed, while its separate production-provider job failed; that evidence does not qualify this child or the deployed provider. Testv5/live qualification remains a separate gate. This PR performs no deployment, provider calls, credential inspection or test-data deletion.
