### PR TITLE
Complete personal memory catalog updates atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,12 @@ The 0.11 baseline remains under review; this is not a release or a completed MVP
   Integrators can now bind new operation storage to the actual Absurd task admitted in the same
   transaction. Exact replay returns the saved receipt without admitting another task. Source
   preparation reads one caller-authored message and rechecks its encrypted coordinates under
-  current conversation access. Authenticated product command composition, worker/provider wiring
-  and the complete memory journey remain unfinished.
+  current conversation access. Catalog completion now publishes the new fact, replaces a prior
+  fact for Correct, or finalizes Forget together with the operation's progress. A failed transaction
+  preserves both prior states; retries cannot publish another correction successor. The catalog
+  keeps consent, personal sensitivity and message provenance without remembered text.
+  Authenticated product command composition, worker/provider wiring and the complete memory
+  journey remain unfinished.
 
 - **Conversation participants can open ready uploaded files from the Files panel.** Supported
   previews and downloads use the current authorized content read, show loading and safe retry

--- a/docs/design/personal-memory-operations.md
+++ b/docs/design/personal-memory-operations.md
@@ -36,6 +36,12 @@ It does not accept an arbitrary text field or another participant's message. Cor
 new authorized source message and an expected revision of the old fact. Forget identifies the exact
 fact and expected revision. These authenticated commands are explicit consent for their operation.
 
+Facts created by this direct message flow record Explicit consent and the server-selected
+`personal` sensitivity. The command cannot choose or change that classification. It describes the
+fact's personal context and grants no access; dataset, consent and lifecycle checks remain required.
+Supporting more classifications later requires admitting and retaining the selected value before
+provider dispatch so a restart cannot change it at catalog completion.
+
 The source reader binds silo, conversation, message ID, message position, author, private payload
 reference and ciphertext digest. It must still work after later messages are appended. A whole
 conversation-head equality check would incorrectly invalidate a saved Remember command.
@@ -59,6 +65,14 @@ referenced facts sorted by ID, then operation.
 Command kind and lifecycle have separate responsibilities: kind selects Remember, Correct or Forget
 behavior; the lifecycle decides whether the saved evidence permits the next step. Repositories and
 controllers must not maintain their own competing transition tables.
+
+Remember and Correct use the operation UUID as the new fact ID. Their content-free Message
+provenance comes from the saved operation and selected message; it does not classify the fact as
+an ExplicitUserFact for automatic preference selection. Catalog publication and the accepted
+operation transition share one transaction. Correct inserts the successor and lets PostgreSQL mark
+the prior fact Corrected and increment its revision. Forget finalization updates the saved target
+from ForgetPending at admitted revision R+1 to Forgotten at R+2. If the operation write loses after
+any catalog mutation, the whole transaction must roll back.
 
 | Saved phase | Evidence needed to advance | Result |
 | --- | --- | --- |

--- a/libs/backend/agents/personal/memory/main/README.md
+++ b/libs/backend/agents/personal/memory/main/README.md
@@ -75,7 +75,10 @@ in sorted ID order, and then the operation. Exact command replays return the fir
 task without calling task admission. For a new command, the repository calls the transaction-bound
 task admission once after those locks, validates the returned UUID/name/key, and inserts that exact
 receipt. Conflicting command or task evidence fails. Accepted events use the shared lifecycle planner
-and a revision compare-and-set, and a lost compare-and-set returns the validated row that won.
+and a revision compare-and-set. Accepted catalog events first write the exact catalog evidence in
+the same transaction: Remember and Correct create one deterministic Active fact, while Forget
+finalizes only its revision-fenced hidden target. A lost compare-and-set after either catalog write
+throws so the caller rolls back the catalog mutation with the operation advance.
 
 ## Boundary
 
@@ -103,9 +106,12 @@ The command supplies only the expected workflow task name and idempotency key. A
 inserted only after a callback bound to the same transaction returns the actual task receipt. The
 repository does not itself prove current product authority; the composite conversation owner must
 compose dataset creation, authorization audit, this transaction-scoped repository, and workflow
-admission. Bare catalog completion events fail closed until that transaction also proves the exact
-catalog mutation. Forget admission hides its exact Active or Corrected target as `ForgetPending` in
-the same database transaction; the database owns the fact revision increment.
+admission. Only lifecycle-accepted catalog completion events write the exact catalog mutation in
+that transaction. Catalog completion persists content-free Message provenance from the immutable
+source coordinates, Explicit consent, server-selected `personal` sensitivity, and the operation UUID
+as the fact ID. Correct relies on PostgreSQL to mark its exact predecessor Corrected. Forget admission
+hides its exact Active or Corrected target as `ForgetPending`, and finalization advances that same
+target to Forgotten. The database owns every fact revision increment.
 
 ## Dependency direction
 
@@ -117,9 +123,11 @@ Tagged `scope:personal-memory`, this backend package may depend only on its own 
 Owns `MemoryDataset`, `MemoryFactCatalog`, and `PersonalMemoryOperation` in `memory.prisma`.
 `MemoryDataset` distinguishes explicit `Provisioning` from `Active` and `Retired`, and its provider
 UUID is nullable only until the exact DatasetEnsured event adopts it. `MemoryFactCatalog.revision`
-fences target commands. The operation stores immutable replay, source, target, and actual workflow
-receipt evidence plus write-once provider receipts and current lifecycle recovery fields. No memory outbox,
-queue, scheduler, route, provider call, or plaintext store is introduced.
+fences target commands. Remember and Correct catalog rows retain only their provider coordinate,
+content digest, fixed consent and sensitivity, and content-free Message provenance; no remembered
+text is copied into PostgreSQL. The operation stores immutable replay, source, target, and actual
+workflow receipt evidence plus write-once provider receipts and current lifecycle recovery fields.
+No memory outbox, queue, scheduler, route, provider call, or plaintext store is introduced.
 
 ## See also
 

--- a/libs/backend/agents/personal/memory/main/src/operations/__tests__/personal-memory-operation.sql.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/__tests__/personal-memory-operation.sql.test.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from "node:crypto";
 
-import { AuthorizationBoundaryKind, MemoryConsentState, MemoryDatasetState, MemoryFactState, PrincipalProvenance, Prisma, PrismaClient } from "@prisma/client";
+import { AuthorizationBoundaryKind, MemoryConsentState, MemoryDatasetState, MemoryFactState, PersonalMemoryOperationPhase as PrismaOperationPhase, PrincipalProvenance, Prisma, PrismaClient } from "@prisma/client";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { MemoryMutationDeliveryStates } from "@opencrane/contracts";
+import { MemoryFactProvenanceSourceKinds, MemoryMutationDeliveryStates } from "@opencrane/contracts";
 import { ___RunInPrismaUnitOfWork } from "@opencrane/backend/server/infra/prisma-unit-of-work";
 
 import { PersonalMemoryOperationAdmissionOutcomes, PersonalMemoryOperationInvalidState, PersonalMemoryOperationPersistenceOutcomes, type AdmitPersonalMemoryOperationCommand, type PersonalMemoryOperationTaskAdmission } from "../personal-memory-operation-persistence.types";
@@ -185,4 +185,159 @@ describe("personal-memory operations on fresh PostgreSQL", function _Suite()
 		expect(await _First.memoryFactCatalog.findUnique({ where: { id: factId } })).toMatchObject({ revision: expectedFactRevision + 1, state: MemoryFactState.ForgetPending });
 		expect(results.every(result => result.operation.expectedFactRevision === expectedFactRevision)).toBe(true);
 	});
+
+	it("publishes one Remember fact and replays the completed operation after restart", async function _RememberCatalogCompletion()
+	{
+		const pending = await _RememberAtCatalogPending();
+		const recordedAt = _CatalogRecordedAt(pending.command);
+		const owner = _Owner(_First);
+		await expect(owner.apply({ operationId: pending.command.operationId, kind: pending.command.kind, expectedRevision: 5, event: PersonalMemoryOperationEvents.CatalogCommitted }, recordedAt)).resolves.toMatchObject({ outcome: PersonalMemoryOperationPersistenceOutcomes.Advanced, operation: { phase: PersonalMemoryOperationPhases.Completed, revision: 6 } });
+
+		const restartedClient = new PrismaClient();
+		try
+		{
+			const operation = await restartedClient.personalMemoryOperation.findUniqueOrThrow({ where: { id: pending.command.operationId } });
+			const facts = await restartedClient.memoryFactCatalog.findMany({ where: { datasetId: pending.command.datasetId } });
+			expect(operation).toMatchObject({ phase: PrismaOperationPhase.Completed, revision: 6, completedAt: recordedAt });
+			expect(facts).toHaveLength(1);
+			expect(facts[0]).toMatchObject({ id: pending.command.operationId, datasetId: pending.command.datasetId, cogneeExternalId: pending.documentId, contentDigest: pending.command.contentDigest, state: MemoryFactState.Active, revision: 1, consentState: MemoryConsentState.Explicit, sensitivity: "personal", sourceArtifactRevisionId: null, sourceMessageId: pending.command.source?.messageId, supersedesFactId: null, recordedBy: pending.command.actorPrincipalId, recordedAt: recordedAt });
+			expect(facts[0]?.provenance).toEqual({ sourceKind: MemoryFactProvenanceSourceKinds.Message, operationId: pending.command.operationId, conversationId: pending.command.source?.conversationId, messagePosition: pending.command.source?.messagePosition.toString(), authorPrincipalId: pending.command.source?.authorPrincipalId });
+			await expect(_Owner(restartedClient).admit(pending.command)).resolves.toMatchObject({ outcome: PersonalMemoryOperationAdmissionOutcomes.Replayed, operation: { phase: PersonalMemoryOperationPhases.Completed, revision: 6 } });
+		}
+		finally { await restartedClient.$disconnect(); }
+	});
+
+	it("publishes one Correct successor, fences its predecessor, and ignores duplicate completion", async function _CorrectCatalogCompletion()
+	{
+		const pending = await _CorrectAtCatalogPending();
+		const recordedAt = _CatalogRecordedAt(pending.command);
+		const event = { operationId: pending.command.operationId, kind: pending.command.kind, expectedRevision: 4, event: PersonalMemoryOperationEvents.CatalogCommitted } as const;
+		const results = await Promise.allSettled([_Owner(_First).apply(event, recordedAt), _Owner(_Second).apply(event, recordedAt)]);
+		expect(results.every(result => result.status === "fulfilled")).toBe(true);
+		expect(results.filter(result => result.status === "fulfilled" && result.value.outcome === PersonalMemoryOperationPersistenceOutcomes.Advanced)).toHaveLength(1);
+		const facts = await _First.memoryFactCatalog.findMany({ where: { datasetId: pending.command.datasetId } });
+		const predecessor = facts.find(fact => fact.id === pending.targetFactId);
+		const successors = facts.filter(fact => fact.supersedesFactId === pending.targetFactId);
+		expect(predecessor).toMatchObject({ state: MemoryFactState.Corrected, revision: 2 });
+		expect(successors).toHaveLength(1);
+		expect(successors[0]).toMatchObject({ id: pending.command.operationId, state: MemoryFactState.Active, revision: 1, cogneeExternalId: pending.documentId, contentDigest: pending.command.contentDigest, consentState: MemoryConsentState.Explicit, sensitivity: "personal", sourceMessageId: pending.command.source?.messageId, recordedBy: pending.command.actorPrincipalId });
+		expect(await _First.personalMemoryOperation.findUniqueOrThrow({ where: { id: pending.command.operationId } })).toMatchObject({ phase: PrismaOperationPhase.PriorDocumentDeletePending, revision: 5 });
+	});
+
+	it("finishes Forget at the database-owned revision after restart", async function _ForgetCatalogCompletion()
+	{
+		const pending = await _ForgetAtCatalogFinalizePending();
+		const recordedAt = _CatalogRecordedAt(pending.command);
+		await expect(_Owner(_First).apply({ operationId: pending.command.operationId, kind: pending.command.kind, expectedRevision: 2, event: PersonalMemoryOperationEvents.CatalogFinalized }, recordedAt)).resolves.toMatchObject({ outcome: PersonalMemoryOperationPersistenceOutcomes.Advanced, operation: { phase: PersonalMemoryOperationPhases.Completed, revision: 3 } });
+
+		const restartedClient = new PrismaClient();
+		try
+		{
+			const fact = await restartedClient.memoryFactCatalog.findUniqueOrThrow({ where: { id: pending.targetFactId } });
+			const operation = await restartedClient.personalMemoryOperation.findUniqueOrThrow({ where: { id: pending.command.operationId } });
+			expect(fact).toMatchObject({ state: MemoryFactState.Forgotten, revision: 3, forgottenAt: recordedAt });
+			expect(operation).toMatchObject({ phase: PrismaOperationPhase.Completed, revision: 3, completedAt: recordedAt });
+		}
+		finally { await restartedClient.$disconnect(); }
+	});
+
+	it("rolls back Remember catalog publication and operation advancement together", async function _RememberCatalogRollback()
+	{
+		const pending = await _RememberAtCatalogPending();
+		await expect(_First.$transaction(async function _Rollback(transaction)
+		{
+			await new PrismaPersonalMemoryOperationRepository(transaction).apply({ operationId: pending.command.operationId, kind: pending.command.kind, expectedRevision: 5, event: PersonalMemoryOperationEvents.CatalogCommitted }, _CatalogRecordedAt(pending.command));
+			throw new Error("synthetic Remember catalog rollback");
+		}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })).rejects.toThrow("synthetic Remember catalog rollback");
+		expect(await _Second.memoryFactCatalog.count({ where: { datasetId: pending.command.datasetId } })).toBe(0);
+		expect(await _Second.personalMemoryOperation.findUniqueOrThrow({ where: { id: pending.command.operationId } })).toMatchObject({ phase: PrismaOperationPhase.CatalogCommitPending, revision: 5 });
+	});
+
+	it("rolls back Correct successor publication and predecessor transition together", async function _CorrectCatalogRollback()
+	{
+		const pending = await _CorrectAtCatalogPending();
+		await expect(_First.$transaction(async function _Rollback(transaction)
+		{
+			await new PrismaPersonalMemoryOperationRepository(transaction).apply({ operationId: pending.command.operationId, kind: pending.command.kind, expectedRevision: 4, event: PersonalMemoryOperationEvents.CatalogCommitted }, _CatalogRecordedAt(pending.command));
+			throw new Error("synthetic Correct catalog rollback");
+		}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })).rejects.toThrow("synthetic Correct catalog rollback");
+		expect(await _Second.memoryFactCatalog.findUniqueOrThrow({ where: { id: pending.targetFactId } })).toMatchObject({ state: MemoryFactState.Active, revision: 1 });
+		expect(await _Second.memoryFactCatalog.count({ where: { datasetId: pending.command.datasetId } })).toBe(1);
+		expect(await _Second.personalMemoryOperation.findUniqueOrThrow({ where: { id: pending.command.operationId } })).toMatchObject({ phase: PrismaOperationPhase.CatalogCommitPending, revision: 4 });
+	});
+
+	it("rolls back Forget completion while retaining its admission hide", async function _ForgetCatalogRollback()
+	{
+		const pending = await _ForgetAtCatalogFinalizePending();
+		await expect(_First.$transaction(async function _Rollback(transaction)
+		{
+			await new PrismaPersonalMemoryOperationRepository(transaction).apply({ operationId: pending.command.operationId, kind: pending.command.kind, expectedRevision: 2, event: PersonalMemoryOperationEvents.CatalogFinalized }, _CatalogRecordedAt(pending.command));
+			throw new Error("synthetic Forget catalog rollback");
+		}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })).rejects.toThrow("synthetic Forget catalog rollback");
+		expect(await _Second.memoryFactCatalog.findUniqueOrThrow({ where: { id: pending.targetFactId } })).toMatchObject({ state: MemoryFactState.ForgetPending, revision: 2 });
+		expect(await _Second.personalMemoryOperation.findUniqueOrThrow({ where: { id: pending.command.operationId } })).toMatchObject({ phase: PrismaOperationPhase.CatalogFinalizePending, revision: 2 });
+	});
 });
+
+/** Fixed digest for the synthetic indexing evidence used by every catalog fixture. */
+const _InputDigest = `sha256:${"d".repeat(64)}`;
+
+/** Derives a catalog timestamp after the command's live admission timestamp. */
+function _CatalogRecordedAt(command: AdmitPersonalMemoryOperationCommand): Date
+{
+	return new Date(command.admittedAt.getTime() + 1_000);
+}
+
+/** Drives a new Remember operation through provider and indexing receipts to catalog completion. */
+async function _RememberAtCatalogPending()
+{
+	const command = await _Fixture();
+	const owner = _Owner(_First);
+	await owner.admit(command);
+	const recordedAt = _CatalogRecordedAt(command);
+	const providerDatasetId = randomUUID();
+	const documentId = randomUUID();
+	await owner.apply({ operationId: command.operationId, kind: command.kind, expectedRevision: 1, event: PersonalMemoryOperationEvents.DatasetEnsured, providerDatasetId }, recordedAt);
+	await owner.apply({ operationId: command.operationId, kind: command.kind, expectedRevision: 2, event: PersonalMemoryOperationEvents.DocumentAdded, documentId, contentDigest: command.contentDigest! }, recordedAt);
+	await owner.apply({ operationId: command.operationId, kind: command.kind, expectedRevision: 3, event: PersonalMemoryOperationEvents.IndexEvidenceSaved, indexingOperationId: randomUUID(), expectedInputEvidenceDigest: _InputDigest }, recordedAt);
+	const operation = await _First.personalMemoryOperation.findUniqueOrThrow({ where: { id: command.operationId } });
+	await owner.apply({ operationId: command.operationId, kind: command.kind, expectedRevision: 4, event: PersonalMemoryOperationEvents.IndexingCompleted, indexingOperationId: operation.indexingOperationId!, expectedInputEvidenceDigest: operation.expectedInputEvidenceDigest!, pipelineRunId: randomUUID() }, recordedAt);
+	return { command, datasetId: command.datasetId, documentId };
+}
+
+/** Seeds one Active fact and drives a Correct operation to catalog completion. */
+async function _CorrectAtCatalogPending()
+{
+	const command = await _Fixture();
+	const providerDatasetId = randomUUID();
+	await _First.memoryDataset.update({ where: { id: command.datasetId }, data: { state: MemoryDatasetState.Active, cogneeDatasetId: providerDatasetId } });
+	const targetFactId = randomUUID();
+	const targetDocumentId = randomUUID();
+	await _First.memoryFactCatalog.create({ data: { id: targetFactId, datasetId: command.datasetId, cogneeExternalId: targetDocumentId, contentDigest: _ContentDigest, consentState: MemoryConsentState.Explicit, sensitivity: "personal", provenance: { sourceKind: MemoryFactProvenanceSourceKinds.Message }, sourceMessageId: command.source!.messageId, recordedBy: command.actorPrincipalId } });
+	const correct = { ...command, kind: PersonalMemoryOperationKinds.Correct, targetFactId, targetDocumentId, expectedFactRevision: 1, providerDatasetId };
+	const owner = _Owner(_First);
+	await owner.admit(correct);
+	const recordedAt = _CatalogRecordedAt(correct);
+	const documentId = randomUUID();
+	await owner.apply({ operationId: correct.operationId, kind: correct.kind, expectedRevision: 1, event: PersonalMemoryOperationEvents.DocumentAdded, documentId, contentDigest: correct.contentDigest! }, recordedAt);
+	await owner.apply({ operationId: correct.operationId, kind: correct.kind, expectedRevision: 2, event: PersonalMemoryOperationEvents.IndexEvidenceSaved, indexingOperationId: randomUUID(), expectedInputEvidenceDigest: _InputDigest }, recordedAt);
+	const indexed = await _First.personalMemoryOperation.findUniqueOrThrow({ where: { id: correct.operationId } });
+	await owner.apply({ operationId: correct.operationId, kind: correct.kind, expectedRevision: 3, event: PersonalMemoryOperationEvents.IndexingCompleted, indexingOperationId: indexed.indexingOperationId!, expectedInputEvidenceDigest: indexed.expectedInputEvidenceDigest!, pipelineRunId: randomUUID() }, recordedAt);
+	return { command: correct, datasetId: command.datasetId, documentId, targetFactId };
+}
+
+/** Seeds an Active target, admits Forget, and advances through exact provider absence. */
+async function _ForgetAtCatalogFinalizePending()
+{
+	const command = await _Fixture();
+	const providerDatasetId = randomUUID();
+	await _First.memoryDataset.update({ where: { id: command.datasetId }, data: { state: MemoryDatasetState.Active, cogneeDatasetId: providerDatasetId } });
+	const targetFactId = randomUUID();
+	const targetDocumentId = randomUUID();
+	await _First.memoryFactCatalog.create({ data: { id: targetFactId, datasetId: command.datasetId, cogneeExternalId: targetDocumentId, contentDigest: _ContentDigest, consentState: MemoryConsentState.Explicit, sensitivity: "personal", provenance: { sourceKind: MemoryFactProvenanceSourceKinds.Message }, sourceMessageId: command.source!.messageId, recordedBy: command.actorPrincipalId } });
+	const forget = { ...command, kind: PersonalMemoryOperationKinds.Forget, source: null, contentDigest: null, targetFactId, targetDocumentId, expectedFactRevision: 1, providerDatasetId };
+	const owner = _Owner(_First);
+	await owner.admit(forget);
+	await owner.apply({ operationId: forget.operationId, kind: forget.kind, expectedRevision: 1, event: PersonalMemoryOperationEvents.DocumentDeleted, documentId: targetDocumentId }, _CatalogRecordedAt(forget));
+	return { command: forget, targetFactId };
+}

--- a/libs/backend/agents/personal/memory/main/src/operations/__tests__/prisma-personal-memory-operation-repository.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/__tests__/prisma-personal-memory-operation-repository.test.ts
@@ -1,9 +1,11 @@
-import { AuthorizationBoundaryKind, MemoryDatasetState, MemoryFactState, PersonalMemoryOperationDeliveryState as PrismaDeliveryState, PersonalMemoryOperationFailureCode as PrismaFailureCode, PersonalMemoryOperationKind as PrismaKind, PersonalMemoryOperationPhase as PrismaPhase, type PersonalMemoryOperation as PrismaOperationRow, type Prisma } from "@prisma/client";
+import { AuthorizationBoundaryKind, MemoryConsentState, MemoryDatasetState, MemoryFactState, PersonalMemoryOperationDeliveryState as PrismaDeliveryState, PersonalMemoryOperationFailureCode as PrismaFailureCode, PersonalMemoryOperationKind as PrismaKind, PersonalMemoryOperationPhase as PrismaPhase, type PersonalMemoryOperation as PrismaOperationRow, type Prisma } from "@prisma/client";
 import { describe, expect, it, vi, type Mock } from "vitest";
 
 import { MemoryMutationDeliveryStates } from "@opencrane/contracts";
 
+import { _PersonalMemoryFactCreateData } from "../personal-memory-fact-catalog";
 import { PersonalMemoryOperationAdmissionOutcomes, PersonalMemoryOperationInvalidState, PersonalMemoryOperationPersistenceOutcomes, PersonalMemoryOperationReplayConflict, type AdmitPersonalMemoryOperationCommand, type PersonalMemoryOperationTaskAdmission } from "../personal-memory-operation-persistence.types";
+import { _PersonalMemoryOperationRecord } from "../prisma-personal-memory-operation-mapper";
 import { PrismaPersonalMemoryOperationRepository } from "../prisma-personal-memory-operation-repository";
 import { PersonalMemoryOperationEvents, PersonalMemoryOperationFailureCodes, PersonalMemoryOperationKinds, type PersonalMemoryOperationEvent } from "../personal-memory-operation.types";
 
@@ -41,6 +43,8 @@ interface _TransactionFixture
 	readonly updateOperation: Mock;
 	/** Operation insert used by a new admission. */
 	readonly createOperation: Mock;
+	/** Fact insert used by an accepted Remember or Correct catalog event. */
+	readonly createFact: Mock;
 }
 
 describe("PrismaPersonalMemoryOperationRepository", function _Suite()
@@ -247,15 +251,118 @@ describe("PrismaPersonalMemoryOperationRepository", function _Suite()
 		expect(fixture.updateFact.mock.calls[1][0]).toEqual({ where: { id: "fact-1", datasetId: "dataset-1", state: MemoryFactState.Corrected, revision: 7 }, data: { state: MemoryFactState.ForgetPending, forgetRequestedAt: _ADMITTED_AT } });
 	});
 
-	it("fails closed when a bare catalog event supplies no exact fact mutation evidence", async function _CatalogEvidence()
+	it("creates the exact content-free Remember fact before the operation compare-and-set", async function _RememberCatalogCommit()
 	{
-		const row = { ..._CorrectRow(), phase: PrismaPhase.CatalogCommitPending, revision: 4, providerDocumentId: _NEW_DOCUMENT_ID, indexingOperationId: _INDEXING_ID, expectedInputEvidenceDigest: _INPUT_DIGEST, pipelineRunId: _PIPELINE_ID };
-		const fixture = _Fixture(row);
+		const callOrder: string[] = [];
+		const initial = _RememberCatalogRow();
+		const completed = { ...initial, phase: PrismaPhase.Completed, revision: 6, completedAt: _RECORDED_AT };
+		const fixture = _Fixture(initial, callOrder);
+		_PrepareApply(fixture, initial, completed, callOrder);
+		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+		const event: PersonalMemoryOperationEvent = { operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Remember, expectedRevision: 5, event: PersonalMemoryOperationEvents.CatalogCommitted };
+
+		await expect(repository.apply(event, _RECORDED_AT)).resolves.toMatchObject({ outcome: PersonalMemoryOperationPersistenceOutcomes.Advanced, operation: { phase: "completed", revision: 6 } });
+		expect(callOrder).toEqual(["operation-read", "dataset-read", "dataset-lock", "operation-lock", "operation-reread", "fact-create", "operation-cas", "operation-saved"]);
+		expect(fixture.createFact).toHaveBeenCalledWith({ data: {
+			id: _OPERATION_ID,
+			datasetId: "dataset-1",
+			cogneeExternalId: _NEW_DOCUMENT_ID,
+			contentDigest: _CONTENT_DIGEST,
+			sensitivity: "personal",
+			provenance: { sourceKind: "message", operationId: _OPERATION_ID, conversationId: "conversation-1", messagePosition: "4", authorPrincipalId: "principal-1" },
+			sourceArtifactRevisionId: null,
+			sourceMessageId: "message-1",
+			supersedesFactId: null,
+			recordedBy: "principal-1",
+			recordedAt: _RECORDED_AT,
+			state: MemoryFactState.Active,
+			consentState: MemoryConsentState.Explicit,
+		} });
+		expect(fixture.createFact.mock.calls[0][0].data).not.toHaveProperty("revision");
+	});
+
+	it("creates a Correct successor without writing the locked predecessor", async function _CorrectCatalogCommit()
+	{
+		const callOrder: string[] = [];
+		const initial = _CorrectCatalogRow();
+		const advanced = { ...initial, phase: PrismaPhase.PriorDocumentDeletePending, revision: 5 };
+		const fixture = _Fixture(initial, callOrder);
+		_PrepareApply(fixture, initial, advanced, callOrder);
 		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
 		const event: PersonalMemoryOperationEvent = { operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Correct, expectedRevision: 4, event: PersonalMemoryOperationEvents.CatalogCommitted };
 
+		await expect(repository.apply(event, _RECORDED_AT)).resolves.toMatchObject({ outcome: PersonalMemoryOperationPersistenceOutcomes.Advanced, operation: { phase: "prior_document_delete_pending", revision: 5 } });
+		expect(fixture.createFact.mock.calls[0][0].data).toMatchObject({ id: _OPERATION_ID, supersedesFactId: "fact-1", state: MemoryFactState.Active, consentState: MemoryConsentState.Explicit });
+		expect(fixture.createFact.mock.calls[0][0].data).not.toHaveProperty("revision");
+		expect(fixture.updateFact).toHaveBeenCalledOnce();
+		expect(callOrder.indexOf("fact-create")).toBeLessThan(callOrder.indexOf("operation-cas"));
+	});
+
+	it("finalizes only the exact hidden Forget target before advancing the operation", async function _ForgetCatalogFinalize()
+	{
+		const callOrder: string[] = [];
+		const initial = _ForgetCatalogRow();
+		const completed = { ...initial, phase: PrismaPhase.Completed, revision: 3, completedAt: _RECORDED_AT };
+		const fixture = _Fixture(initial, callOrder, _Dataset(MemoryDatasetState.Active, _DATASET_PROVIDER_ID), _Fact(MemoryFactState.ForgetPending, 8));
+		_PrepareApply(fixture, initial, completed, callOrder);
+		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+		const event: PersonalMemoryOperationEvent = { operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Forget, expectedRevision: 2, event: PersonalMemoryOperationEvents.CatalogFinalized };
+
+		await expect(repository.apply(event, _RECORDED_AT)).resolves.toMatchObject({ outcome: PersonalMemoryOperationPersistenceOutcomes.Advanced, operation: { phase: "completed", revision: 3 } });
+		expect(fixture.updateFact.mock.calls[1][0]).toEqual({ where: { id: "fact-1", datasetId: "dataset-1", cogneeExternalId: _TARGET_DOCUMENT_ID, state: MemoryFactState.ForgetPending, revision: 8 }, data: { state: MemoryFactState.Forgotten, forgottenAt: _RECORDED_AT } });
+		expect(fixture.updateFact.mock.calls[1][0].data).not.toHaveProperty("revision");
+		expect(callOrder.indexOf("fact-finalize:fact-1")).toBeLessThan(callOrder.indexOf("operation-cas"));
+	});
+
+	it("performs no catalog mutation for a wrong phase or a concurrent catalog winner", async function _RejectCatalogDuplicates()
+	{
+		const wrongPhase = _Fixture(_CorrectRow());
+		const repository = new PrismaPersonalMemoryOperationRepository(wrongPhase.transaction);
+		const event: PersonalMemoryOperationEvent = { operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Correct, expectedRevision: 1, event: PersonalMemoryOperationEvents.CatalogCommitted };
+		await expect(repository.apply(event, _RECORDED_AT)).resolves.toMatchObject({ outcome: PersonalMemoryOperationPersistenceOutcomes.Denied });
+		expect(wrongPhase.createFact).not.toHaveBeenCalled();
+		expect(wrongPhase.updateFact).toHaveBeenCalledOnce();
+
+		const initial = _CorrectCatalogRow();
+		const winner = { ...initial, phase: PrismaPhase.PriorDocumentDeletePending, revision: 5 };
+		const concurrent = _Fixture(initial);
+		concurrent.findOperation.mockReset().mockResolvedValueOnce(initial).mockResolvedValueOnce(winner);
+		await expect(new PrismaPersonalMemoryOperationRepository(concurrent.transaction).apply({ ...event, expectedRevision: 4 }, _RECORDED_AT)).resolves.toMatchObject({ outcome: PersonalMemoryOperationPersistenceOutcomes.ConcurrentWinner, operation: { revision: 5 } });
+		expect(concurrent.createFact).not.toHaveBeenCalled();
+	});
+
+	it("fails before the operation CAS when the Forget finalization fence is lost", async function _ForgetFence()
+	{
+		const initial = _ForgetCatalogRow();
+		const fixture = _Fixture(initial, [], _Dataset(MemoryDatasetState.Active, _DATASET_PROVIDER_ID), _Fact(MemoryFactState.ForgetPending, 8));
+		fixture.updateFact.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 0 });
+		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+		const event: PersonalMemoryOperationEvent = { operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Forget, expectedRevision: 2, event: PersonalMemoryOperationEvents.CatalogFinalized };
+
 		await expect(repository.apply(event, _RECORDED_AT)).rejects.toBeInstanceOf(PersonalMemoryOperationInvalidState);
-		expect(fixture.updateOperation).toHaveBeenCalledTimes(1);
+		expect(fixture.updateOperation).toHaveBeenCalledOnce();
+	});
+
+	it("throws after a catalog write loses the operation revision fence", async function _CatalogCasFence()
+	{
+		const initial = _RememberCatalogRow();
+		const fixture = _Fixture(initial);
+		fixture.findOperation.mockReset().mockResolvedValueOnce(initial).mockResolvedValueOnce(initial).mockResolvedValueOnce(initial);
+		fixture.updateOperation.mockReset().mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 0 });
+		const repository = new PrismaPersonalMemoryOperationRepository(fixture.transaction);
+		const event: PersonalMemoryOperationEvent = { operationId: _OPERATION_ID, kind: PersonalMemoryOperationKinds.Remember, expectedRevision: 5, event: PersonalMemoryOperationEvents.CatalogCommitted };
+
+		await expect(repository.apply(event, _RECORDED_AT)).rejects.toBeInstanceOf(PersonalMemoryOperationInvalidState);
+		expect(fixture.createFact).toHaveBeenCalledOnce();
+		expect(fixture.updateOperation).toHaveBeenCalledTimes(2);
+	});
+
+	it("rejects incomplete saved evidence in the pure fact mapper", function _RejectIncompleteFactEvidence()
+	{
+		const operation = _PersonalMemoryOperationRecord(_CorrectCatalogRow());
+		expect(_PersonalMemoryFactCreateData({ ...operation, source: null }, _RECORDED_AT)).toBeNull();
+		expect(_PersonalMemoryFactCreateData({ ...operation, documentId: null }, _RECORDED_AT)).toBeNull();
+		expect(_PersonalMemoryFactCreateData({ ...operation, expectedContentDigest: null }, _RECORDED_AT)).toBeNull();
 	});
 
 	it("rejects an impossible saved row before lifecycle planning or any database write", async function _RejectInvalidRow()
@@ -404,6 +511,34 @@ function _RememberInitialRow(providerDatasetId: string | null): PrismaOperationR
 	};
 }
 
+/** Creates a Remember row whose provider indexing evidence is ready for catalog commit. */
+function _RememberCatalogRow(): PrismaOperationRow
+{
+	return {
+		..._RememberRow(_DATASET_PROVIDER_ID, _DATASET_PROVIDER_ID),
+		phase: PrismaPhase.CatalogCommitPending,
+		revision: 5,
+		providerDocumentId: _NEW_DOCUMENT_ID,
+		indexingOperationId: _INDEXING_ID,
+		expectedInputEvidenceDigest: _INPUT_DIGEST,
+		pipelineRunId: _PIPELINE_ID,
+	};
+}
+
+/** Creates a Correct row whose replacement indexing evidence is ready for catalog commit. */
+function _CorrectCatalogRow(): PrismaOperationRow
+{
+	return {
+		..._CorrectRow(),
+		phase: PrismaPhase.CatalogCommitPending,
+		revision: 4,
+		providerDocumentId: _NEW_DOCUMENT_ID,
+		indexingOperationId: _INDEXING_ID,
+		expectedInputEvidenceDigest: _INPUT_DIGEST,
+		pipelineRunId: _PIPELINE_ID,
+	};
+}
+
 /** Creates a valid Forget command that targets the active catalog revision. */
 function _ForgetCommand(): AdmitPersonalMemoryOperationCommand
 {
@@ -432,6 +567,12 @@ function _ForgetRow(): PrismaOperationRow
 	};
 }
 
+/** Creates a Forget row after exact provider document absence has been saved. */
+function _ForgetCatalogRow(): PrismaOperationRow
+{
+	return { ..._ForgetRow(), phase: PrismaPhase.CatalogFinalizePending, revision: 2 };
+}
+
 /** Creates one local dataset state returned by the fake transaction. */
 function _Dataset(state: MemoryDatasetState, cogneeDatasetId: string | null)
 {
@@ -452,6 +593,18 @@ function _TaskAdmission(taskId = _TASK_ID, callOrder?: string[]): Mock<PersonalM
 		callOrder?.push("task-admit");
 		return { taskId, ...coordinates };
 	});
+}
+
+/** Makes lifecycle reads and writes expose the lock, catalog, and compare-and-set order. */
+function _PrepareApply(fixture: _TransactionFixture, initial: PrismaOperationRow, saved: PrismaOperationRow, callOrder: string[]): void
+{
+	fixture.findOperation.mockReset()
+		.mockImplementationOnce(async function _InitialRead() { callOrder.push("operation-read"); return initial; })
+		.mockImplementationOnce(async function _LockedRead() { callOrder.push("operation-reread"); return initial; })
+		.mockImplementationOnce(async function _SavedRead() { callOrder.push("operation-saved"); return saved; });
+	fixture.updateOperation.mockReset()
+		.mockImplementationOnce(async function _Lock() { callOrder.push("operation-lock"); return { count: 1 }; })
+		.mockImplementationOnce(async function _Cas() { callOrder.push("operation-cas"); return { count: 1 }; });
 }
 
 /** Creates fake Prisma delegates and optionally records the externally visible lock sequence. */
@@ -476,8 +629,13 @@ function _Fixture(row: PrismaOperationRow, callOrder: string[] = [], dataset = _
 	const updateFact = vi.fn(async function _UpdateFact(query)
 	{
 		const id = query.where.id;
-		callOrder.push(`fact-lock:${id}`);
+		callOrder.push(query.data.forgottenAt === undefined ? `fact-lock:${id}` : `fact-finalize:${id}`);
 		return { count: 1 };
+	});
+	const createFact = vi.fn(async function _CreateFact(query)
+	{
+		callOrder.push("fact-create");
+		return query.data;
 	});
 	const findOperation = vi.fn(async function _FindOperation()
 	{
@@ -492,8 +650,8 @@ function _Fixture(row: PrismaOperationRow, callOrder: string[] = [], dataset = _
 	const createOperation = vi.fn(async function _CreateOperation() { return row; });
 	const transaction = {
 		memoryDataset: { findFirst: findDataset, updateMany: updateDataset },
-		memoryFactCatalog: { findFirst: findFact, updateMany: updateFact },
+		memoryFactCatalog: { findFirst: findFact, updateMany: updateFact, create: createFact },
 		personalMemoryOperation: { findUnique: findOperation, updateMany: updateOperation, create: createOperation },
 	} as unknown as Prisma.TransactionClient;
-	return { transaction, findDataset, updateDataset, findFact, updateFact, findOperation, updateOperation, createOperation };
+	return { transaction, findDataset, updateDataset, findFact, updateFact, findOperation, updateOperation, createOperation, createFact };
 }

--- a/libs/backend/agents/personal/memory/main/src/operations/personal-memory-fact-catalog.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/personal-memory-fact-catalog.ts
@@ -1,0 +1,39 @@
+import { MemoryFactProvenanceSourceKinds } from "@opencrane/contracts";
+
+import { PersonalMemoryFactSensitivities } from "./personal-memory-fact-catalog.types";
+import type { PersonalMemoryOperationRecord } from "./personal-memory-operation-persistence.types";
+import { PersonalMemoryOperationKinds } from "./personal-memory-operation.types";
+
+/** Builds the content-free catalog metadata for an accepted Remember or Correct operation. */
+export function _PersonalMemoryFactCreateData(operation: PersonalMemoryOperationRecord, recordedAt: Date)
+{
+	if ((operation.kind !== PersonalMemoryOperationKinds.Remember && operation.kind !== PersonalMemoryOperationKinds.Correct)
+		|| operation.source === null
+		|| operation.documentId === null
+		|| operation.expectedContentDigest === null)
+		return null;
+	if (operation.kind === PersonalMemoryOperationKinds.Remember && operation.targetFactId !== null)
+		return null;
+	if (operation.kind === PersonalMemoryOperationKinds.Correct && operation.targetFactId === null)
+		return null;
+
+	return {
+		id: operation.operationId,
+		datasetId: operation.datasetId,
+		cogneeExternalId: operation.documentId,
+		contentDigest: operation.expectedContentDigest,
+		sensitivity: PersonalMemoryFactSensitivities.Personal,
+		provenance: {
+			sourceKind: MemoryFactProvenanceSourceKinds.Message,
+			operationId: operation.operationId,
+			conversationId: operation.source.conversationId,
+			messagePosition: operation.source.messagePosition.toString(),
+			authorPrincipalId: operation.source.authorPrincipalId,
+		},
+		sourceArtifactRevisionId: null,
+		sourceMessageId: operation.source.messageId,
+		supersedesFactId: operation.targetFactId,
+		recordedBy: operation.actorPrincipalId,
+		recordedAt,
+	};
+}

--- a/libs/backend/agents/personal/memory/main/src/operations/personal-memory-fact-catalog.types.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/personal-memory-fact-catalog.types.ts
@@ -1,0 +1,12 @@
+/**
+ * Sensitivity classifications persisted for direct personal-memory commands.
+ *
+ * The server selects this value instead of accepting a caller classification. The stored string
+ * is immutable catalog metadata; changing it requires a reviewed policy for already-admitted
+ * operations. The label never grants access.
+ */
+export enum PersonalMemoryFactSensitivities
+{
+	/** Marks a fact as personal while conferring no permission to read or mutate it. */
+	Personal = "personal",
+}

--- a/libs/backend/agents/personal/memory/main/src/operations/prisma-personal-memory-operation-repository.ts
+++ b/libs/backend/agents/personal/memory/main/src/operations/prisma-personal-memory-operation-repository.ts
@@ -1,5 +1,6 @@
-import { AuthorizationBoundaryKind, MemoryDatasetState, MemoryFactState, type PersonalMemoryOperation as PrismaOperationRow, type Prisma } from "@prisma/client";
+import { AuthorizationBoundaryKind, MemoryConsentState, MemoryDatasetState, MemoryFactState, type PersonalMemoryOperation as PrismaOperationRow, type Prisma } from "@prisma/client";
 
+import { _PersonalMemoryFactCreateData } from "./personal-memory-fact-catalog";
 import { __CreatePersonalMemoryOperationLifecycle, __PlanPersonalMemoryOperationLifecycle } from "./personal-memory-operation-lifecycle";
 import { ___AdmitPersonalMemoryOperationCommandSchema, ___PersonalMemoryOperationReplayLookupSchema, ___PersonalMemoryOperationTaskIdentitySchema } from "./personal-memory-operation-persistence.validator";
 import { PersonalMemoryOperationAdmissionOutcomes, PersonalMemoryOperationInvalidState, PersonalMemoryOperationPersistenceOutcomes, PersonalMemoryOperationReplayConflict, type AdmitPersonalMemoryOperationCommand, type PersonalMemoryOperationAdmissionResult, type PersonalMemoryOperationMessageSource, type PersonalMemoryOperationPersistenceResult, type PersonalMemoryOperationRecord, type PersonalMemoryOperationRepository, type PersonalMemoryOperationTaskAdmission } from "./personal-memory-operation-persistence.types";
@@ -82,8 +83,6 @@ export class PrismaPersonalMemoryOperationRepository implements PersonalMemoryOp
 		const operation = await this._lockOperation(initialRow);
 		if (operation.revision !== initial.revision)
 			return { outcome: PersonalMemoryOperationPersistenceOutcomes.ConcurrentWinner, operation };
-		if (event.event === PersonalMemoryOperationEvents.CatalogCommitted || event.event === PersonalMemoryOperationEvents.CatalogFinalized)
-			throw new PersonalMemoryOperationInvalidState("personal-memory catalog event requires exact fact mutation evidence in this transaction");
 
 		const planned = __PlanPersonalMemoryOperationLifecycle(_PersonalMemoryOperationLifecycle(operation), event);
 		if (planned.outcome === PersonalMemoryOperationTransitionOutcomes.Denied)
@@ -93,6 +92,7 @@ export class PrismaPersonalMemoryOperationRepository implements PersonalMemoryOp
 		if (planned.operation === undefined)
 			throw new PersonalMemoryOperationInvalidState("personal-memory lifecycle accepted an event without next state");
 		const adoptedDataset = await this._adoptDatasetForEvent(dataset, operation, event);
+		const changedCatalog = await this._applyCatalogEvent(operation, event, recordedAt);
 
 		const update = await this.transaction.personalMemoryOperation.updateMany({
 			where: { id: operation.operationId, revision: operation.revision },
@@ -104,8 +104,8 @@ export class PrismaPersonalMemoryOperationRepository implements PersonalMemoryOp
 		const durable = _PersonalMemoryOperationRecord(saved);
 		if (update.count === 0)
 		{
-			if (adoptedDataset)
-				throw new PersonalMemoryOperationInvalidState("dataset adoption lost the matching operation revision");
+			if (adoptedDataset || changedCatalog)
+				throw new PersonalMemoryOperationInvalidState("a dependent personal-memory write lost the matching operation revision");
 			return { outcome: PersonalMemoryOperationPersistenceOutcomes.ConcurrentWinner, operation: durable };
 		}
 		return { outcome: PersonalMemoryOperationPersistenceOutcomes.Advanced, operation: durable };
@@ -159,6 +159,30 @@ export class PrismaPersonalMemoryOperationRepository implements PersonalMemoryOp
 		});
 		if (adopted.count !== 1)
 			throw new PersonalMemoryOperationInvalidState("personal-memory dataset provider adoption lost its state fence");
+		return true;
+	}
+
+	/** Applies exact catalog evidence only after the lifecycle planner accepts the event. */
+	private async _applyCatalogEvent(operation: PersonalMemoryOperationRecord, event: PersonalMemoryOperationEvent, recordedAt: Date): Promise<boolean>
+	{
+		if (event.event === PersonalMemoryOperationEvents.CatalogCommitted)
+		{
+			const data = _PersonalMemoryFactCreateData(operation, recordedAt);
+			if (data === null)
+				throw new PersonalMemoryOperationInvalidState("personal-memory catalog commit lacks immutable fact evidence");
+			await this.transaction.memoryFactCatalog.create({ data: { ...data, state: MemoryFactState.Active, consentState: MemoryConsentState.Explicit } });
+			return true;
+		}
+		if (event.event !== PersonalMemoryOperationEvents.CatalogFinalized)
+			return false;
+		if (operation.kind !== PersonalMemoryOperationKinds.Forget || operation.targetFactId === null || operation.targetDocumentId === null || operation.expectedFactRevision === null)
+			throw new PersonalMemoryOperationInvalidState("personal-memory catalog finalization lacks immutable target evidence");
+		const finalized = await this.transaction.memoryFactCatalog.updateMany({
+			where: { id: operation.targetFactId, datasetId: operation.datasetId, cogneeExternalId: operation.targetDocumentId, state: MemoryFactState.ForgetPending, revision: operation.expectedFactRevision + 1 },
+			data: { state: MemoryFactState.Forgotten, forgottenAt: recordedAt },
+		});
+		if (finalized.count !== 1)
+			throw new PersonalMemoryOperationInvalidState("personal-memory Forget target lost its finalization fence");
 		return true;
 	}
 

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,36 @@
 # OpenCrane — Active Plan
 
+## Personal memory catalog completion — transaction integration
+
+This slice starts above draft #877 at `5618b277157b9601fdd3527c3fc423bcd1247f9e` on
+`feat/0.12-personal-memory-catalog-completion`. Its parent passes exact-head CI in run
+`34727906356`, including affected build/test/lint, database authority, KurrentDB recovery, generated
+API, component contracts and server image publication. Provider qualification was unaffected and
+skipped; testv5 remains a separate gate.
+
+The existing personal-memory operation repository will compose catalog mutations with accepted
+operation transitions. The lifecycle planner retains all state/event decisions; PostgreSQL retains
+fact revisions and correction constraints. Catalog mutation precedes the operation compare-and-set
+in the same transaction. A lost operation write after a fact mutation must abort the transaction.
+
+| Saved operation state | Accepted event | Catalog effect and next operation state |
+| --- | --- | --- |
+| Remember, CatalogCommitPending | CatalogCommitted | Create the exact Active fact and complete the operation together. |
+| Correct, CatalogCommitPending | CatalogCommitted | Create one Active successor; PostgreSQL marks its prior Active fact Corrected at revision R+1. Advance to PriorDocumentDeletePending. |
+| Forget, CatalogFinalizePending | CatalogFinalized | Change the exact ForgetPending fact from R+1 to Forgotten at R+2 and complete the operation together. |
+| RecoveryRequired with one of these saved recovery phases | Matching accepted catalog event | Apply the same catalog transaction through the existing lifecycle planner. |
+| Stale revision, wrong kind/phase or completed operation | Any catalog event | Deny before a fact write; preserve the saved state. |
+
+Architecture preflight passes. Direct message facts use server-selected personal sensitivity,
+Explicit consent, the operation UUID as fact identity and content-free Message provenance.
+Implementation passes 51 unit tests and all 13 personal-memory PostgreSQL cases, including six new
+completion, duplicate/restart and rollback proofs. The server SQL target also passes its 48 cases
+and raw authority scripts. Package lint/type checks, server build/OpenAPI, style, Prisma ownership,
+module growth and release binding pass. Architecture post-review and independent review of the
+complete nine-file change pass with no blocking findings. This source slice does not add a grant,
+public route, gateway transport or worker; the pending first-dataset permission and gateway
+replacement remain separate decisions. Publication and exact-head CI remain the next gates.
+
 ## Personal memory command preparation and atomic task admission
 
 This slice starts directly above draft #876 at
@@ -634,7 +665,7 @@ remain separate gates.
 | --- | --- | --- | --- |
 | 1 | T1 — real tool retrieval | A permitted real record reaches an answer in personal and company-child chats; remote MCP connections and hosted MCP execution have qualified journeys. Results survive reload and restart without repeated dispatch. | IN PROGRESS: company tool selection and participant terminal-result history are implemented. Explicit connection readiness and execution fencing pass source review and local database proof. Standard remote activation/discovery/calls, hosted MCP execution and real integration qualification remain. |
 | 2 | T2 — approved external actions | A person reviews an exact action and arguments; one approval permits that effect once. Denial, expiry, changed arguments and revoked authority prevent it. | IN PROGRESS: personal approval, expiry, durable resume and visible decision controls are implemented in draft #857. Company approver/connection binding and real action qualification remain. |
-| 3 | M1 — long-term memory | Explicit remember, cross-conversation recall, correction and forget work with consent and isolated datasets. | IN PROGRESS: the repaired 1.5.4 candidate passes exact-image deletion, isolation, dataset permission and indexing recovery qualification. Durable operation persistence is published in #876 with passing CI. Command/source preparation and actual Absurd admission are locally tested; authenticated composition, gateway/client wiring and product Remember, recall, Correct and Forget remain unfinished. |
+| 3 | M1 — long-term memory | Explicit remember, cross-conversation recall, correction and forget work with consent and isolated datasets. | IN PROGRESS: the repaired 1.5.4 candidate passes exact-image deletion, isolation, dataset permission and indexing recovery qualification. Durable operation persistence is published in #876 with passing CI. Command/source preparation and actual Absurd admission are published in #877 with passing CI; catalog completion now passes local unit and PostgreSQL proof; authenticated composition, gateway/client wiring and product Remember, recall, Correct and Forget remain unfinished. |
 | 4 | U1 — visible work controls | People can follow waiting, running and terminal work, make supported decisions and cancel eligible work after refresh. | IN PROGRESS: requester-only personal Stop and durable cleanup pass independent review and exact-head CI in draft #862; qualify the live journey. Other-participant controls remain a separate actor-policy decision. |
 | 5 | U2 — rich interaction | Durable choices, free text, structured results and A2UI remain usable and accessible after refresh. | PAUSED: runtime-question source work awaits its separate explicit approval; partial implementation is not validated delivery. Structured results and A2UI remain. |
 | 6 | F1 — documents and generated files | A scanned document can inform an answer, and a generated file remains downloadable by its authorized audience. | IN PROGRESS: Ready-file Open/Preview/Download is implemented and exact-head CI passes in #868. PDF-informed answers are source complete in #869 and exact-head CI passes, including real-store recovery and Linux visuals; live qualification remains. Generated file production follows. |
@@ -949,7 +980,7 @@ their own completion track; they are not silently bundled into the first tool PR
 | T1 — first permitted tool retrieval | IN PROGRESS — the server's one-tool continuation is implemented and now progresses through Absurd in #849. Company tool assignment is the first active follow-up. Connection activation, a real integration and participant result evidence remain required. |
 | T2 | IN PROGRESS: personal approval and durable resume pass local integration; company approval and real external-action qualification remain. |
 | U1 | IN PROGRESS: requester-only personal Stop passes source review and exact-head CI in #862; live qualification and wider participant controls remain separate. |
-| M1 | IN PROGRESS: the candidate in #875 passes exact-image deletion, isolation, permission recovery and interrupted-indexing qualification. Durable Remember/Correct/Forget persistence is published in #876 with passing CI. Command/source preparation and transaction-bound Absurd admission pass local proof. Authenticated composition, gateway/client integration and product memory journeys remain. The separate production-provider qualification still fails. |
+| M1 | IN PROGRESS: the candidate in #875 passes exact-image deletion, isolation, permission recovery and interrupted-indexing qualification. Durable Remember/Correct/Forget persistence is published in #876 with passing CI. Command/source preparation and transaction-bound Absurd admission are published in #877 with passing CI; catalog completion passes local unit and PostgreSQL proof. Authenticated composition, gateway/client integration and product memory journeys remain. The separate production-provider qualification still fails. |
 | U2 | PAUSED: partial runtime-question source awaits its separate explicit approval. |
 | F1 | IN PROGRESS: Ready-file Open/Preview/Download and PDF-informed answers pass exact-head CI in #868 and #869. Generated outputs and live qualification remain. |
 | D1, S1, A2, T3 | PLANNED in the exact priority order above, with separate acceptance for each journey. |


### PR DESCRIPTION
A personal-memory operation could reach a catalog step, but the repository could not yet save the fact and operation progress together. The existing operation transaction now creates the exact remembered fact, creates a correction successor, or finalizes a forgotten fact before advancing the operation. If the operation write loses, the whole transaction rolls back. Concurrent and restarted replay cannot publish another fact.

The lifecycle planner still decides which event is accepted, and PostgreSQL still owns fact revisions and correction constraints. New facts derive their identity, provider document coordinate, digest, and content-free Message provenance from the saved operation. Consent is Explicit and sensitivity is server-selected personal; neither value grants access. Remembered text and provider credentials do not enter the catalog.

The former rejection of all catalog-completion events is replaced inside the existing repository. There is no second catalog writer, queue, scheduler, outbox, schema change, public route, or registered worker. Authenticated command composition, first-dataset authorization, gateway/client integration and the complete Remember → recall → Correct → Forget product journey remain unfinished.

Direct parent: #877 (`feat/0.12-personal-memory-command-admission`), immutable review base `5618b277157b9601fdd3527c3fc423bcd1247f9e`. Its live branch and SHA were verified before publication.

## Review order

#831 → #843 → #849 → #850 → #851 → #852 → #853 → #854 → #855 → #856 → #857 → #858 → #862 → #863 → #867 → #868 → #869 → #870 → #871 → #872 → #873 → #874 → #875 → #876 → #877 → #878.

## Validation completed

- Personal-memory Nx unit suite: 51 tests across eight files pass. The final package lint/TypeScript target passes after the SQL fixture corrections.
- Personal-memory real PostgreSQL suite: all 13 cases pass, including deterministic Remember completion, concurrent Correct completion, restart replay, Forget revision fencing, and complete rollback for all three catalog mutations.
- Existing server SQL target: 48 integration cases and raw authority scripts pass. Its evidence comes from the earlier combined run; the corrected personal-memory suite was then rerun separately and passed all 13 cases.
- Server Nx build and OpenAPI generation pass.
- Style: three production files, zero errors or warnings. Prisma ownership: 253 files, zero errors. Module growth: three production files, zero errors or review candidates. Release binding and live stack preflight pass.
- Architecture preflight/post-review and integrated independent review of the exact nine-file overlay pass without blocking findings. Only the final plan validation status changed after review; the other eight reviewed file hashes are unchanged.

The disposable PostgreSQL fixture and SQL processes use UTC. No database constraint was weakened. Exact-head CI passes at `5acd38a6f6dec8a0dc4fa4e010bf7a9b9e73b37d` in [run 34729341100](https://github.com/elewa-git/opencrane/actions/runs/34729341100), including affected build/test/lint, database authority, KurrentDB recovery, API generation, component contracts, stack integrity and server image publication. Provider qualification was unaffected and skipped. Testv5/live qualification remains a separate gate; this source change makes no deployment, real provider call, credential inspection, or test-data deletion.
